### PR TITLE
fix: only coerce semantically numeric properties to JSON numbers

### DIFF
--- a/src/hunch_result.rs
+++ b/src/hunch_result.rs
@@ -217,26 +217,34 @@ impl HunchResult {
     }
 
     /// Convert to a flat map (first value per property), useful for JSON output.
+    ///
+    /// Only semantically numeric properties (year, season, episode, etc.) are
+    /// coerced to JSON numbers. Name-like properties (title, release_group,
+    /// episode_title, etc.) always serialize as strings, even if the value
+    /// happens to be all digits (e.g., the movie "2001").
     pub fn to_flat_map(&self) -> BTreeMap<String, serde_json::Value> {
         let mut map = BTreeMap::new();
         for (k, v) in &self.props {
             let key = k.to_string();
+            let numeric = k.is_numeric();
             if v.len() == 1 {
-                // Try to parse as number for year/season/episode
-                if let Ok(n) = v[0].parse::<i64>() {
-                    map.insert(key, serde_json::Value::Number(n.into()));
-                } else {
-                    map.insert(key, serde_json::Value::String(v[0].clone()));
+                if numeric {
+                    if let Ok(n) = v[0].parse::<i64>() {
+                        map.insert(key, serde_json::Value::Number(n.into()));
+                        continue;
+                    }
                 }
+                map.insert(key, serde_json::Value::String(v[0].clone()));
             } else {
                 let arr: Vec<serde_json::Value> = v
                     .iter()
                     .map(|s| {
-                        if let Ok(n) = s.parse::<i64>() {
-                            serde_json::Value::Number(n.into())
-                        } else {
-                            serde_json::Value::String(s.clone())
+                        if numeric {
+                            if let Ok(n) = s.parse::<i64>() {
+                                return serde_json::Value::Number(n.into());
+                            }
                         }
+                        serde_json::Value::String(s.clone())
                     })
                     .collect();
                 map.insert(key, serde_json::Value::Array(arr));

--- a/src/matcher/span.rs
+++ b/src/matcher/span.rs
@@ -340,4 +340,30 @@ impl Property {
             _ => None,
         }
     }
+
+    /// Whether this property is semantically numeric and should be coerced
+    /// to a JSON number in [`HunchResult::to_flat_map`](crate::HunchResult::to_flat_map).
+    ///
+    /// Name-like properties (`Title`, `ReleaseGroup`, `EpisodeTitle`, etc.)
+    /// always serialize as strings, even when the value is all digits.
+    pub fn is_numeric(&self) -> bool {
+        matches!(
+            self,
+            Self::Year
+                | Self::Season
+                | Self::Episode
+                | Self::AbsoluteEpisode
+                | Self::Part
+                | Self::Bonus
+                | Self::Film
+                | Self::Cd
+                | Self::CdCount
+                | Self::Disc
+                | Self::Week
+                | Self::EpisodeCount
+                | Self::SeasonCount
+                | Self::ProperCount
+                | Self::Version
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #5 — `to_flat_map()` was blindly calling `parse::<i64>()` on **all** property values, causing name-like properties to be coerced to JSON numbers when the value happened to be all digits.

**Before:** `"title": 2001` (number — wrong!)
**After:** `"title": "2001"` (string — correct!)

## Changes

### `src/matcher/span.rs`
- Added `Property::is_numeric()` — returns `true` only for semantically numeric properties: `Year`, `Season`, `Episode`, `AbsoluteEpisode`, `Part`, `Bonus`, `Film`, `Cd`, `CdCount`, `Disc`, `Week`, `EpisodeCount`, `SeasonCount`, `ProperCount`, `Version`

### `src/hunch_result.rs`
- `to_flat_map()` now only coerces values to JSON numbers for `is_numeric()` properties
- Added rustdoc explaining the coercion policy

## Testing

- All 295 tests pass ✅
- All guessit regression floors maintained (81.7%) ✅
- Clippy clean ✅
- Manual verification: `hunch "2001.A.Space.Odyssey.1968.1080p.BluRay.mkv"` → `"title": "2001 A Space Odyssey"` (string), `"year": 1968` (number)
