### PR TITLE
refactor(#64): consolidate SEPS + expand is_generic_dir

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,14 @@
 /// (x264, x265, AES-128) and should not be treated as years or episodes.
 pub(crate) const CODEC_NUMBERS: &[u32] = &[264, 265, 128];
 
+/// Common separators used in media filenames.
+///
+/// These characters are treated as word boundaries when normalizing
+/// filenames for title extraction and gap analysis. Path separators
+/// (`/`, `\`) are intentionally excluded — they are only relevant
+/// in the cross-file context module where full paths are analyzed.
+pub(crate) const FILENAME_SEPS: &[char] = &['.', ' ', '_', '-', '+'];
+
 pub mod matcher;
 pub mod properties;
 pub mod tokenizer;

--- a/src/pipeline/context.rs
+++ b/src/pipeline/context.rs
@@ -13,8 +13,15 @@
 
 use crate::matcher::span::MatchSpan;
 
-/// Separators used in media filenames for normalization.
-pub(crate) const SEPS: &[char] = &['.', ' ', '_', '-', '+', '/', '\\'];
+/// Separators for cross-file gap normalization.
+///
+/// Extends [`crate::FILENAME_SEPS`] with path separators (`/`, `\`) because
+/// batch mode constructs inputs like `"ParentDir/filename.mkv"` and we
+/// need to normalize the path separator into a space boundary.
+pub(crate) const SEPS: &[char] = &[
+    '.', ' ', '_', '-', '+', // same as FILENAME_SEPS
+    '/', '\\', // path separators (batch mode)
+];
 
 /// Brackets to strip from gap boundaries.
 pub(crate) const TRIM_CHARS: &[char] = &[

--- a/src/properties/title/clean.rs
+++ b/src/properties/title/clean.rs
@@ -258,10 +258,18 @@ pub(super) fn pick_better_casing<'a>(a: &'a str, b: &'a str) -> &'a str {
 }
 
 /// Check if a directory name is generic (should be skipped for title).
+///
+/// Generic directories are structural (e.g., "Season 1", "Extras") or
+/// organizational (e.g., "Movies", "Downloads"). When walking parent
+/// directories for title fallback, these are skipped so the real title
+/// directory (e.g., "Transformers 1984") is found.
 pub(super) fn is_generic_dir(name: &str) -> bool {
     let lower = name.to_lowercase();
-    matches!(
+
+    // Exact matches (case-insensitive).
+    if matches!(
         lower.as_str(),
+        // Library root / organizational
         "movies"
             | "movie"
             | "films"
@@ -273,6 +281,11 @@ pub(super) fn is_generic_dir(name: &str) -> bool {
             | "media"
             | "video"
             | "videos"
+            | "anime"
+            | "donghua"
+            | "kids"
+            | "cartoons"
+            // Download / system
             | "downloads"
             | "download"
             | "completed"
@@ -285,10 +298,60 @@ pub(super) fn is_generic_dir(name: &str) -> bool {
             | "home"
             | "tmp"
             | "temp"
-    ) || lower.starts_with("season")
+            // Bonus / extras
+            | "extras"
+            | "extra"
+            | "specials"
+            | "special"
+            | "bonus"
+            | "featurettes"
+            | "featurette"
+            | "behind the scenes"
+            | "deleted scenes"
+            | "interviews"
+            | "interview"
+            | "trailers"
+            | "trailer"
+            | "samples"
+            | "sample"
+            // Subtitles / audio
+            | "subs"
+            | "subtitles"
+            | "subtitle"
+            | "ost"
+            | "soundtrack"
+            | "soundtracks"
+    ) {
+        return true;
+    }
+
+    // Prefix matches (e.g., "Season 1", "Disc 2", "CD1").
+    if lower.starts_with("season")
         || lower.starts_with("saison")
         || lower.starts_with("temporada")
         || lower.starts_with("stagione")
+        || lower.starts_with("disc")
+        || lower.starts_with("disk")
+        || lower.starts_with("dvd")
+    {
+        return true;
+    }
+
+    // CD1, CD2, etc.
+    if lower.starts_with("cd") && lower[2..].chars().all(|c| c.is_ascii_digit()) && lower.len() <= 4
+    {
+        return true;
+    }
+
+    // Quality-as-dir: "1080p", "720p", "2160p", "4K", "4k"
+    if lower.ends_with('p') && lower[..lower.len() - 1].chars().all(|c| c.is_ascii_digit()) {
+        return true;
+    }
+    if lower == "4k" {
+        return true;
+    }
+
+    false
 }
 
 #[cfg(test)]
@@ -313,5 +376,71 @@ mod tests {
     #[test]
     fn test_strip_paren_year() {
         assert_eq!(clean_title("Movie Name (2005)"), "Movie Name");
+    }
+
+    // ── is_generic_dir ──────────────────────────────────────────────
+
+    #[test]
+    fn generic_dir_originals() {
+        // Original entries still work.
+        assert!(is_generic_dir("Movies"));
+        assert!(is_generic_dir("tv"));
+        assert!(is_generic_dir("Season 1"));
+        assert!(is_generic_dir("Saison 03"));
+    }
+
+    #[test]
+    fn generic_dir_extras_and_bonus() {
+        assert!(is_generic_dir("Extras"));
+        assert!(is_generic_dir("Specials"));
+        assert!(is_generic_dir("Bonus"));
+        assert!(is_generic_dir("Featurettes"));
+        assert!(is_generic_dir("Behind The Scenes"));
+        assert!(is_generic_dir("Deleted Scenes"));
+        assert!(is_generic_dir("Trailers"));
+        assert!(is_generic_dir("Sample"));
+    }
+
+    #[test]
+    fn generic_dir_disc_and_cd() {
+        assert!(is_generic_dir("Disc 1"));
+        assert!(is_generic_dir("Disc2"));
+        assert!(is_generic_dir("Disk 3"));
+        assert!(is_generic_dir("DVD1"));
+        assert!(is_generic_dir("CD1"));
+        assert!(is_generic_dir("CD2"));
+        assert!(!is_generic_dir("CD123")); // too long for CD pattern
+    }
+
+    #[test]
+    fn generic_dir_quality() {
+        assert!(is_generic_dir("1080p"));
+        assert!(is_generic_dir("720p"));
+        assert!(is_generic_dir("2160p"));
+        assert!(is_generic_dir("4K"));
+    }
+
+    #[test]
+    fn generic_dir_subtitles_and_audio() {
+        assert!(is_generic_dir("Subs"));
+        assert!(is_generic_dir("Subtitles"));
+        assert!(is_generic_dir("OST"));
+        assert!(is_generic_dir("Soundtrack"));
+    }
+
+    #[test]
+    fn generic_dir_structural() {
+        assert!(is_generic_dir("Anime"));
+        assert!(is_generic_dir("Kids"));
+        assert!(is_generic_dir("Cartoons"));
+    }
+
+    #[test]
+    fn non_generic_dirs() {
+        // Real titles should NOT be generic.
+        assert!(!is_generic_dir("Paw Patrol"));
+        assert!(!is_generic_dir("Transformers 1984"));
+        assert!(!is_generic_dir("Breaking Bad"));
+        assert!(!is_generic_dir("十二国記"));
     }
 }

--- a/src/properties/title/mod.rs
+++ b/src/properties/title/mod.rs
@@ -11,6 +11,7 @@ pub use secondary::{
     extract_alternative_titles, extract_episode_title, extract_film_title, infer_media_type,
 };
 
+use crate::FILENAME_SEPS as SEPS;
 use crate::matcher::span::{MatchSpan, Property};
 use crate::tokenizer::TokenStream;
 use crate::zone_map::ZoneMap;
@@ -18,9 +19,6 @@ use clean::{
     clean_title, is_abbreviated, is_generic_dir, is_likely_extension, pick_better_casing,
     strip_extension,
 };
-
-/// Separators used in media filenames.
-const SEPS: &[char] = &['.', ' ', '_', '-', '+'];
 
 /// Characters we strip from title boundaries.
 const BRACKETS: &[char] = &['(', ')', '[', ']', '{', '}'];


### PR DESCRIPTION
## Tasks 1 & 2 from #64

### Task 1: Consolidate SEPS constants (DRY)

Two `SEPS` constants existed with overlapping values and the same name — a bug magnet.

| Location | Before | After |
|----------|--------|-------|
| `lib.rs` | *(none)* | `FILENAME_SEPS` — shared base constant |
| `title/mod.rs` | `SEPS = [. _ - +]` (private) | `use FILENAME_SEPS as SEPS` |
| `context.rs` | `SEPS = [. _ - + / \]` | Same, with doc explaining the relationship |

The title module intentionally excludes path separators (it cleans individual segments). The context module includes them (it normalizes full paths in batch mode). Both now have doc comments explaining *why* they differ.

### Task 2: Expand `is_generic_dir`

Added ~30 new entries across 6 categories. These directories are skipped when walking parent dirs for title fallback.

| Category | New entries |
|----------|-------------|
| Bonus/extras | extras, specials, bonus, featurettes, behind the scenes, deleted scenes, interviews, trailers, sample |
| Subtitles/audio | subs, subtitles, ost, soundtrack |
| Disc/CD | disc\*, disk\*, dvd\*, cd1–cd99 |
| Quality-as-dir | 1080p, 720p, 2160p, 4k |
| Structural | anime, donghua, kids, cartoons |
| **Patterns** | `cd` + digits (≤4 chars), `\d+p`, season prefixes |

8 new unit tests cover all categories + verify real titles are not flagged.

### Verification

```
Transformers 1984/Season 1/01.mkv → title: "Transformers" ✅ (skips "Season 1")
Breaking Bad/Extras/PV.mkv → title: "Breaking Bad" ✅ (skips "Extras")  
Paw Patrol batch mode → unchanged ✅
All tests pass, fmt + clippy clean ✅
```

Refs: #64