### PR TITLE
feat(#70): warn when flat --batch skips subdirectories with media files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,12 @@ fn run_batch(pipeline: &Pipeline, batch_dir: &Path, recursive: bool, json: bool)
     } else {
         list_media_files(batch_dir)
     };
+
+    // In flat mode, warn if subdirectories contain media files being skipped.
+    if !recursive {
+        warn_if_subdirs_have_media(batch_dir);
+    }
+
     if files.is_empty() {
         eprintln!("No media files found in {}", batch_dir.display());
         std::process::exit(1);
@@ -299,4 +305,54 @@ fn is_media_extension(path: &Path) -> bool {
                 .iter()
                 .any(|me| me.eq_ignore_ascii_case(ext))
         })
+}
+
+/// When running flat `--batch` (no `-r`), check if subdirectories contain
+/// media files. If so, print a hint suggesting `-r` for better results.
+///
+/// This catches the #1 UX footgun: flat batch silently loses path context
+/// from ancestor directories (tv/, Anime/, Season 1/), producing plausible
+/// but wrong results (e.g., bonus content classified as movies).
+fn warn_if_subdirs_have_media(batch_dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(batch_dir) else {
+        return;
+    };
+    let subdirs_with_media: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .filter(|e| dir_contains_media(&e.path()))
+        .filter_map(|e| e.file_name().to_str().map(String::from))
+        .collect();
+
+    if subdirs_with_media.is_empty() {
+        return;
+    }
+
+    let n = subdirs_with_media.len();
+    let dir_display = batch_dir.display();
+    eprintln!(
+        "hint: found media files in {n} subdirector{} being skipped. \
+         Use -r to include them\n      \
+         with full path context (improves type detection and title extraction).\n      \
+         Example: hunch --batch {dir_display} -r -j",
+        if n == 1 { "y" } else { "ies" },
+    );
+}
+
+/// Check if a directory (recursively) contains at least one media file.
+/// Short-circuits on the first match for performance.
+fn dir_contains_media(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    let mut subdirs = Vec::new();
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.is_file() && is_media_extension(&path) {
+            return true;
+        } else if path.is_dir() {
+            subdirs.push(path);
+        }
+    }
+    subdirs.iter().any(|d| dir_contains_media(d))
 }


### PR DESCRIPTION
## PR B: Smart flat-batch warning (#70 item 5)

When running `--batch <dir>` without `-r`, hunch now checks if subdirectories contain media files being skipped. If so, prints a hint to stderr:

```
hint: found media files in 2 subdirectories being skipped. Use -r to include them
      with full path context (improves type detection and title extraction).
      Example: hunch --batch /tmp/audit-test/tv -r -j
```

### Why this instead of flipping the default (#70 item 1)

The owner correctly rejected making `--batch` recursive by default (Unix convention: `ls`/`grep`/`find` all default to flat). But the problem with flat batch is that it **silently degrades quality** rather than obviously failing:

- `grep` without `-r`: returns *nothing* from subdirs (obviously wrong, user fixes it)
- `hunch --batch` without `-r`: returns *plausible-looking wrong results* (user doesn't know to fix it)

The warning catches this footgun every time without changing semantics.

### Implementation

- `warn_if_subdirs_have_media()`: scans immediate subdirs for media files, prints hint if found
- `dir_contains_media()`: recursive check that short-circuits on first match (fast)
- Warning fires before the "no files found" exit, so users see both messages
- Only runs in flat mode (no `-r`)

### Test cases verified

| Scenario | Warning? | Correct? |
|----------|----------|----------|
| Flat on `tv/` (subdirs have media) | Yes | Yes |
| Flat on leaf dir (no subdirs) | No | Yes |
| Recursive mode | No | Yes |
| Flat on mid-level dir | Yes | Yes |

407 tests pass, clippy clean, docs clean.

Refs: #70
