### PR TITLE
chore: opt into Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,8 @@ jobs:
     name: GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
GitHub is deprecating Node.js 20 for Actions on June 2, 2026.

`softprops/action-gh-release@v2.6.1` still runs on Node 20 and has no newer release.
This sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on the `github-release` job to
opt in early and suppress the deprecation warning.

When `softprops/action-gh-release` ships a Node 24 build, we can remove the env var.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/