### PR TITLE
refactor: rename known_tokens.rs → validation.rs

### DIFF
--- a/src/properties/release_group/mod.rs
+++ b/src/properties/release_group/mod.rs
@@ -18,19 +18,17 @@
 //!
 //! ## Module structure
 //! - `mod.rs` — regex patterns + find_matches (matching logic)
-//! - `known_tokens.rs` — position-based validation + helpers
+//! - `validation.rs` — position-based validation + helpers
 
-mod known_tokens;
+mod validation;
 
 use regex::Regex;
 
 use crate::matcher::span::{MatchSpan, Property};
 use crate::tokenizer::TokenStream;
 use crate::zone_map::ZoneMap;
-use known_tokens::{
-    expand_group_backwards, is_hex_crc, is_rejected_group, strip_trailing_metadata,
-};
 use std::sync::LazyLock;
+use validation::{expand_group_backwards, is_hex_crc, is_rejected_group, strip_trailing_metadata};
 
 // ── Regex patterns ────────────────────────────────────────────────────────
 

--- a/src/properties/release_group/validation.rs
+++ b/src/properties/release_group/validation.rs
@@ -1,13 +1,21 @@
-//! Release group validation helpers.
+//! Release group validation: position-based overlap detection and token filtering.
 //!
-//! v0.3: Position-based overlap detection replaces the old 130+ token
-//! exclusion list. Release group now runs AFTER conflict resolution, so
-//! we can check whether a candidate span is already claimed by a resolved
-//! tech match (VideoCodec, Source, etc.).
+//! # Architecture
 //!
-//! A small curated list of non-tech tokens that should never be release
-//! groups (subtitle markers, metadata tags) is retained for tokens not
-//! covered by TOML rules.
+//! v0.3 replaced the old 130+ token exclusion list with position-based
+//! overlap detection (`is_position_claimed`). Release group extraction now
+//! runs AFTER conflict resolution, so we check whether a candidate span is
+//! already claimed by a resolved tech match (VideoCodec, Source, etc.).
+//!
+//! A small curated list of non-tech tokens (`is_non_group_token`) is retained
+//! for tokens not covered by TOML rules:
+//!
+//! - **Container extensions** (mkv, mp4, etc.): These exist in `container.toml`
+//!   but container detection uses the extension path (PATH A), not token
+//!   matching. So `is_position_claimed()` won't catch them mid-filename.
+//!
+//! - **Subtitle/metadata markers** (fansub, dublado, etc.): Not covered by
+//!   any TOML rule — they're purely release-group-exclusion tokens.
 
 use crate::matcher::span::{MatchSpan, Property};
 use crate::zone_map;


### PR DESCRIPTION
## What does this PR do?

Renames `src/properties/release_group/known_tokens.rs` → `validation.rs` and adds architecture documentation explaining why each remaining token list exists.

### Audit Summary

After v0.3 replaced the 130+ token exclusion list with `is_position_claimed()`, the file is 90% position-based validation logic. The name "known_tokens" was misleading.

**Token lists still needed:**
- **Container extensions** (mkv, mp4, etc.): In `container.toml` but container detection uses PATH A (extension), not token matching — `is_position_claimed()` won't catch them mid-filename
- **Subtitle/metadata markers** (fansub, dublado, etc.): Not in any TOML rule

**All 8 functions actively used** (10+ total call sites across release_group/mod.rs).

## Testing
- [x] `cargo test` — all 295 tests + 9 doc-tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean

Closes #6