### PR TITLE
accuracy: multi-segment alternative_title + earliest-boundary fix

### DIFF
--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -441,10 +441,9 @@ impl Pipeline {
             all_matches.push(ep_title);
         }
 
-        // Step 5d: Alternative title.
-        if let Some(alt_title) =
-            title::extract_alternative_title(input, &all_matches, &token_stream)
-        {
+        // Step 5d: Alternative title(s).
+        let alt_titles = title::extract_alternative_titles(input, &all_matches, &token_stream);
+        for alt_title in alt_titles {
             all_matches.push(alt_title);
         }
 

--- a/src/properties/title/mod.rs
+++ b/src/properties/title/mod.rs
@@ -8,7 +8,7 @@ mod clean;
 mod secondary;
 
 pub use secondary::{
-    extract_alternative_title, extract_episode_title, extract_film_title, infer_media_type,
+    extract_alternative_titles, extract_episode_title, extract_film_title, infer_media_type,
 };
 
 use crate::matcher::span::{MatchSpan, Property};
@@ -388,29 +388,13 @@ fn has_parent_dir(input: &str) -> bool {
 fn find_title_boundary(raw: &str) -> Option<usize> {
     let min_title_len = 3;
 
-    for sep in [" (", "_(", ".("] {
-        if let Some(pos) = raw.find(sep)
-            && pos >= min_title_len
-        {
-            return Some(pos);
-        }
-    }
+    // Find the earliest structural separator across all types.
+    let separators: &[&str] = &[" (", "_(", ".(", " - ", "_-_", ".-.", "--"];
 
-    for sep in [" - ", "_-_", ".-."] {
-        if let Some(pos) = raw.find(sep)
-            && pos >= min_title_len
-        {
-            return Some(pos);
-        }
-    }
-
-    if let Some(pos) = raw.find("--")
-        && pos >= min_title_len
-    {
-        return Some(pos);
-    }
-
-    None
+    separators
+        .iter()
+        .filter_map(|sep| raw.find(sep).filter(|&pos| pos >= min_title_len))
+        .min()
 }
 
 #[cfg(test)]

--- a/src/properties/title/secondary.rs
+++ b/src/properties/title/secondary.rs
@@ -245,12 +245,17 @@ pub fn extract_film_title(
     ))
 }
 
-/// Extract alternative_title from content after the title boundary.
-pub fn extract_alternative_title(
+/// Extract alternative titles from content after the title boundary.
+///
+/// When a title zone contains multiple `" - "` separated segments,
+/// each segment after the first becomes a separate `AlternativeTitle` value.
+/// E.g., `"Echec et Mort - Hard to Kill - Steven Seagal"` →
+///   title: "Echec et Mort", alt_titles: ["Hard to Kill", "Steven Seagal"]
+pub fn extract_alternative_titles(
     input: &str,
     matches: &[MatchSpan],
     _token_stream: &TokenStream,
-) -> Option<MatchSpan> {
+) -> Vec<MatchSpan> {
     let filename_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
 
     let first_match = matches
@@ -278,11 +283,14 @@ pub fn extract_alternative_title(
     };
 
     if title_end_abs <= filename_start {
-        return None;
+        return Vec::new();
     }
 
     let raw_title = &input[filename_start..title_end_abs];
-    let boundary_offset = find_title_boundary(raw_title)?;
+    let boundary_offset = match find_title_boundary(raw_title) {
+        Some(offset) => offset,
+        None => return Vec::new(),
+    };
 
     let after = &raw_title[boundary_offset..];
     let sep_len =
@@ -300,21 +308,71 @@ pub fn extract_alternative_title(
     let sep_end = boundary_offset + sep_len;
 
     if sep_end >= raw_title.len() {
-        return None;
+        return Vec::new();
     }
 
     let alt_raw = &raw_title[sep_end..];
-    let alt_cleaned = clean_title(alt_raw);
-    if alt_cleaned.is_empty() {
-        return None;
+
+    // Split on " - ", "_-_", ".-." to produce multiple alternative titles.
+    let separators = [" - ", "_-_", ".-."];
+    let segments = split_on_separators(alt_raw, &separators);
+
+    let mut results = Vec::new();
+    let mut offset = sep_end;
+    for segment in &segments {
+        let cleaned = clean_title(segment);
+        if !cleaned.is_empty() {
+            results.push(MatchSpan::new(
+                filename_start + offset,
+                filename_start + offset + segment.len(),
+                Property::AlternativeTitle,
+                cleaned,
+            ));
+        }
+        // Advance past this segment and the next separator.
+        offset += segment.len();
+        // Skip the separator (find which one is next).
+        let remaining = &raw_title[offset..];
+        for sep in &separators {
+            if remaining.starts_with(sep) {
+                offset += sep.len();
+                break;
+            }
+        }
     }
 
-    Some(MatchSpan::new(
-        filename_start + sep_end,
-        title_end_abs,
-        Property::AlternativeTitle,
-        alt_cleaned,
-    ))
+    results
+}
+
+/// Split a string on any of the given separators, preserving order.
+fn split_on_separators<'a>(s: &'a str, separators: &[&str]) -> Vec<&'a str> {
+    let mut result = Vec::new();
+    let mut remaining = s;
+
+    loop {
+        // Find the earliest separator.
+        let earliest = separators
+            .iter()
+            .filter_map(|sep| remaining.find(sep).map(|pos| (pos, *sep)))
+            .min_by_key(|(pos, _)| *pos);
+
+        match earliest {
+            Some((pos, sep)) => {
+                if pos > 0 {
+                    result.push(&remaining[..pos]);
+                }
+                remaining = &remaining[pos + sep.len()..];
+            }
+            None => {
+                if !remaining.is_empty() {
+                    result.push(remaining);
+                }
+                break;
+            }
+        }
+    }
+
+    result
 }
 
 /// Infer media type from the set of matched properties.


### PR DESCRIPTION
## What does this PR do?

Two changes that dramatically improve alternative_title accuracy:

### 1. find_title_boundary — find earliest separator

**Before:** Checked separator types in priority order (`" ("` before `" - "`).
**After:** Finds the earliest occurrence across ALL separator types.

This fixes `Star Wars: Episode IV - A New Hope (2004)` where `" - "` at position 21 was ignored because `" ("` at position 34 was checked first.

### 2. extract_alternative_titles — multi-segment support

**Before:** `extract_alternative_title` returned `Option<MatchSpan>` (single value).
**After:** `extract_alternative_titles` returns `Vec<MatchSpan>`, splitting on `" - "` separators.

```
"Echec et Mort - Hard to Kill - Steven Seagal"
  Before: alt_title = "Hard to Kill Steven Seagal"
  After:  alt_titles = ["Hard to Kill", "Steven Seagal"]
```

### Accuracy Impact
- `alternative_title`: **43.8% → 68.8%** (+25pp, 7→11 passes)
- `title`: 92.2% (no regression)
- All ratchet floors maintained

## Testing
- [x] `cargo test` — all 289 tests + 9 doc-tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean

Partial fix for #7