### PR TITLE
ci: auto-merge Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (squash)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that auto-approves and squash-merges Dependabot PRs.

### How it works

1. Triggers on `pull_request` only when actor is `dependabot[bot]`
2. Auto-approves the PR
3. Enables auto-merge (squash) — waits for CI to pass before merging

### Requirements

- Branch protection must require CI status checks (already configured)
- "Allow auto-merge" must be enabled in repo settings

No code changes — CI-only.