### PR TITLE
fix: compound codec strings no longer falsely detected as release_group (#37)

### DIFF
--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -881,6 +881,26 @@ mod tests {
     }
 
     #[test]
+    fn test_issue_37_compound_codec_not_release_group() {
+        // Issue #37: compound codec strings like H264_FLACx3_DTS-HDMA should
+        // not be detected as release_group when individual codecs are resolved.
+        let pipeline = Pipeline::default();
+
+        let result = pipeline.run(
+            "[Kimetsu no Yaiba Mugen Ressha Hen][JPN+ENG][BDRIP][1080P][H264_FLACx3_DTS-HDMA].mkv",
+        );
+        assert_eq!(result.video_codec(), Some("H.264"));
+        let codecs = result.all(Property::AudioCodec);
+        assert!(codecs.contains(&"FLAC"), "FLAC should be detected");
+        assert!(codecs.contains(&"DTS-HD"), "DTS-HD should be detected");
+        assert_ne!(
+            result.release_group(),
+            Some("H264_FLACx3_DTS-HDMA"),
+            "compound codec should not be release_group"
+        );
+    }
+
+    #[test]
     fn test_toml_rules_load() {
         // Smoke test: all TOML rule sets parse and have entries.
         assert!(VIDEO_CODEC_RULES.exact_count() >= 10);

--- a/src/properties/release_group/validation.rs
+++ b/src/properties/release_group/validation.rs
@@ -20,46 +20,53 @@
 use crate::matcher::span::{MatchSpan, Property};
 use crate::zone_map;
 
-/// Check if a byte range in the input is already claimed by a resolved match.
+/// Check if a byte range in the input is already claimed by resolved matches.
 ///
-/// Returns true if ANY resolved match overlaps with `[start, end)`.
-/// Only considers matches where the overlap is substantial (the candidate
-/// is mostly inside the resolved span), to avoid rejecting groups that
-/// barely touch an over-broad regex match.
+/// Returns true when resolved tech matches **collectively** cover ≥50% of
+/// the candidate span `[start, end)`. This catches both:
+/// - A single match covering most of the candidate (original behavior)
+/// - Multiple matches covering a compound string like `H264_FLACx3_DTS-HDMA`
+///   where three smaller matches together cover the full span (#37)
 pub fn is_position_claimed(start: usize, end: usize, resolved: &[MatchSpan]) -> bool {
     let candidate_len = end.saturating_sub(start);
     if candidate_len == 0 {
         return false;
     }
 
-    resolved.iter().any(|m| {
-        // Skip positional/aggregate properties — these claim broad text spans
-        // that may overlap with the release group. Only tech properties
-        // (codecs, sources, etc.) are reliable for overlap detection.
-        if matches!(
-            m.property,
-            Property::ReleaseGroup
-                | Property::Title
-                | Property::EpisodeTitle
-                | Property::FilmTitle
-                | Property::BonusTitle
-                | Property::AlternativeTitle
-        ) {
-            return false;
-        }
-        // Check overlap: two ranges overlap iff start < m.end AND end > m.start.
-        if start >= m.end || end <= m.start {
-            return false;
-        }
-        // Calculate how much of the candidate is inside this resolved match.
-        let overlap_start = start.max(m.start);
-        let overlap_end = end.min(m.end);
-        let overlap_len = overlap_end.saturating_sub(overlap_start);
-        // Require at least 50% of the candidate to be inside the resolved span.
-        // This prevents over-broad regex matches (like VideoCodec "hevc.+"
-        // spanning "HEVC.Atmos-EPSiLON") from blocking the release group.
-        overlap_len * 2 >= candidate_len
-    })
+    // Aggregate non-overlapping coverage from all tech matches.
+    let total_overlap: usize = resolved
+        .iter()
+        .filter(|m| {
+            // Skip positional/aggregate properties — these claim broad text
+            // spans that may overlap with the release group. Only tech
+            // properties (codecs, sources, etc.) are reliable.
+            !matches!(
+                m.property,
+                Property::ReleaseGroup
+                    | Property::Title
+                    | Property::EpisodeTitle
+                    | Property::FilmTitle
+                    | Property::BonusTitle
+                    | Property::AlternativeTitle
+            )
+        })
+        .filter_map(|m| {
+            // Only count overlapping ranges.
+            if start >= m.end || end <= m.start {
+                return None;
+            }
+            let overlap_start = start.max(m.start);
+            let overlap_end = end.min(m.end);
+            Some(overlap_end.saturating_sub(overlap_start))
+        })
+        .sum();
+
+    // Require at least 50% aggregate coverage.
+    // This prevents over-broad regex matches (like VideoCodec "hevc.+"
+    // spanning "HEVC.Atmos-EPSiLON") from blocking the release group,
+    // while still catching compound codec strings where multiple matches
+    // together cover the full span.
+    total_overlap * 2 >= candidate_len
 }
 
 /// Check if a candidate group name should be rejected.


### PR DESCRIPTION
## Problem

Compound codec bracket content like `[H264_FLACx3_DTS-HDMA]` was falsely detected as `release_group`. The individual codecs (H.264, FLAC, DTS-HD) were correctly extracted, but the full string was *also* claimed as release_group because `is_position_claimed()` only checked if any **single** resolved match covered ≥50% of the candidate. Three matches each covering ~33% didn't trigger the threshold.

**Before:**
```json
{
  "release_group": "H264_FLACx3_DTS-HDMA",
  "video_codec": "H.264",
  "audio_codec": ["FLAC", "DTS-HD"]
}
```

**After:**
```json
{
  "video_codec": "H.264",
  "audio_codec": ["FLAC", "DTS-HD"],
  "audio_profile": "Master Audio"
}
```

## Fix

Changed `is_position_claimed()` from per-match threshold to **aggregate** overlap. All resolved tech match overlaps are summed; if total coverage ≥50% of the candidate span, it's rejected. This correctly catches compound strings where multiple smaller matches together cover the full span.

## Tests

- 1 new regression test in `test_issue_37_compound_codec_not_release_group`
- All 230+ existing tests pass

Fixes #37