### PR TITLE
chore: release v1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.5] - 2026-03-20
+
+### Added
+
+- **CJK episode markers** (`第N話`, `第N集`, `第N回`, `第N话`) — structural
+  pattern recognition for Japanese and Chinese episode numbering. Full-width
+  digit normalization (０-９ → 0-9) included. (#46)
+- **Anime bonus vocabulary** — NCOP, NCED, PV, CM tokens emit
+  `EpisodeDetails`, correctly classifying bonus content as episodes. (#46)
+- **Path-based type inference** — directory names (`tv/`, `anime/`,
+  `donghua/`, `Season N/`, `sN/`) force `MediaType::Episode` even when
+  the filename alone lacks episode markers. (#46)
+- **InvarianceReport** with year/episode signal detection — cross-file
+  sequential analysis identifies bare numbers as episodes and suppresses
+  invariant years from metadata. (#47, #48)
+- **Source tagging** (`Structural`, `Context`, `Heuristic`) on all
+  `MatchSpan`s — heuristic-only results cap confidence at Medium. (#47, #48)
+- 28 new integration tests (370 → 386 total) covering CJK markers,
+  path inference, invariance signals, cross-feature interactions, and
+  panic safety edge cases.
+
+### Changed
+
+- **`find_invariant_text`** now returns `(usize, String)` — pre-computed
+  byte offset eliminates fragile `input.find()` re-search that could match
+  the wrong occurrence for short/repeated title strings.
+- **`find_invariant_text`** accepts `&[&[UnclaimedGap]]` instead of
+  cloning all gap Vecs (zero-copy).
+- **Year signal expansion** sorts signals by `.start` before the loop,
+  preventing non-adjacent text from being glued into titles.
+- **Heuristic eviction guard** — `apply_invariance_signals` now checks
+  for non-heuristic overlaps *before* evicting heuristic matches,
+  preventing data loss when a codec or screen-size match occupies the
+  same span.
+- **Trailing Part regex** hoisted to `LazyLock<Regex>` (was compiled
+  per-call in episode title extraction).
+- **`is_episode_directory`** uses `strip_prefix('s')` instead of
+  `component[1..]` byte indexing for safe UTF-8 handling.
+
+### Fixed
+
+- **`CODEC_NUMBERS` shared constant** (264, 265, 128) — extracted from
+  duplicated checks in `invariance.rs` and `episodes/mod.rs`. (DRY)
+- Stale SP comment orphan removed from `anime_bonus.toml`.
+- Unused `_input` parameter removed from `apply_invariance_signals`.
+- `.unwrap()` → `.expect()` on CJK regex capture groups.
+
 ## [1.1.4] - 2026-03-20
 
 ### Added
@@ -542,6 +589,7 @@ source, audio_codec, screen_size, audio_channels, date.
 
 color_depth, streaming_service, bonus, episode_details, film.
 
+[1.1.5]: https://github.com/lijunzh/hunch/releases/tag/v1.1.5
 [1.1.4]: https://github.com/lijunzh/hunch/releases/tag/v1.1.4
 [1.1.3]: https://github.com/lijunzh/hunch/releases/tag/v1.1.3
 [1.1.2]: https://github.com/lijunzh/hunch/releases/tag/v1.1.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hunch"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hunch"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Lijun Zhu"]

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -5,7 +5,7 @@ This document tracks how closely hunch reproduces guessit's behavior, measured
 by running hunch against guessit's own test suite (1,309 test cases across 22
 YAML files).
 
-> **Last updated:** 2026-03-20 (v1.1.4-dev)
+> **Last updated:** 2026-03-20 (v1.1.5)
 
 ---
 


### PR DESCRIPTION
## Release v1.1.5

Bumps version to **1.1.5** with changelog entry.

### What's in this release

#### New Features
- **CJK episode markers** — `第N話`, `第N集`, `第N回`, `第N话` with full-width digit normalization (０-９ → 0-9)
- **Anime bonus vocabulary** — NCOP, NCED, PV, CM → `EpisodeDetails` (correctly classifies bonus content as episodes)
- **Path-based type inference** — `tv/`, `anime/`, `donghua/`, `Season N/`, `sN/` directories force `MediaType::Episode`
- **InvarianceReport** — cross-file sequential analysis identifies bare numbers as episodes and suppresses invariant years
- **Source tagging** — `Structural`, `Context`, `Heuristic` on all `MatchSpan`s; heuristic-only caps confidence at Medium

#### Bug Fixes
- `find_invariant_text` returns pre-computed byte offset (was using fragile `input.find()`)
- Year signals sorted by position before expansion
- Heuristic eviction guard checks overlaps *before* evicting (was evict-then-check)
- Trailing Part regex hoisted to `LazyLock` (was compiled per-call)
- `CODEC_NUMBERS` shared constant (DRY)
- Safe UTF-8 handling via `strip_prefix` instead of byte indexing
- `.unwrap()` → `.expect()` on regex captures
- Stale comments and unused params cleaned up

#### Tests
- **386 total** (was 370 at v1.1.4)
- 28 new integration tests for CJK, path inference, invariance, cross-feature interactions, and panic safety

### Verification
- ✅ 386/386 tests pass
- ✅ Clippy clean
- ✅ `cargo fmt` clean