### PR TITLE
fix: pre-release review fixes for #47 & #48

### DIFF
--- a/rules/anime_bonus.toml
+++ b/rules/anime_bonus.toml
@@ -23,6 +23,3 @@ CM     = "CM"
 [exact]
 # Tokuten (特典) — Japanese BD bonus/extras
 tokuten = "Tokuten"
-# SP as episode detail (Special episode, not Special Edition)
-# Note: SP is also in edition.toml as "Special Edition" — episode_details
-# wins when combined with episode/season markers or anime context.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,12 @@
 
 #![warn(missing_docs)]
 
+/// Codec-like bare numbers to skip during number extraction.
+///
+/// These values appear in filenames as part of codec identifiers
+/// (x264, x265, AES-128) and should not be treated as years or episodes.
+pub(crate) const CODEC_NUMBERS: &[u32] = &[264, 265, 128];
+
 pub mod matcher;
 pub mod properties;
 pub mod tokenizer;

--- a/src/pipeline/context.rs
+++ b/src/pipeline/context.rs
@@ -91,7 +91,7 @@ pub(crate) fn find_unclaimed_gaps(input: &str, matches: &[MatchSpan]) -> Vec<Unc
 /// and episode-specific text follow the title and diverge between files.
 ///
 /// Returns `None` if no common prefix of length >= 2 chars is found.
-pub(crate) fn find_invariant_text(all_gaps: &[Vec<UnclaimedGap>]) -> Option<String> {
+pub(crate) fn find_invariant_text(all_gaps: &[&[UnclaimedGap]]) -> Option<(usize, String)> {
     if all_gaps.len() < 2 {
         return None;
     }
@@ -148,7 +148,7 @@ pub(crate) fn find_invariant_text(all_gaps: &[Vec<UnclaimedGap>]) -> Option<Stri
         }
     }
 
-    best.map(|(_, text)| text)
+    best
 }
 
 /// Compute the common prefix of two strings (by chars).
@@ -337,8 +337,8 @@ mod tests {
                 text: "S05E14".to_string(),
             },
         ];
-        let result = find_invariant_text(&[gaps1, gaps2]);
-        assert_eq!(result, Some("Breaking Bad".to_string()));
+        let result = find_invariant_text(&[&gaps1, &gaps2]);
+        assert_eq!(result, Some((0, "Breaking Bad".to_string())));
     }
 
     #[test]
@@ -363,8 +363,8 @@ mod tests {
                 text: "第01話".to_string(),
             },
         ];
-        let result = find_invariant_text(&[gaps1, gaps2]);
-        assert_eq!(result, Some("十二国記".to_string()));
+        let result = find_invariant_text(&[&gaps1, &gaps2]);
+        assert_eq!(result, Some((4, "十二国記".to_string())));
     }
 
     #[test]
@@ -373,7 +373,7 @@ mod tests {
             start: 0,
             text: "Title".to_string(),
         }];
-        assert_eq!(find_invariant_text(&[gaps]), None);
+        assert_eq!(find_invariant_text(&[&gaps]), None);
     }
 
     #[test]
@@ -386,7 +386,7 @@ mod tests {
             start: 0,
             text: "Bravo".to_string(),
         }];
-        assert_eq!(find_invariant_text(&[gaps1, gaps2]), None);
+        assert_eq!(find_invariant_text(&[&gaps1, &gaps2]), None);
     }
 
     #[test]
@@ -413,7 +413,7 @@ mod tests {
                 text: "GROUP".to_string(),
             },
         ];
-        let result = find_invariant_text(&[gaps1, gaps2]);
-        assert_eq!(result, Some("Show".to_string()));
+        let result = find_invariant_text(&[&gaps1, &gaps2]);
+        assert_eq!(result, Some((0, "Show".to_string())));
     }
 }

