### PR TITLE
fix(#61): batch siblings must include parent dir for invariance

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,9 +83,10 @@ fn main() {
             .collect();
 
         for (i, input) in inputs.iter().enumerate() {
-            // Siblings stay as bare filenames — invariance detection
-            // only needs the varying parts across sibling files.
-            let siblings: Vec<&str> = bare_filenames
+            // Siblings also include the parent dir prefix so the invariance
+            // engine sees "Paw Patrol" as invariant text across all files,
+            // rather than finding a spurious common prefix in episode titles.
+            let siblings: Vec<&str> = inputs
                 .iter()
                 .enumerate()
                 .filter(|(j, _)| *j != i)

--- a/src/pipeline/context.rs
+++ b/src/pipeline/context.rs
@@ -14,7 +14,7 @@
 use crate::matcher::span::MatchSpan;
 
 /// Separators used in media filenames for normalization.
-pub(crate) const SEPS: &[char] = &['.', ' ', '_', '-', '+'];
+pub(crate) const SEPS: &[char] = &['.', ' ', '_', '-', '+', '/', '\\'];
 
 /// Brackets to strip from gap boundaries.
 pub(crate) const TRIM_CHARS: &[char] = &[


### PR DESCRIPTION
## Follow-up to #62

The previous fix added the parent dir prefix to the **input** but left siblings as bare filenames. This caused two bugs:

### Bug 1: Invariance picks up wrong common prefix
Siblings without the parent dir prefix meant the invariance engine couldn't see `"Paw Patrol"` as invariant text. Instead it found `"Pups"` (common prefix of episode titles `"Pups Save..."` and `"Pups and..."`).

**Before:** `hunch --batch "Paw Patrol/" → title: "Pups"` ❌
**After:** `hunch --batch "Paw Patrol/" → title: "Paw Patrol"` ✅

### Bug 2: Trailing `/` in title
Path separators (`/`, `\`) weren't in the `SEPS` constant used by gap normalization, so the invariant text included a trailing slash: `"Paw Patrol/"`.

**Fix:** Added `/` and `\` to `SEPS` in `context.rs`.

### Changes
| File | Change |
|------|--------|
| `src/main.rs` | Siblings use `inputs` (with parent dir) instead of `bare_filenames` |
| `src/pipeline/context.rs` | Add path separators to `SEPS` |

### Verification
```
Paw Patrol/S01E10 - Pups Save...mkv → title: "Paw Patrol" ✅
西游记/01.mp4 → title: "西游记" ✅
[DBD-Raws][4K_HDR][ready.player.one]... → title: "ready player one" ✅
All 388 tests pass, fmt + clippy clean ✅
```

Refs: #61