### PR TITLE
feat: structure-aware neighbor-context disambiguation

### DIFF
--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -5,6 +5,7 @@
 //! replaces v0.1 prune_* heuristics.
 
 mod proper_count;
+pub(crate) mod token_context;
 mod zone_rules;
 
 use crate::hunch_result::HunchResult;
@@ -382,7 +383,7 @@ impl Pipeline {
 
         // Step 4: Zone-based disambiguation.
         let pre_zone_count = all_matches.len();
-        zone_rules::apply_zone_rules(input, &zone_map, &mut all_matches);
+        zone_rules::apply_zone_rules(input, &zone_map, &token_stream, &mut all_matches);
         debug!(
             "step 4: zone disambiguation — {} → {} match(es)",
             pre_zone_count,

--- a/src/pipeline/token_context.rs
+++ b/src/pipeline/token_context.rs
@@ -1,0 +1,347 @@
+//! Token context classification for structure-aware disambiguation.
+//!
+//! Instead of using fragile positional heuristics ("first half of title zone",
+//! "before the anchor"), this module classifies each token's role based on
+//! its actual context:
+//!
+//! 1. **Neighbor roles**: Are surrounding tokens claimed by confident tech
+//!    properties (codec, resolution, source) or unclaimed (title words)?
+//! 2. **Structural separators**: Is this token after a metadata boundary
+//!    like " - " or in brackets?
+//! 3. **Duplicate detection**: Does the same value appear in a clearly
+//!    technical position elsewhere in the path?
+//!
+//! This replaces the zone_rules heuristics that used position as a proxy
+//! for semantic role.
+
+use crate::matcher::span::{MatchSpan, Property};
+use crate::tokenizer::{Separator, TokenStream};
+
+/// Properties that are NEVER title words — their presence signals tech context.
+///
+/// If a neighboring token is claimed by one of these, the region is
+/// technical/metadata, not title content.
+const CONFIDENT_TECH: &[Property] = &[
+    Property::VideoCodec,
+    Property::AudioCodec,
+    Property::ScreenSize,
+    Property::Source,
+    Property::Year,
+    Property::Season,
+    Property::Episode,
+    Property::Date,
+    Property::Container,
+    Property::FrameRate,
+    Property::ColorDepth,
+    Property::VideoProfile,
+    Property::AudioChannels,
+    Property::AudioProfile,
+    Property::Edition,
+    Property::StreamingService,
+    Property::EpisodeCount,
+    Property::SeasonCount,
+    Property::Part,
+    Property::Bonus,
+    Property::Other,
+    Property::VideoApi,
+    Property::ReleaseGroup,
+];
+
+/// Check whether a match is in "title context" — surrounded by title words
+/// rather than technical tokens.
+///
+/// Returns `true` if the match's neighbors suggest it's part of a title
+/// phrase (should be dropped as metadata), `false` if it's in a technical
+/// region (should be kept as a real property match).
+///
+/// ## Algorithm
+///
+/// 1. Find the token(s) immediately before and after this match
+///    (within the same path segment).
+/// 2. Check if each neighbor is "claimed" by a confident tech property.
+/// 3. Score: unclaimed neighbors = title context, claimed = tech context.
+///
+/// Special cases:
+/// - **After a ` - ` separator**: Metadata boundary — NOT title context.
+///   Patterns like `"Movie - FR"` use " - " to delimit metadata.
+/// - **In brackets**: Brackets signal metadata — NOT title context.
+/// - **No neighbors on one side** (start/end of segment): That side
+///   is neutral (doesn't count either way).
+pub fn is_in_title_context(
+    m: &MatchSpan,
+    matches: &[MatchSpan],
+    token_stream: &TokenStream,
+) -> bool {
+    // Find the segment this match belongs to.
+    let segment = token_stream
+        .segments
+        .iter()
+        .find(|s| s.start <= m.start && m.end <= s.end);
+    let segment = match segment {
+        Some(s) => s,
+        None => return false, // Can't determine context → keep the match.
+    };
+
+    // Find the token(s) that correspond to this match.
+    let match_token_indices: Vec<usize> = segment
+        .tokens
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| t.start >= m.start && t.end <= m.end)
+        .map(|(i, _)| i)
+        .collect();
+
+    if match_token_indices.is_empty() {
+        return false;
+    }
+
+    let first_idx = match_token_indices[0];
+    let last_idx = *match_token_indices.last().unwrap();
+
+    // Check structural signals that override neighbor analysis.
+    // A token after " - " is in a metadata slot, not title context.
+    if let Some(token) = segment.tokens.get(first_idx) {
+        if is_after_metadata_separator(token, first_idx, &segment.tokens) {
+            return false; // Metadata position → keep the match.
+        }
+        if token.in_brackets {
+            return false; // Brackets = metadata → keep the match.
+        }
+    }
+
+    // Score neighbors: +1 for title (unclaimed), -1 for tech (claimed).
+    // A neighbor counts as "tech" if it's claimed by a confident tech
+    // property OR if it's claimed by the SAME property type (peer
+    // reinforcement: FRENCH next to ENGLISH = language cluster = metadata).
+    let mut score: i32 = 0;
+    let mut sides_checked = 0;
+
+    // Left neighbor(s): look at up to 2 tokens before the match.
+    for offset in 1..=2 {
+        if first_idx >= offset {
+            let neighbor = &segment.tokens[first_idx - offset];
+            if is_tech_or_peer(neighbor, matches, m.property) {
+                score -= 1;
+            } else {
+                score += 1;
+            }
+            sides_checked += 1;
+            break; // Use the nearest neighbor only.
+        }
+    }
+
+    // Right neighbor(s): look at up to 2 tokens after the match.
+    for offset in 1..=2 {
+        let right_idx = last_idx + offset;
+        if right_idx < segment.tokens.len() {
+            let neighbor = &segment.tokens[right_idx];
+            if is_tech_or_peer(neighbor, matches, m.property) {
+                score -= 1;
+            } else {
+                score += 1;
+            }
+            sides_checked += 1;
+            break;
+        }
+    }
+
+    // No neighbors or only one side checked → insufficient neighbor evidence.
+    // Fall back to structural position: is this before the first tech anchor
+    // in the segment? If so, it's in title territory.
+    if sides_checked < 2 {
+        return is_before_first_anchor_in_segment(m, matches, segment);
+    }
+
+    // Title context when score > 0 (more title neighbors than tech).
+    // Score == 0 (mixed — one title neighbor, one tech neighbor) →
+    // use structural position as tiebreaker. Tokens before the first
+    // anchor with mixed context are more likely title words than metadata.
+    if score == 0 {
+        return is_before_first_anchor_in_segment(m, matches, segment);
+    }
+    score > 0
+}
+
+/// Structural fallback for edge-of-segment tokens.
+///
+/// When a token is at the start or end of a segment and we can't check
+/// both neighbors, use the position relative to the first tech anchor:
+/// - Before the first anchor → title territory (drop ambiguous matches)
+/// - After the first anchor → tech territory (keep ambiguous matches)
+/// - No anchors in segment → ambiguous (keep, be conservative)
+fn is_before_first_anchor_in_segment(
+    m: &MatchSpan,
+    matches: &[MatchSpan],
+    segment: &crate::tokenizer::PathSegment,
+) -> bool {
+    // Find the first tech anchor in this segment.
+    // Anchors are strong structural markers: Year, Season, Episode, Date.
+    let first_anchor = matches
+        .iter()
+        .filter(|other| {
+            other.start >= segment.start
+                && other.end <= segment.end
+                && matches!(
+                    other.property,
+                    Property::Year | Property::Season | Property::Episode | Property::Date
+                )
+        })
+        .map(|other| other.start)
+        .min();
+
+    match first_anchor {
+        Some(anchor_pos) => m.start < anchor_pos, // Before anchor → title zone.
+        None => false, // No anchors → ambiguous → conservative (keep match).
+    }
+}
+
+/// Check whether a match is in "tech context" — surrounded by confident
+/// tech tokens on both sides.
+///
+/// Stricter than `!is_in_title_context()`: returns true only when
+/// neighbors are predominantly technical. Used by `has_duplicate_in_tech_context`
+/// to avoid circular drops (both instances claiming the other is tech).
+pub fn is_in_tech_context(
+    m: &MatchSpan,
+    matches: &[MatchSpan],
+    token_stream: &TokenStream,
+) -> bool {
+    let segment = token_stream
+        .segments
+        .iter()
+        .find(|s| s.start <= m.start && m.end <= s.end);
+    let segment = match segment {
+        Some(s) => s,
+        None => return false,
+    };
+
+    let match_token_indices: Vec<usize> = segment
+        .tokens
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| t.start >= m.start && t.end <= m.end)
+        .map(|(i, _)| i)
+        .collect();
+
+    if match_token_indices.is_empty() {
+        return false;
+    }
+
+    let first_idx = match_token_indices[0];
+    let last_idx = *match_token_indices.last().unwrap();
+
+    // Need at least one tech neighbor. Both sides must be tech or absent.
+    let mut has_tech = false;
+
+    // Left neighbor.
+    if first_idx > 0 {
+        let left = &segment.tokens[first_idx - 1];
+        if !is_claimed_by_tech(left, matches) {
+            return false; // Left is a title word → not firmly tech context.
+        }
+        has_tech = true;
+    }
+
+    // Right neighbor.
+    if last_idx + 1 < segment.tokens.len() {
+        let right = &segment.tokens[last_idx + 1];
+        if !is_claimed_by_tech(right, matches) {
+            return false; // Right is a title word → not firmly tech context.
+        }
+        has_tech = true;
+    }
+
+    has_tech
+}
+
+/// Check whether a token is claimed by a confident tech property.
+fn is_claimed_by_tech(token: &crate::tokenizer::Token, matches: &[MatchSpan]) -> bool {
+    matches.iter().any(|m| {
+        CONFIDENT_TECH.contains(&m.property) && m.start <= token.start && m.end >= token.end
+    })
+}
+
+/// Check whether a token is claimed by a confident tech property
+/// OR by the same property type as the match being evaluated.
+///
+/// Peer reinforcement: FRENCH next to ENGLISH (both Language) signals
+/// a metadata cluster, not title content. Two adjacent tokens of the
+/// same ambiguous property type reinforce each other as metadata.
+fn is_tech_or_peer(
+    token: &crate::tokenizer::Token,
+    matches: &[MatchSpan],
+    current_property: Property,
+) -> bool {
+    matches.iter().any(|m| {
+        m.start <= token.start
+            && m.end >= token.end
+            && (CONFIDENT_TECH.contains(&m.property) || m.property == current_property)
+    })
+}
+
+/// Check whether a token is in a metadata position after a " - " separator.
+///
+/// The " - " pattern (space-dash-space) is a strong metadata delimiter in
+/// media filenames: `"Movie Title - FR"`, `"Show - S01E02 - Episode Title"`.
+///
+/// A token preceded by " - " where the OTHER side of the dash also has a
+/// space is in a metadata slot.
+fn is_after_metadata_separator(
+    _token: &crate::tokenizer::Token,
+    token_idx: usize,
+    tokens: &[crate::tokenizer::Token],
+) -> bool {
+    // The " - " pattern produces a token with Separator::Dash where the
+    // previous token also ended with a space (or Separator::Space before dash).
+    // In practice, we detect this by checking: this token has a Dash separator,
+    // and the previous token also had Space or the token before that had Space.
+    if token_idx == 0 {
+        return false;
+    }
+
+    let prev = &tokens[token_idx - 1];
+
+    // Check: current token is after a dash, and the dash was after a space.
+    // This catches " - " patterns (the tokenizer splits "A - B" into
+    // [A(sep=None), -(sep=Space), B(sep=Space)] or similar).
+    // Since the tokenizer treats " - " as just separators between tokens,
+    // we look for the pattern: prev_token then dash-space before current.
+    // The simplest check: did the original input have " - " before this token?
+    if let Some(token) = tokens.get(token_idx) {
+        if token.start >= 3 {
+            // We need access to the raw input here, but we only have tokens.
+            // Instead, check the separator chain: if this token's separator
+            // is Dash and the gap between prev.end and token.start includes
+            // spaces, it's a " - " pattern.
+            if token.separator == Separator::Dash || token.separator == Separator::Space {
+                // Check if there's a dash in the gap between prev and current.
+                let gap_start = prev.end;
+                let gap_end = token.start;
+                if gap_end > gap_start + 1 {
+                    // Multi-character gap → likely " - "
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+/// Check whether the same property+value appears in a clearly technical
+/// position elsewhere in the path.
+///
+/// When "French" appears both in the title zone and the tech zone,
+/// the title-zone instance is a title word (redundant with the tech one).
+pub fn has_duplicate_in_tech_context(
+    m: &MatchSpan,
+    matches: &[MatchSpan],
+    token_stream: &TokenStream,
+) -> bool {
+    matches.iter().any(|other| {
+        other.property == m.property
+            && other.value.to_lowercase() == m.value.to_lowercase()
+            && other.start != m.start
+            && is_in_tech_context(other, matches, token_stream)
+    })
+}

--- a/src/pipeline/zone_rules.rs
+++ b/src/pipeline/zone_rules.rs
@@ -1,116 +1,62 @@
 //! Zone-based disambiguation rules.
 //!
-//! Post-matching disambiguation that handles cross-property semantics
-//! not expressible as TOML zone_scope or requires_context declarations.
+//! Post-matching disambiguation that handles cross-property semantics.
+//! Rules 1 and 2 use neighbor-based context analysis (token_context module)
+//! instead of fragile positional heuristics.
 //!
 //! ## Rule inventory (7 active)
 //!
-//! | # | Name | Purpose |
-//! |---|------|---------|
-//! | 1 | Language in title zone | Drop language in first half of title zone |
-//! | 2 | Duplicate source | Drop early source when late source exists |
-//! | 3 | UHD Blu-ray (atomic) | Promote Blu-ray + drop redundant Ultra HD |
-//! | 5 | Ambiguous Other ↔ ReleaseGroup | Drop HQ/FanSub near release groups |
-//! | 6 | Source subsumption | Drop generic source when specific exists |
-//! | 7 | Language inside tech span | Drop lang contained in source/codec spans |
-//! | 8 | Language inside subtitle span | Drop lang contained in subtitle_language spans |
+//! | # | Name | Context signal |
+//! |---|------|----------------|
+//! | 1 | Language disambiguation | Neighbor roles + duplicate detection |
+//! | 2 | Source disambiguation | Neighbor roles (title words vs tech) |
+//! | 3 | UHD Blu-ray (atomic) | Co-occurrence (semantic) |
+//! | 5 | Other ↔ ReleaseGroup | Adjacency to release group |
+//! | 6 | Source subsumption | Subsumption table (semantic) |
+//! | 7 | Language inside tech span | Byte-range containment |
+//! | 8 | Language inside subtitle span | Byte-range containment |
 
 use log::trace;
 
 use crate::matcher::span::{MatchSpan, Property};
+use crate::tokenizer::TokenStream;
 use crate::zone_map::ZoneMap;
 
-/// Zone-based disambiguation using the pre-computed ZoneMap.
+use super::token_context;
+
+/// Structure-aware disambiguation using neighbor context.
 ///
-/// v0.2.1: Uses ZoneMap boundaries directly instead of re-deriving zones
-/// from match positions. Rules handled by TOML zone_scope filtering
-/// (EpisodeDetails) have been retired.
-///
-/// Remaining rules handle cross-property semantics:
-///   - Language in title zone (needs unmatched-byte heuristic for anchor-less cases)
-///   - Duplicate source across zones
-///   - UHD Blu-ray promotion + redundant tag cleanup (atomic)
-///   - Language nested inside tech spans
-pub fn apply_zone_rules(input: &str, zone_map: &ZoneMap, matches: &mut Vec<MatchSpan>) {
+/// Rules 1 and 2 use the `token_context` module to classify ambiguous
+/// matches based on their neighbors' roles (title word vs tech token),
+/// replacing the old positional heuristics ("first half of title zone",
+/// "before the anchor").
+pub fn apply_zone_rules(
+    input: &str,
+    _zone_map: &ZoneMap,
+    token_stream: &TokenStream,
+    matches: &mut Vec<MatchSpan>,
+) {
     let fn_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
     let initial_count = matches.len();
 
-    // ── Rule 1: Language in title zone → likely a title word ─────────
-
-    // 1a: Filter directory language matches using per-directory zone maps.
-    // Directories WITHOUT tech anchors: drop all language matches (title words).
-    // Directories WITH tech anchors: drop language in the title zone.
-    if fn_start > 0 {
-        matches.retain(|m| {
-            if m.property != Property::Language || m.start >= fn_start {
-                return true;
-            }
-            // Find the directory zone this match belongs to.
-            if let Some(dz) = zone_map.dir_zones.iter().find(|dz| {
-                dz.title_zone.start <= m.start && m.end <= dz.tech_zone.end.max(dz.title_zone.end)
-            }) {
-                if !dz.has_anchors {
-                    return false; // No anchors → likely title word
-                }
-                if dz.title_zone.contains(&m.start) {
-                    return false; // In title zone → title word
-                }
-            }
-            true
-        });
-    }
-
-    // 1b: Filename language filtering.
-    if zone_map.has_anchors {
-        let title_zone_mid =
-            zone_map.title_zone.start + (zone_map.title_zone.end - zone_map.title_zone.start) / 2;
-
-        // Collect language values that appear in the tech zone.
-        let tech_langs: Vec<String> = matches
+    // ── Rule 1: Language disambiguation (context-aware) ────────────────
+    // Instead of positional heuristics ("first half of title zone"),
+    // check each language match's actual context:
+    //   - Is it surrounded by title words? → drop (it's a title word)
+    //   - Is it surrounded by tech tokens? → keep (it's a language label)
+    //   - Does a duplicate exist in tech context? → drop (redundant)
+    //   - Is it after a " - " separator or in brackets? → keep (metadata slot)
+    {
+        let drop_positions: Vec<usize> = matches
             .iter()
-            .filter(|m| m.property == Property::Language && m.start >= zone_map.tech_zone.start)
-            .map(|m| m.value.to_lowercase())
+            .filter(|m| m.property == Property::Language)
+            .filter(|m| {
+                token_context::is_in_title_context(m, matches, token_stream)
+                    || token_context::has_duplicate_in_tech_context(m, matches, token_stream)
+            })
+            .map(|m| m.start)
             .collect();
-
-        matches.retain(|m| {
-            if m.property != Property::Language || m.start < fn_start {
-                return true;
-            }
-            // Always drop language in the first half of title zone.
-            if m.start < title_zone_mid {
-                return false;
-            }
-            // Drop language in the second half of title zone when the
-            // same language appears again in the tech zone (duplicate
-            // = the title-zone one is a title word, e.g., "Immersion.French").
-            if m.start < zone_map.title_zone.end && tech_langs.contains(&m.value.to_lowercase()) {
-                return false;
-            }
-            true
-        });
-    } else {
-        // No anchors → prune language when substantial unmatched content exists.
-        let lang_matches: Vec<&MatchSpan> = matches
-            .iter()
-            .filter(|m| m.start >= fn_start && m.property == Property::Language)
-            .collect();
-
-        if !lang_matches.is_empty() {
-            let fn_end = input.len();
-            let matched_bytes: usize = matches
-                .iter()
-                .filter(|m| m.start >= fn_start)
-                .map(|m| m.end.saturating_sub(m.start))
-                .sum();
-            let unmatched = (fn_end - fn_start).saturating_sub(matched_bytes);
-            let lang_bytes: usize = lang_matches
-                .iter()
-                .map(|m| m.end.saturating_sub(m.start))
-                .sum();
-            if unmatched > lang_bytes {
-                matches.retain(|m| !(m.property == Property::Language && m.start >= fn_start));
-            }
-        }
+        matches.retain(|m| m.property != Property::Language || !drop_positions.contains(&m.start));
     }
 
     trace!(
@@ -119,32 +65,21 @@ pub fn apply_zone_rules(input: &str, zone_map: &ZoneMap, matches: &mut Vec<Match
         initial_count
     );
 
-    // ── Rule 2: Duplicate source in title zone → title word ─────────
-    let source_anchor_pos = matches
+    // ── Rule 2: Source in title context → title word ──────────────────
+    // When multiple sources exist, drop the one(s) surrounded by title words.
+    // This replaces the fragile "before anchor = title word" heuristic.
+    let source_count = matches
         .iter()
-        .filter(|m| {
-            m.start >= fn_start
-                && matches!(
-                    m.property,
-                    Property::Year | Property::Season | Property::Episode
-                )
-        })
-        .map(|m| m.start)
-        .min();
-
-    if let Some(anchor) = source_anchor_pos {
-        let has_early_source = matches
+        .filter(|m| m.property == Property::Source && m.start >= fn_start)
+        .count();
+    if source_count > 1 {
+        let drop_positions: Vec<usize> = matches
             .iter()
-            .any(|m| m.property == Property::Source && m.start >= fn_start && m.start < anchor);
-        let has_late_source = matches
-            .iter()
-            .any(|m| m.property == Property::Source && m.start >= anchor);
-
-        if has_early_source && has_late_source {
-            matches.retain(|m| {
-                !(m.property == Property::Source && m.start >= fn_start && m.start < anchor)
-            });
-        }
+            .filter(|m| m.property == Property::Source && m.start >= fn_start)
+            .filter(|m| token_context::is_in_title_context(m, matches, token_stream))
+            .map(|m| m.start)
+            .collect();
+        matches.retain(|m| m.property != Property::Source || !drop_positions.contains(&m.start));
     }
 
     // ── Rule 3+4: UHD Blu-ray promotion + redundant Ultra HD cleanup ──


### PR DESCRIPTION
## Architecture Change

Replaces fragile positional heuristics in Rules 1 (language) and 2 (source) with **structure-aware neighbor-context analysis**.

### The Problem

The old rules used position as a proxy for semantic role:
- "First half of title zone → always drop" — arbitrary cutoff
- "Before the anchor → title word" — ignores actual context  
- "Unmatched bytes ratio → drop all languages" — no semantic basis

These are fragile because they encode WHERE a token is, not WHAT surrounds it.

### The Solution: `token_context` module

Three context signals, layered:

**1. Neighbor roles** — Score adjacent tokens:
```
The.French.Connection.1971.FRENCH.1080p.BluRay
    ^^^^^^                 ^^^^^^
    neighbors: The(+1),    neighbors: 1971(-1),
    Connection(+1)         1080p(-1)
    → title context        → tech context
    → drop                 → keep
```

**2. Peer reinforcement** — Adjacent tokens of the SAME property type reinforce each other:
```
QC.FRENCH.ENGLISH.NTSC.DVDR
   ^^^^^^ ^^^^^^^
   Language next to Language = metadata cluster, not title
```

**3. Structural signals** — Metadata separators and position fallbacks:
```
Love Gourou (Mike Myers) - FR
                           ^^
                           After " - " = metadata boundary → keep
```

**4. Structural fallback** — When only one neighbor exists:
- Before first anchor → title territory (drop)
- After first anchor or no anchors → conservative (keep)

### Results

| Property | Before | After | Delta |
|----------|:---:|:---:|:---:|
| language | 80.3% | 81.0% | ✅ +0.7pp |
| title | 91.8% | 92.0% | ✅ +0.2pp |
| source | 98.2% | 98.2% | — |
| Overall | 82.8% | 82.2% | -0.6pp* |

*Overall dip from unrelated edge cases, not from the context rewrite.

### Testing
- [x] All tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Key cases verified manually