### PR TITLE
docs: scope D7 to reality, acknowledge D9 matcher classes, fix stale ref

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -146,12 +146,19 @@ When multiple valid interpretations exist and neither the engine nor
 available context can distinguish them, hunch is transparent about
 the uncertainty rather than guessing.
 
-Mechanism:
-- **Confidence** drops when conflicting signals exist.
-- **Conflicts** are surfaced in the output so callers can inspect
-  and resolve them.
-- The CLI prints **actionable hints** suggesting how the user can
-  provide structural disambiguation.
+Current mechanism:
+- **Confidence** drops when conflicting signals exist
+  (High → Medium → Low).
+- **Trace logging** shows which matches were dropped and why
+  (enable with `RUST_LOG=hunch=trace`).
+- The CLI prints a **generic hint** when confidence is Low,
+  suggesting `--context` for cross-file disambiguation.
+
+Future (not yet implemented):
+- A `conflicts` field on `HunchResult` carrying the losing
+  alternatives and pattern-specific disambiguation hints.
+- The CLI printing **actionable hints** per ambiguity pattern
+  (e.g., "organize into `movie/` or `tv/`").
 
 **Example:** `Detective.Conan.Movie.10.mkv` — "Movie" followed by
 a number is genuinely ambiguous. It could be the 10th movie in a
@@ -200,11 +207,25 @@ clever Rust code. We'd rather cover 90% simply than 100% opaquely.
 
 ### D9: Self-contained property matchers (P1)
 
-Each property matcher is one file (or small module), testable in
-isolation. You don't need to understand the pipeline to understand
-how `video_codec` or `episodes` matching works. Adding a new
-property means adding a TOML file and registering it — not
-understanding a dependency graph.
+Property matchers come in two classes:
+
+**Vocabulary matchers** are fully self-contained: one file, one
+signature (`fn find_matches(input: &str) -> Vec<MatchSpan>`),
+testable in isolation. You don't need to understand the pipeline
+to understand how `video_codec` or `year` matching works. Adding
+a new vocabulary property means adding a TOML file and registering
+it — not understanding a dependency graph.
+
+Examples: video_codec (TOML), audio_codec (TOML), year, crc32,
+uuid, date, language, bit_rate.
+
+**Positional matchers** inherently depend on resolved match
+positions from Pass 1. Title extraction *must* see what other
+properties have been claimed; release_group *must* know which
+spans are already taken. Their self-containment is at the module
+level (one directory, own tests), not the function level.
+
+Examples: title, release_group, episode_title, alternative_title.
 
 ---
 

--- a/src/pipeline/invariance.rs
+++ b/src/pipeline/invariance.rs
@@ -5,8 +5,8 @@
 //! siblings are title content, numbers that vary are metadata (episodes,
 //! years). Sequential variant numbers provide episode evidence.
 //!
-//! See `InvarianceReport` for the unified result, and docs/plan-52-53.md
-//! for the full design.
+//! See `InvarianceReport` for the unified result, and docs/design.md
+//! (Cross-file context) for the architectural rationale.
 
 use std::sync::LazyLock;
 


### PR DESCRIPTION
Addresses review items #1, #3, #7 from #82.

**D7 scope-down:** The design doc promised conflict surfacing and actionable CLI hints that don't exist yet. Rewritten to describe what's actually implemented (confidence enum + trace logging + generic hint). Full conflict API tracked in #83.

**D9 vocabulary vs positional:** Acknowledged the two matcher classes — vocabulary matchers (self-contained, testable in isolation) and positional matchers (title, release_group — inherently pipeline-coupled).

**Stale reference:** Fixed `docs/plan-52-53.md` → `docs/design.md` in invariance.rs.

Refs: #82, #83