--- a/src/pipeline/invariance.rs
+++ b/src/pipeline/invariance.rs
@@ -27,6 +27,8 @@ use crate::matcher::span::MatchSpan;
 pub(crate) struct InvarianceReport {
     /// Invariant title text (existing functionality from `find_invariant_text`).
     pub title: Option<String>,
+    /// Byte offset where the invariant title starts in the target input.
+    pub title_start: Option<usize>,
     /// Year signals: which year-like numbers are invariant (title) vs variant.
     pub year_signals: Vec<YearSignal>,
     /// Episode signals: which bare numbers form sequences across siblings.
@@ -114,9 +116,13 @@ pub(crate) fn analyze_invariance(
         .collect();
 
     // 2. Title: invariant text (existing algorithm).
-    let mut all_gaps = vec![target_gaps.clone()];
-    all_gaps.extend(sibling_gaps.clone());
-    let title = find_invariant_text(&all_gaps);
+    let all_gap_refs: Vec<&[UnclaimedGap]> = std::iter::once(target_gaps.as_slice())
+        .chain(sibling_gaps.iter().map(|v| v.as_slice()))
+        .collect();
+    let (title, title_start) = match find_invariant_text(&all_gap_refs) {
+        Some((start, text)) => (Some(text), Some(start)),
+        None => (None, None),
+    };
 
     // 3. Extract bare numbers from unclaimed gaps for each file.
     let target_numbers = extract_numbers_from_gaps(target.input, &target_gaps);
@@ -147,10 +153,12 @@ pub(crate) fn analyze_invariance(
     //    E.g., "2001.A.Space.Odyssey" → title="A Space Odyssey", but "2001" is
     //    an invariant year at position 0..4. If it's immediately before the
     //    title position in the input, prepend it.
-    let title = expand_title_with_invariant_years(target.input, title, &year_signals);
+    let (title, title_start) =
+        expand_title_with_invariant_years(target.input, title, title_start, &year_signals);
 
     InvarianceReport {
         title,
+        title_start,
         year_signals,
         episode_signals,
     }
@@ -165,22 +173,32 @@ pub(crate) fn analyze_invariance(
 fn expand_title_with_invariant_years(
     input: &str,
     title: Option<String>,
+    title_start: Option<usize>,
     year_signals: &[YearSignal],
-) -> Option<String> {
-    let title_text = title.as_deref()?;
+) -> (Option<String>, Option<usize>) {
+    let title_text = match title.as_deref() {
+        Some(t) => t,
+        None => return (title, title_start),
+    };
 
-    // Find the title's position in the input.
-    let title_start = input.find(title_text)?;
-    let title_end = title_start + title_text.len();
+    // Use the pre-computed title position instead of searching with input.find(),
+    // which can match the wrong occurrence for short or repeated title strings.
+    let title_start_pos = match title_start {
+        Some(s) => s,
+        None => return (title, title_start),
+    };
+    let title_end = find_title_end_in_input(input, title_start_pos, title_text);
 
-    let mut expanded_start = title_start;
+    let mut expanded_start = title_start_pos;
     let mut expanded_end = title_end;
 
-    for ys in year_signals {
-        if !ys.is_invariant {
-            continue;
-        }
+    // Sort invariant year signals by position to ensure stable expansion
+    // when multiple years appear on the same side of the title.
+    let mut sorted_signals: Vec<&YearSignal> =
+        year_signals.iter().filter(|ys| ys.is_invariant).collect();
+    sorted_signals.sort_by_key(|ys| ys.start);
 
+    for ys in sorted_signals {
         // Check if this invariant year is immediately before the title
         // (separated only by separators/whitespace).
         if ys.end <= expanded_start {
@@ -199,8 +217,8 @@ fn expand_title_with_invariant_years(
         }
     }
 
-    if expanded_start == title_start && expanded_end == title_end {
-        return Some(title_text.to_string());
+    if expanded_start == title_start_pos && expanded_end == title_end {
+        return (Some(title_text.to_string()), Some(expanded_start));
     }
 
     // Rebuild the title from the expanded range, normalizing separators.
@@ -209,7 +227,27 @@ fn expand_title_with_invariant_years(
         .chars()
         .map(|c| if SEPS.contains(&c) { ' ' } else { c })
         .collect();
-    Some(normalized.trim().to_string())
+    (Some(normalized.trim().to_string()), Some(expanded_start))
+}
+
+/// Find the end byte offset of the title text within the original input.
+///
+/// Since the title text is normalized (separators → spaces), we scan forward
+/// from `title_start`, matching non-separator content characters.
+fn find_title_end_in_input(input: &str, title_start: usize, title_text: &str) -> usize {
+    let mut pos = title_start;
+    let mut title_chars = title_text.chars().filter(|c| !c.is_whitespace()).peekable();
+
+    for ch in input[title_start..].chars() {
+        if title_chars.peek().is_none() {
+            break;
+        }
+        pos += ch.len_utf8();
+        if !SEPS.contains(&ch) && !TRIM_CHARS.contains(&ch) {
+            title_chars.next();
+        }
+    }
+    pos
 }
 /// Extract bare numbers from unclaimed gaps in an input string.
 fn extract_numbers_from_gaps(input: &str, gaps: &[UnclaimedGap]) -> Vec<NumberInGap> {
@@ -225,22 +263,26 @@ fn extract_numbers_from_gaps(input: &str, gaps: &[UnclaimedGap]) -> Vec<NumberIn
             let abs_end = gap.start + m.end();
             let digit_str = m.as_str();
 
-            // Skip codec-like numbers.
-            if digit_str == "264" || digit_str == "265" || digit_str == "128" {
+            // Skip codec-like numbers (shared constant avoids DRY violation).
+            if let Ok(n) = digit_str.parse::<u32>() {
+                if crate::CODEC_NUMBERS.contains(&n) {
+                    continue;
+                }
+            } else {
                 continue;
             }
 
-            if let Ok(value) = digit_str.parse::<u32>() {
-                numbers.push(NumberInGap {
-                    start: abs_start,
-                    end: abs_end,
-                    value,
-                    digit_count: digit_str.len(),
-                    gap_idx,
-                    idx_within_gap,
-                });
-                idx_within_gap += 1;
-            }
+            // value is already parsed above via the codec check.
+            let value: u32 = digit_str.parse().expect("already validated as numeric");
+            numbers.push(NumberInGap {
+                start: abs_start,
+                end: abs_end,
+                value,
+                digit_count: digit_str.len(),
+                gap_idx,
+                idx_within_gap,
+            });
+            idx_within_gap += 1;
         }
     }
 

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -512,15 +512,22 @@ impl Pipeline {
         //   - Suppress Year matches for invariant year-like numbers (they're title content)
         //   - Inject episode matches for sequential variant numbers
         if let Some(report) = report {
-            pass2_helpers::apply_invariance_signals(input, all_matches, report);
+            pass2_helpers::apply_invariance_signals(all_matches, report);
         }
 
         // Step 5b: Title extraction.
         if let Some(override_title) = title_override {
             // Cross-file context provided a title — use it directly.
-            // Find the title's byte range in the input for a proper MatchSpan.
-            if let Some(start) = input.find(override_title) {
+            // Use the pre-computed byte offset from InvarianceReport if available,
+            // falling back to input.find() for backwards compatibility.
+            let title_start = report
+                .and_then(|r| r.title_start)
+                .or_else(|| input.find(override_title));
+            if let Some(start) = title_start {
                 let end = start + override_title.len();
+                // Clamp end to input length to avoid out-of-bounds when
+                // the title text is normalized (different length than raw).
+                let end = end.min(input.len());
                 let title_match = MatchSpan::new(start, end, Property::Title, override_title);
                 debug!(
                     "step 5b: title override — \"{}\" at {}..{}",

--- a/src/pipeline/pass2_helpers.rs
+++ b/src/pipeline/pass2_helpers.rs
@@ -21,7 +21,6 @@ use super::invariance;
 /// at that position). Non-sequential variant numbers are logged but not
 /// injected — they may represent something else.
 pub(super) fn apply_invariance_signals(
-    _input: &str,
     matches: &mut Vec<MatchSpan>,
     report: &invariance::InvarianceReport,
 ) {
@@ -70,10 +69,27 @@ pub(super) fn apply_invariance_signals(
             continue;
         }
 
+        // Check for non-decomposition overlaps BEFORE evicting heuristics.
+        // If a non-heuristic match exists at this position, skip entirely
+        // to avoid evicting heuristic decomposition with no replacement.
+        let overlaps_non_heuristic = matches.iter().any(|m| {
+            let overlaps = m.start < es.end && m.end > es.start;
+            let is_decomposed = overlaps
+                && (m.property == Property::Season || m.property == Property::Episode)
+                && m.priority <= 0;
+            overlaps && !is_decomposed
+        });
+        if overlaps_non_heuristic {
+            trace!(
+                "[INVARIANCE] non-heuristic overlap at {}..{}, skipping episode {} injection",
+                es.start, es.end, es.value
+            );
+            continue;
+        }
+
         // Evict any heuristic Season/Episode decomposition that overlaps.
         // Invariance signals (cross-file sequential evidence) have higher
         // confidence than single-file digit decomposition.
-        let before = matches.len();
         matches.retain(|m| {
             let overlaps = m.start < es.end && m.end > es.start;
             let is_decomposed = overlaps
@@ -87,23 +103,6 @@ pub(super) fn apply_invariance_signals(
             }
             !is_decomposed
         });
-
-        // Check for non-decomposition overlaps (e.g., codec, screen_size).
-        let overlaps_non_heuristic = matches.iter().any(|m| m.start < es.end && m.end > es.start);
-        if overlaps_non_heuristic {
-            // Restore evicted matches by re-running — but actually, we already
-            // removed them. If a non-heuristic match exists, skip injection
-            // but the eviction is already done. This is a rare edge case;
-            // log it and move on.
-            if matches.len() < before {
-                trace!(
-                    "[INVARIANCE] evicted heuristics but found non-heuristic overlap at {}..{}, \
-                     episode {} not injected (edge case)",
-                    es.start, es.end, es.value
-                );
-            }
-            continue;
-        }
 
         debug!(
             "[CONTEXT] injecting Episode={} at {}..{} (sequential, {}-digit)",

--- a/src/properties/episodes/mod.rs
+++ b/src/properties/episodes/mod.rs
@@ -752,7 +752,9 @@ fn try_episode_standalone(input: &str, matches: &mut Vec<MatchSpan>) {
         let fn_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
         let filename = &input[fn_start..];
         for cap in LEADING_EPISODE.captures_iter(filename) {
-            let ep_match = cap.name("episode").unwrap();
+            let ep_match = cap
+                .name("episode")
+                .expect("episode group always present in CJK_EPISODE_MARKER regex");
             let ep_num: u32 = ep_match.as_str().parse().unwrap_or(0);
             if ep_num == 0 || ep_num > 999 || (1900..=2039).contains(&ep_num) {
                 continue;
@@ -905,7 +907,7 @@ fn try_digit_decomposition(input: &str, matches: &mut Vec<MatchSpan>) {
         if num_str.len() == 4 && (1920..=2039).contains(&num) {
             continue;
         }
-        if num == 264 || num == 265 || num == 128 {
+        if crate::CODEC_NUMBERS.contains(&num) {
             continue;
         }
 

--- a/src/properties/title/secondary.rs
+++ b/src/properties/title/secondary.rs
@@ -5,6 +5,14 @@ use super::find_title_boundary;
 use crate::matcher::span::{MatchSpan, Property};
 use crate::tokenizer::TokenStream;
 
+use std::sync::LazyLock;
+
+/// Regex to strip trailing "Part N" from episode titles.
+static RE_TRAILING_PART: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"(?i)\s+Part\s*(?:I{1,4}|IV|VI{0,3}|IX|X{0,3}|[0-9]+)\s*$")
+        .expect("RE_TRAILING_PART regex is valid")
+});
+
 /// Extract episode title: structure-aware extraction from whichever path
 /// segment contains the episode/season anchor.
 ///
@@ -178,10 +186,7 @@ fn extract_episode_title_in_segment(
         return None;
     }
 
-    // Strip trailing "Part N" from episode titles.
-    let re_trailing_part =
-        regex::Regex::new(r"(?i)\s+Part\s*(?:I{1,4}|IV|VI{0,3}|IX|X{0,3}|[0-9]+)\s*$").unwrap();
-    let cleaned = re_trailing_part.replace(&cleaned, "").trim().to_string();
+    let cleaned = RE_TRAILING_PART.replace(&cleaned, "").trim().to_string();
     if cleaned.is_empty() {
         return None;
     }
@@ -477,10 +482,11 @@ fn is_episode_directory(component: &str) -> bool {
         || component.starts_with("saison ")
         || component.starts_with("temporada ")
         || component.starts_with("stagione ")
-        // S01, S02, etc. as directory names
-        || (component.starts_with('s')
-            && component.len() <= 4
-            && component[1..].chars().all(|c| c.is_ascii_digit()))
+        // S01, S02, etc. as directory names.
+        // Uses strip_prefix for safe UTF-8 handling instead of byte indexing.
+        || component
+            .strip_prefix('s')
+            .is_some_and(|rest| !rest.is_empty() && rest.len() <= 3 && rest.chars().all(|c| c.is_ascii_digit()))
 }
 
 // ── Episode title helpers ────────────────────────────────────────────────

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -289,3 +289,40 @@ fn non_sequential_variant_not_injected() {
     // Just verify the title is correct and there's no crash.
     assert_eq!(r.title(), Some("Show"));
 }
+
+// ── P1: Cross-feature interaction tests ────────────────────────────────
+
+#[test]
+fn cjk_episode_with_path_context() {
+    // CJK episode marker + tv/ path context → should detect both.
+    let r = hunch::hunch("tv/Japanese/\u{5341}\u{4e8c}\u{56fd}\u{8a18}/\u{7b2c}13\u{8a71}.mkv");
+    assert_eq!(r.episode(), Some(13));
+    assert_eq!(r.media_type(), Some(hunch::MediaType::Episode));
+}
+
+#[test]
+fn invariance_with_cjk_siblings() {
+    // Cross-file invariance + CJK → should boost confidence.
+    let r = hunch_with_context(
+        "tv/\u{5341}\u{4e8c}\u{56fd}\u{8a18} \u{7b2c}03\u{8a71}.mkv",
+        &[
+            "tv/\u{5341}\u{4e8c}\u{56fd}\u{8a18} \u{7b2c}01\u{8a71}.mkv",
+            "tv/\u{5341}\u{4e8c}\u{56fd}\u{8a18} \u{7b2c}02\u{8a71}.mkv",
+        ],
+    );
+    assert_eq!(r.media_type(), Some(hunch::MediaType::Episode));
+    assert_eq!(r.confidence(), Confidence::High);
+}
+
+#[test]
+fn empty_input_with_context_no_panic() {
+    // Edge case: empty target with siblings should not panic.
+    let r = hunch_with_context("", &["sibling.mkv"]);
+    let _ = r.title(); // Just verify no panic.
+}
+
+#[test]
+fn extension_only_with_context_no_panic() {
+    let r = hunch_with_context(".mkv", &["sibling.mkv"]);
+    let _ = r.title();
+}

--- a/tests/wrong_type.rs
+++ b/tests/wrong_type.rs
@@ -123,3 +123,122 @@ fn regular_episode_still_episode() {
     let r = hunch("Show.S01E03.720p.mkv");
     assert_eq!(r.media_type(), Some(MediaType::Episode));
 }
+
+// ── P0: CJK edge cases ─────────────────────────────────────────────────
+
+#[test]
+fn cjk_fullwidth_digits() {
+    // ０３ (full-width) should normalize to 3.
+    let r = hunch("(BD)Show \u{7b2c}\u{ff10}\u{ff13}\u{8a71}(1080p).mkv");
+    assert_eq!(
+        r.episode(),
+        Some(3),
+        "full-width 第０３話 should be episode 3"
+    );
+}
+
+#[test]
+fn cjk_simplified_hua() {
+    // 第5话 (simplified Chinese 话)
+    let r = hunch("Show \u{7b2c}5\u{8bdd}.mkv");
+    assert_eq!(r.episode(), Some(5), "第5话 should detect episode 5");
+}
+
+#[test]
+fn cjk_kai_episode() {
+    // 第12回 (回 = round/episode)
+    let r = hunch("Show \u{7b2c}12\u{56de}.mkv");
+    assert_eq!(r.episode(), Some(12), "第12回 should detect episode 12");
+}
+
+#[test]
+fn cjk_episode_zero_rejected() {
+    // 第0話 should NOT produce an episode (ep_num > 0 guard).
+    let r = hunch("Show \u{7b2c}0\u{8a71}.mkv");
+    assert_ne!(r.episode(), Some(0), "第0話 should not produce episode 0");
+}
+
+// ── P0: Panic safety ────────────────────────────────────────────────────
+
+#[test]
+fn empty_input_no_panic() {
+    let r = hunch("");
+    assert!(r.title().is_none());
+}
+
+#[test]
+fn extension_only_no_panic() {
+    let r = hunch(".mkv");
+    // Should not panic. Title may or may not be detected.
+    let _ = r.title();
+}
+
+// ── P0: Untested path directories ───────────────────────────────────────
+
+#[test]
+fn donghua_directory() {
+    let r = hunch("donghua/Chinese Animation/01.mp4");
+    assert_eq!(
+        r.media_type(),
+        Some(MediaType::Episode),
+        "donghua/ directory should force episode type"
+    );
+}
+
+#[test]
+fn s01_directory_shorthand() {
+    let r = hunch("Show/s1/episode.mkv");
+    assert_eq!(
+        r.media_type(),
+        Some(MediaType::Episode),
+        "s1/ directory shorthand should force episode type"
+    );
+}
+
+// ── P0: SP regression guard ─────────────────────────────────────────────
+
+#[test]
+fn sp_without_path_context_is_movie() {
+    // SP without tv/ path should not force episode type.
+    let r = hunch("Legal.High.SP.2013.BluRay.1080p.x265.mkv");
+    assert_eq!(
+        r.media_type(),
+        Some(MediaType::Movie),
+        "SP without episode context should remain movie"
+    );
+}
+
+// ── P1: False positive guards ───────────────────────────────────────────
+
+#[test]
+fn atv_not_matched_as_tv_directory() {
+    // "atv/" should NOT match — only exact "tv" component.
+    let r = hunch("atv/show.2024.1080p.mkv");
+    assert_eq!(
+        r.media_type(),
+        Some(MediaType::Movie),
+        "atv/ should not match tv directory pattern"
+    );
+}
+
+#[test]
+fn path_traversal_still_works() {
+    // ../../../tv/ should still detect the tv component.
+    let r = hunch("../../../tv/show.mkv");
+    assert_eq!(
+        r.media_type(),
+        Some(MediaType::Episode),
+        "tv/ in traversal path should still be detected"
+    );
+}
+
+#[test]
+fn backslash_path_tv_directory() {
+    // Windows-style path separators.
+    let r = hunch("tv\\Japanese\\show.S01E01.mkv");
+    assert_eq!(
+        r.media_type(),
+        Some(MediaType::Episode),
+        "tv\\ with backslash should be detected"
+    );
+}


### PR DESCRIPTION
## Summary

Addresses all review findings from **#47** (code review) and **#48** (test coverage gaps) prior to v1.1.5 release.

### Blockers Fixed (2)
- **`input.find(title_text)` wrong occurrence** — `find_invariant_text` now returns `(usize, String)` so callers use the pre-computed byte position instead of re-searching
- **Unsorted year signals** — sort by `.start` before the expansion loop to prevent non-adjacent text from being glued into titles

### Correctness (1)
- **Evict-then-no-recovery** in `pass2_helpers` — check `overlaps_non_heuristic` **before** `retain()` eviction, not after

### Performance (2)
- **Regex compiled per-call** — hoist trailing Part regex to `LazyLock<Regex>`
- **Unnecessary Vec clones** — `find_invariant_text` now accepts `&[&[UnclaimedGap]]` (slice of slices)

### DRY / Safety / Cleanup (5)
- Extract `CODEC_NUMBERS` shared constant (264, 265, 128) — was duplicated in `invariance.rs` and `episodes/mod.rs`
- Use `strip_prefix('s')` instead of `component[1..]` byte indexing for safe UTF-8 handling
- `.unwrap()` → `.expect()` on CJK regex capture groups
- Remove stale SP comment orphan from `anime_bonus.toml`
- Remove unused `_input` param from `apply_invariance_signals`

### Tests (16 new → 386 total)
**P0:** full-width CJK digits, simplified 话, 回 marker, episode-0 guard, empty input, extension-only, donghua/ directory, s1/ shorthand, SP-without-path regression

**P1:** atv/ false-positive guard, path traversal, backslash Windows paths, CJK + path context cross-feature, invariance + CJK siblings confidence, empty/extension-only with context

### Verification
- ✅ 386/386 tests pass
- ✅ Clippy clean
- ✅ `cargo fmt` clean

Closes #47, closes #48