### PR TITLE
refactor: named priority constants, shared filename_start, legacy matcher categorization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,12 +119,27 @@ pub(crate) const CODEC_NUMBERS: &[u32] = &[264, 265, 128];
 pub(crate) const FILENAME_SEPS: &[char] = &['.', ' ', '_', '-', '+'];
 
 pub mod matcher;
+pub(crate) mod priority;
 pub mod properties;
 pub mod tokenizer;
 pub mod zone_map;
 
 mod hunch_result;
 mod pipeline;
+
+/// Byte offset where the filename starts in a path string.
+///
+/// Returns the position after the last `/` or `\`, or 0 if no
+/// path separator is present. This is the single source of truth
+/// for legacy matchers that need to distinguish filename tokens
+/// from directory path components.
+///
+/// Prefer `TokenStream.filename_start` when a token stream is
+/// available. This function exists for legacy matchers that only
+/// receive the raw input string.
+pub(crate) fn filename_start(input: &str) -> usize {
+    input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0)
+}
 
 pub use hunch_result::{Confidence, HunchResult, MediaType};
 pub use matcher::span::Property;

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -23,6 +23,8 @@ use matching::MatchContext;
 use log::{debug, trace};
 use std::sync::LazyLock;
 
+use crate::priority;
+
 // ── TOML rule sets (embedded at compile time) ──────────────────────────────
 
 static VIDEO_CODEC_RULES: LazyLock<RuleSet> =
@@ -92,10 +94,6 @@ enum SegmentScope {
     AllSegments,
 }
 
-/// Priority penalty applied to matches from directory segments.
-/// Ensures filename matches always win over directory matches in conflict resolution.
-const DIR_PRIORITY_PENALTY: i32 = -5;
-
 /// The two-pass parsing pipeline.
 ///
 /// Orchestrates the full parsing flow: tokenization → zone mapping
@@ -132,43 +130,43 @@ impl Pipeline {
             (
                 &VIDEO_CODEC_RULES,
                 Property::VideoCodec,
-                0,
+                priority::DEFAULT,
                 SegmentScope::AllSegments,
             ),
             (
                 &COLOR_DEPTH_RULES,
                 Property::ColorDepth,
-                0,
+                priority::DEFAULT,
                 SegmentScope::AllSegments,
             ),
             (
                 &AUDIO_CODEC_RULES,
                 Property::AudioCodec,
-                0,
+                priority::DEFAULT,
                 SegmentScope::AllSegments,
             ),
             (
                 &AUDIO_PROFILE_RULES,
                 Property::AudioProfile,
-                1,
+                priority::VOCABULARY,
                 SegmentScope::AllSegments,
             ),
             (
                 &AUDIO_CHANNELS_RULES,
                 Property::AudioChannels,
-                -1,
+                priority::HEURISTIC,
                 SegmentScope::AllSegments,
             ),
             (
                 &FRAME_RATE_RULES,
                 Property::FrameRate,
-                0,
+                priority::DEFAULT,
                 SegmentScope::AllSegments,
             ),
             (
                 &SCREEN_SIZE_RULES,
                 Property::ScreenSize,
-                0,
+                priority::DEFAULT,
                 SegmentScope::AllSegments,
             ),
             // Tech properties: ambiguous tokens, filename only.
@@ -176,64 +174,69 @@ impl Pipeline {
             (
                 &STREAMING_SERVICE_RULES,
                 Property::StreamingService,
-                1,
+                priority::VOCABULARY,
                 SegmentScope::FilenameOnly,
             ),
             (
                 &VIDEO_PROFILE_RULES,
                 Property::VideoProfile,
-                -2,
+                priority::POSITIONAL,
                 SegmentScope::FilenameOnly,
             ),
             (
                 &EPISODE_DETAILS_RULES,
                 Property::EpisodeDetails,
-                -1,
+                priority::HEURISTIC,
                 SegmentScope::FilenameOnly,
             ),
             (
                 &ANIME_BONUS_RULES,
                 Property::EpisodeDetails,
-                -1,
+                priority::HEURISTIC,
                 SegmentScope::FilenameOnly,
             ),
             (
                 &EPISODE_FORMAT_RULES,
                 Property::EpisodeFormat,
-                -1,
+                priority::HEURISTIC,
                 SegmentScope::FilenameOnly,
             ),
             (
                 &EDITION_RULES,
                 Property::Edition,
-                0,
+                priority::DEFAULT,
                 SegmentScope::AllSegments,
             ),
             // Other: AllSegments with dir priority penalty.
             // Per-directory zone maps filter false positives in title zones.
-            (&OTHER_RULES, Property::Other, 0, SegmentScope::AllSegments),
+            (
+                &OTHER_RULES,
+                Property::Other,
+                priority::DEFAULT,
+                SegmentScope::AllSegments,
+            ),
             (
                 &OTHER_POSITIONAL_RULES,
                 Property::Other,
-                -2,
+                priority::POSITIONAL,
                 SegmentScope::FilenameOnly,
             ),
             (
                 &VIDEO_API_RULES,
                 Property::VideoApi,
-                0,
+                priority::DEFAULT,
                 SegmentScope::FilenameOnly,
             ),
             (
                 &SOURCE_RULES,
                 Property::Source,
-                0,
+                priority::DEFAULT,
                 SegmentScope::AllSegments,
             ),
             (
                 &CONTAINER_RULES,
                 Property::Container,
-                5,
+                priority::STRUCTURAL,
                 SegmentScope::FilenameOnly,
             ),
             // Contextual properties: match all segments (dirs carry real metadata)
@@ -248,25 +251,37 @@ impl Pipeline {
             (
                 &COUNTRY_RULES,
                 Property::Country,
-                -2,
+                priority::POSITIONAL,
                 SegmentScope::FilenameOnly,
             ),
             (
                 &LANGUAGE_RULES,
                 Property::Language,
-                -1,
+                priority::HEURISTIC,
                 SegmentScope::AllSegments,
             ),
             (
                 &SUBTITLE_LANGUAGE_RULES,
                 Property::SubtitleLanguage,
-                -1,
+                priority::HEURISTIC,
                 SegmentScope::FilenameOnly,
             ),
         ];
 
-        // Legacy matchers — algorithmic patterns not expressible in TOML.
-        // Note: source is now fully TOML (source.toml with side_effects).
+        // Legacy matchers — algorithmic patterns that need Rust.
+        //
+        // **Algorithmic** (genuinely need Rust — branching, state, or position):
+        //   episodes, date, language, subtitle_language, episode_count,
+        //   release_group (Pass 2), part, website, aspect_ratio, bit_rate
+        //
+        // **Migration candidates** (could be expressed as TOML rules):
+        //   crc32     — single regex, bracket context expressible via zone_scope
+        //   uuid      — two regex patterns, no boundary logic beyond TOML's
+        //   version   — two regexes + CharClass boundaries (needs D8 extension)
+        //   size      — regex + unit parse (needs value normalization in TOML)
+        //   bonus     — regex + boundary check (borderline)
+        //
+        // NOTE: source is now fully TOML (source.toml with side_effects).
         // audio_profile is handled entirely by audio_profile.toml.
         let legacy_matchers: Vec<LegacyMatcherFn> = vec![
             aspect_ratio::find_matches,
@@ -673,7 +688,7 @@ impl Pipeline {
 
                 // Directory matches get a priority penalty so filename wins in conflicts.
                 let effective_priority = if is_dir {
-                    *priority + DIR_PRIORITY_PENALTY
+                    *priority + priority::DIR_PENALTY
                 } else {
                     *priority
                 };
@@ -717,7 +732,7 @@ impl Pipeline {
             matches.push(
                 MatchSpan::new(ext_start, input.len(), Property::Container, ext.as_str())
                     .as_extension()
-                    .with_priority(10),
+                    .with_priority(priority::EXTENSION),
             );
         }
 

--- a/src/pipeline/proper_count.rs
+++ b/src/pipeline/proper_count.rs
@@ -13,7 +13,7 @@ static REPACK_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
 });
 
 pub fn compute_proper_count(input: &str, matches: &[MatchSpan]) -> u32 {
-    let fn_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
+    let fn_start = crate::filename_start(input);
     let mut has_real = false;
     let mut proper_count_raw: u32 = 0;
     let mut repack_count: u32 = 0;

--- a/src/pipeline/zone_rules.rs
+++ b/src/pipeline/zone_rules.rs
@@ -36,7 +36,7 @@ pub fn apply_zone_rules(
     token_stream: &TokenStream,
     matches: &mut Vec<MatchSpan>,
 ) {
-    let fn_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
+    let fn_start = crate::filename_start(input);
     let initial_count = matches.len();
 
     // ── Rule 1: Language disambiguation (context-aware) ────────────────

--- a/src/priority.rs
+++ b/src/priority.rs
@@ -1,0 +1,65 @@
+//! Named priority constants for match conflict resolution.
+//!
+//! Higher values win when two matches of the same property overlap.
+//! These constants replace magic integer literals throughout the
+//! codebase to make the priority system self-documenting (P1).
+//!
+//! ## Tier overview
+//!
+//! ```text
+//! EXTENSION   (10)  File extension → container (always wins)
+//! STRUCTURAL   (5)  Unambiguous structural markers (SxxExx)
+//! PATTERN      (3)  Compound patterns (NxN, Cap.NNN, CJK brackets)
+//! KEYWORD      (2)  Keyword-driven matches ("Episode 1", full dates, CRC32)
+//! VOCABULARY   (1)  Word-based lookups ("Season 1", Part, size, anime ep)
+//! DEFAULT      (0)  Standard TOML exact/pattern matches
+//! HEURISTIC   (-1)  Single-file guesses (bare year, bare episode)
+//! POSITIONAL  (-2)  Position-dependent fallbacks (release_group, country)
+//! DIR_PENALTY (-5)  Applied to directory segment matches
+//! ```
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use crate::priority;
+//!
+//! MatchSpan::new(start, end, Property::Episode, value)
+//!     .with_priority(priority::STRUCTURAL);
+//! ```
+//!
+//! For fine-grained ordering within a tier, use arithmetic:
+//! `priority::STRUCTURAL - 1` for slightly-less-confident structural.
+
+/// File extension → container. Always wins over in-filename matches.
+pub const EXTENSION: i32 = 10;
+
+/// Unambiguous structural markers: SxxExx, parenthesized year, S01E01-S01E21.
+pub const STRUCTURAL: i32 = 5;
+
+/// Compound patterns: NxN compact notation, Cap.NNN, CJK bracket episodes.
+pub const PATTERN: i32 = 3;
+
+/// Keyword-driven matches: "Episode 1", full dates (YYYY-MM-DD), CRC32,
+/// UUID, subtitle language with explicit markers ("Sub French").
+pub const KEYWORD: i32 = 2;
+
+/// Word-based lookups: "Season 1", "Part 2", size, anime-style episodes,
+/// versioned episodes, bit_rate.
+pub const VOCABULARY: i32 = 1;
+
+/// Standard TOML exact/pattern matches, bonus, language codes, leading
+/// episodes, digit decomposition. The baseline.
+pub const DEFAULT: i32 = 0;
+
+/// Single-file heuristic guesses: bare year numbers, bare episodes,
+/// primary release_group candidates, aspect ratio.
+pub const HEURISTIC: i32 = -1;
+
+/// Position-dependent fallbacks: release_group secondary candidates,
+/// country codes, video_profile, other_positional, episode_details.
+pub const POSITIONAL: i32 = -2;
+
+/// Priority penalty applied to matches from directory path segments.
+/// Added to a rule's base priority so filename matches always win
+/// over directory matches for the same property.
+pub const DIR_PENALTY: i32 = -5;

--- a/src/properties/aspect_ratio.rs
+++ b/src/properties/aspect_ratio.rs
@@ -27,7 +27,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                 let full = cap.get(0).unwrap();
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::AspectRatio, formatted)
-                        .with_priority(-1),
+                        .with_priority(crate::priority::HEURISTIC),
                 );
             }
         }

--- a/src/properties/bit_rate.rs
+++ b/src/properties/bit_rate.rs
@@ -64,8 +64,10 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
         // Output without spaces: "320Kbps", "19.1Mbps".
         let value = format!("{num}{normalized_unit}");
 
-        matches
-            .push(MatchSpan::new(abs_start, abs_end, Property::BitRate, &value).with_priority(1));
+        matches.push(
+            MatchSpan::new(abs_start, abs_end, Property::BitRate, &value)
+                .with_priority(crate::priority::VOCABULARY),
+        );
 
         // Advance past this match.
         search_start = abs_end;

--- a/src/properties/bonus.rs
+++ b/src/properties/bonus.rs
@@ -38,7 +38,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
             if n > 0 {
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Bonus, n.to_string())
-                        .with_priority(0),
+                        .with_priority(crate::priority::DEFAULT),
                 );
             }
         }
@@ -52,7 +52,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
         if !cleaned.is_empty() {
             matches.push(
                 MatchSpan::new(title.start(), title.end(), Property::BonusTitle, cleaned)
-                    .with_priority(0),
+                    .with_priority(crate::priority::DEFAULT),
             );
         }
     }

--- a/src/properties/crc32.rs
+++ b/src/properties/crc32.rs
@@ -23,7 +23,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                     Property::Crc,
                     crc.as_str().to_uppercase(),
                 )
-                .with_priority(2),
+                .with_priority(crate::priority::KEYWORD),
             );
         }
     }

--- a/src/properties/date.rs
+++ b/src/properties/date.rs
@@ -89,7 +89,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                 Property::Date,
                 format!("{}-{}-{}", year.as_str(), month.as_str(), day.as_str()),
             )
-            .with_priority(2),
+            .with_priority(crate::priority::KEYWORD),
         );
     }
 
@@ -111,7 +111,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                 Property::Date,
                 format!("{}-{}-{}", year.as_str(), month.as_str(), day.as_str()),
             )
-            .with_priority(2),
+            .with_priority(crate::priority::KEYWORD),
         );
     }
 
@@ -133,7 +133,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                 Property::Date,
                 format!("{}-{}-{}", year.as_str(), month.as_str(), day.as_str()),
             )
-            .with_priority(2),
+            .with_priority(crate::priority::KEYWORD),
         );
     }
 
@@ -155,7 +155,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                 Property::Date,
                 format!("{}-{}-{}", year.as_str(), month.as_str(), day.as_str()),
             )
-            .with_priority(2),
+            .with_priority(crate::priority::KEYWORD),
         );
     }
 
@@ -177,7 +177,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                 Property::Date,
                 format!("{}-{}-{}", year.as_str(), month.as_str(), day.as_str()),
             )
-            .with_priority(1),
+            .with_priority(crate::priority::VOCABULARY),
         );
     }
 
@@ -205,7 +205,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                     Property::Date,
                     format!("{year_full}-{m:02}-{d:02}"),
                 )
-                .with_priority(0),
+                .with_priority(crate::priority::DEFAULT),
             );
         }
     }
@@ -239,7 +239,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                         Property::Date,
                         format!("{}-{month_num:02}-{day:02}", year_s),
                     )
-                    .with_priority(1),
+                    .with_priority(crate::priority::VOCABULARY),
                 );
             }
         }

--- a/src/properties/episodes/mod.rs
+++ b/src/properties/episodes/mod.rs
@@ -218,8 +218,10 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
     for cap in WEEK.captures_iter(input) {
         let full = cap.get(0).expect("group 0 always present");
         let week = parse_num(&cap, "week");
-        matches
-            .push(MatchSpan::new(full.start(), full.end(), Property::Week, week).with_priority(1));
+        matches.push(
+            MatchSpan::new(full.start(), full.end(), Property::Week, week)
+                .with_priority(crate::priority::VOCABULARY),
+        );
     }
 
     matches
@@ -239,7 +241,7 @@ fn try_sxxexx_family(input: &str, matches: &mut Vec<MatchSpan>) {
         if s1 == s2 && e2 >= e1 {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::Season, s1.to_string())
-                    .with_priority(5),
+                    .with_priority(crate::priority::STRUCTURAL),
             );
             matches.extend(episode_range(e1, e2, full.start(), full.end(), 5));
         }
@@ -268,7 +270,7 @@ fn try_sxxexx_family(input: &str, matches: &mut Vec<MatchSpan>) {
                 Property::Season,
                 season.to_string(),
             )
-            .with_priority(-1),
+            .with_priority(crate::priority::HEURISTIC),
         );
 
         let ep_rest = cap.name("ep_rest").map(|m| m.as_str()).unwrap_or("");
@@ -280,13 +282,13 @@ fn try_sxxexx_family(input: &str, matches: &mut Vec<MatchSpan>) {
                     Property::Episode,
                     ep_start.to_string(),
                 )
-                .with_priority(5),
+                .with_priority(crate::priority::STRUCTURAL),
             );
         } else {
             for ep in &parse_multi_episodes(ep_start, ep_rest) {
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Episode, ep.to_string())
-                        .with_priority(5),
+                        .with_priority(crate::priority::STRUCTURAL),
                 );
             }
         }
@@ -294,15 +296,25 @@ fn try_sxxexx_family(input: &str, matches: &mut Vec<MatchSpan>) {
 
     // S03-E01 (dash separated).
     if matches.is_empty() {
-        match_season_episode(&SXX_DASH_EXX, input, 4, matches);
+        match_season_episode(
+            &SXX_DASH_EXX,
+            input,
+            crate::priority::STRUCTURAL - 1,
+            matches,
+        );
     }
     // S06xE01.
     if matches.is_empty() {
-        match_season_episode(&SXX_X_EXX, input, 4, matches);
+        match_season_episode(&SXX_X_EXX, input, crate::priority::STRUCTURAL - 1, matches);
     }
     // S03-X01 for bonus.
     if matches.is_empty() {
-        match_season_episode(&SXX_DASH_XXX, input, 4, matches);
+        match_season_episode(
+            &SXX_DASH_XXX,
+            input,
+            crate::priority::STRUCTURAL - 1,
+            matches,
+        );
     }
 }
 
@@ -332,7 +344,7 @@ fn try_nxn(input: &str, matches: &mut Vec<MatchSpan>) {
                 Property::Season,
                 season.to_string(),
             )
-            .with_priority(3),
+            .with_priority(crate::priority::PATTERN),
         );
 
         let ep_end = cap.name("ep2").and_then(|m| m.as_str().parse::<u32>().ok());
@@ -348,11 +360,11 @@ fn try_nxn(input: &str, matches: &mut Vec<MatchSpan>) {
                         Property::Episode,
                         ep_start.to_string(),
                     )
-                    .with_priority(3),
+                    .with_priority(crate::priority::PATTERN),
                 );
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Episode, end.to_string())
-                        .with_priority(3),
+                        .with_priority(crate::priority::PATTERN),
                 );
             }
             None => {
@@ -363,7 +375,7 @@ fn try_nxn(input: &str, matches: &mut Vec<MatchSpan>) {
                         Property::Episode,
                         ep_start.to_string(),
                     )
-                    .with_priority(3),
+                    .with_priority(crate::priority::PATTERN),
                 );
             }
         }
@@ -392,7 +404,7 @@ fn try_season_patterns(input: &str, matches: &mut Vec<MatchSpan>) {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::Season, season)
                     .as_path_based()
-                    .with_priority(-2),
+                    .with_priority(crate::priority::POSITIONAL),
             );
         }
     }
@@ -415,7 +427,8 @@ fn try_season_patterns(input: &str, matches: &mut Vec<MatchSpan>) {
             }
             let season = parse_num(&cap, "season");
             matches.push(
-                MatchSpan::new(full.start(), full.end(), Property::Season, season).with_priority(1),
+                MatchSpan::new(full.start(), full.end(), Property::Season, season)
+                    .with_priority(crate::priority::VOCABULARY),
             );
         }
     }
@@ -431,7 +444,7 @@ fn try_s_prefix_ranges(input: &str, matches: &mut Vec<MatchSpan>) {
         for s in s1..=s2 {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::Season, s.to_string())
-                    .with_priority(1),
+                    .with_priority(crate::priority::VOCABULARY),
             );
         }
         return;
@@ -445,7 +458,7 @@ fn try_s_prefix_ranges(input: &str, matches: &mut Vec<MatchSpan>) {
         for s in s1..=s2 {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::Season, s.to_string())
-                    .with_priority(1),
+                    .with_priority(crate::priority::VOCABULARY),
             );
         }
         return;
@@ -462,7 +475,7 @@ fn try_s_prefix_ranges(input: &str, matches: &mut Vec<MatchSpan>) {
             if let Ok(s) = num_str.parse::<u32>() {
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Season, s.to_string())
-                        .with_priority(1),
+                        .with_priority(crate::priority::VOCABULARY),
                 );
             }
         }
@@ -481,7 +494,7 @@ fn try_s_prefix_ranges(input: &str, matches: &mut Vec<MatchSpan>) {
         for s in &nums {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::Season, s.to_string())
-                    .with_priority(1),
+                    .with_priority(crate::priority::VOCABULARY),
             );
         }
     }
@@ -498,7 +511,7 @@ fn try_season_words(input: &str, matches: &mut Vec<MatchSpan>) {
             for s in s1..=s2 {
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Season, s.to_string())
-                        .with_priority(1),
+                        .with_priority(crate::priority::VOCABULARY),
                 );
             }
             return;
@@ -519,7 +532,7 @@ fn try_season_words(input: &str, matches: &mut Vec<MatchSpan>) {
         for s in &nums {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::Season, s.to_string())
-                    .with_priority(1),
+                    .with_priority(crate::priority::VOCABULARY),
             );
         }
         return;
@@ -538,14 +551,14 @@ fn try_season_words(input: &str, matches: &mut Vec<MatchSpan>) {
         for s in &prefix_nums {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::Season, s.to_string())
-                    .with_priority(1),
+                    .with_priority(crate::priority::VOCABULARY),
             );
         }
         if let Some(&last) = prefix_nums.last() {
             for s in (last + 1)..=end {
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Season, s.to_string())
-                        .with_priority(1),
+                        .with_priority(crate::priority::VOCABULARY),
                 );
             }
         }
@@ -572,14 +585,14 @@ fn try_season_words(input: &str, matches: &mut Vec<MatchSpan>) {
             for s in &nums[..nums.len() - 2] {
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Season, s.to_string())
-                        .with_priority(1),
+                        .with_priority(crate::priority::VOCABULARY),
                 );
             }
             if range_end > range_start {
                 for s in range_start..=range_end {
                     matches.push(
                         MatchSpan::new(full.start(), full.end(), Property::Season, s.to_string())
-                            .with_priority(1),
+                            .with_priority(crate::priority::VOCABULARY),
                     );
                 }
             }
@@ -587,7 +600,7 @@ fn try_season_words(input: &str, matches: &mut Vec<MatchSpan>) {
             for s in &nums {
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Season, s.to_string())
-                        .with_priority(1),
+                        .with_priority(crate::priority::VOCABULARY),
                 );
             }
         }
@@ -610,7 +623,7 @@ fn try_season_words(input: &str, matches: &mut Vec<MatchSpan>) {
         if let Some(num) = roman_to_int(roman_str) {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::Season, num.to_string())
-                    .with_priority(2),
+                    .with_priority(crate::priority::KEYWORD),
             );
         }
     }
@@ -660,7 +673,7 @@ fn try_episode_standalone(input: &str, matches: &mut Vec<MatchSpan>) {
                         Property::Episode,
                         ep_start.to_string(),
                     )
-                    .with_priority(2),
+                    .with_priority(crate::priority::KEYWORD),
                 );
             } else if !extra_eps.is_empty() {
                 // Space-separated zero-padded episodes: E01 02 03
@@ -671,7 +684,7 @@ fn try_episode_standalone(input: &str, matches: &mut Vec<MatchSpan>) {
                         Property::Episode,
                         ep_start.to_string(),
                     )
-                    .with_priority(2),
+                    .with_priority(crate::priority::KEYWORD),
                 );
                 for ep in &extra_eps {
                     matches.push(
@@ -681,14 +694,14 @@ fn try_episode_standalone(input: &str, matches: &mut Vec<MatchSpan>) {
                             Property::Episode,
                             ep.to_string(),
                         )
-                        .with_priority(2),
+                        .with_priority(crate::priority::KEYWORD),
                     );
                 }
             } else {
                 for ep in &parse_multi_episodes(ep_start, ep_rest) {
                     matches.push(
                         MatchSpan::new(full.start(), full.end(), Property::Episode, ep.to_string())
-                            .with_priority(2),
+                            .with_priority(crate::priority::KEYWORD),
                     );
                 }
             }
@@ -715,7 +728,7 @@ fn try_episode_standalone(input: &str, matches: &mut Vec<MatchSpan>) {
                         Property::Episode,
                         ep_start.to_string(),
                     )
-                    .with_priority(2),
+                    .with_priority(crate::priority::KEYWORD),
                 );
             }
         }
@@ -733,7 +746,8 @@ fn try_episode_standalone(input: &str, matches: &mut Vec<MatchSpan>) {
         let full = cap.get(0).expect("group 0 always present");
         let episode = parse_num(&cap, "episode");
         matches.push(
-            MatchSpan::new(full.start(), full.end(), Property::Episode, episode).with_priority(-1),
+            MatchSpan::new(full.start(), full.end(), Property::Episode, episode)
+                .with_priority(crate::priority::HEURISTIC),
         );
     }
 
@@ -744,13 +758,14 @@ fn try_episode_standalone(input: &str, matches: &mut Vec<MatchSpan>) {
         let full = cap.get(0).expect("group 0 always present");
         let episode = parse_num(&cap, "episode");
         matches.push(
-            MatchSpan::new(full.start(), full.end(), Property::Episode, episode).with_priority(1),
+            MatchSpan::new(full.start(), full.end(), Property::Episode, episode)
+                .with_priority(crate::priority::VOCABULARY),
         );
     }
 
     // Leading episode: `01 - Ep Name`.
     if !has_property(matches, Property::Episode) {
-        let fn_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
+        let fn_start = crate::filename_start(input);
         let filename = &input[fn_start..];
         for cap in LEADING_EPISODE.captures_iter(filename) {
             let ep_match = cap
@@ -764,7 +779,7 @@ fn try_episode_standalone(input: &str, matches: &mut Vec<MatchSpan>) {
             let abs_end = fn_start + ep_match.end();
             matches.push(
                 MatchSpan::new(abs_start, abs_end, Property::Episode, ep_num.to_string())
-                    .with_priority(0),
+                    .with_priority(crate::priority::DEFAULT),
             );
             break;
         }
@@ -796,13 +811,13 @@ fn try_episode_standalone(input: &str, matches: &mut Vec<MatchSpan>) {
                             Property::Episode,
                             ep1.to_string(),
                         )
-                        .with_priority(3),
+                        .with_priority(crate::priority::PATTERN),
                     );
                 }
             } else {
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Episode, ep1.to_string())
-                        .with_priority(3),
+                        .with_priority(crate::priority::PATTERN),
                 );
             }
         }
@@ -814,7 +829,7 @@ fn try_episode_standalone(input: &str, matches: &mut Vec<MatchSpan>) {
 /// CJK fansub: `[Group][Title][01][1080P]...
 /// Detects bare 1-3 digit numbers in brackets between other brackets.
 fn try_cjk_bracket_episode(input: &str, matches: &mut Vec<MatchSpan>) {
-    let fn_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
+    let fn_start = crate::filename_start(input);
     let filename = &input[fn_start..];
 
     // Only apply to filenames starting with `[` (CJK fansub style).
@@ -836,7 +851,7 @@ fn try_cjk_bracket_episode(input: &str, matches: &mut Vec<MatchSpan>) {
         let abs_end = fn_start + ep_match.end();
         matches.push(
             MatchSpan::new(abs_start, abs_end, Property::Episode, ep_num.to_string())
-                .with_priority(1),
+                .with_priority(crate::priority::VOCABULARY),
         );
     }
 }
@@ -869,7 +884,7 @@ fn try_cjk_episode_marker(input: &str, matches: &mut Vec<MatchSpan>) {
         let abs_end = ep_match.end();
         matches.push(
             MatchSpan::new(abs_start, abs_end, Property::Episode, ep_num.to_string())
-                .with_priority(2),
+                .with_priority(crate::priority::KEYWORD),
         );
     }
 }
@@ -889,7 +904,7 @@ fn try_cjk_episode_marker(input: &str, matches: &mut Vec<MatchSpan>) {
 /// detect episode numbering patterns across siblings instead of guessing
 /// from digit positions in a single filename.
 fn try_digit_decomposition(input: &str, matches: &mut Vec<MatchSpan>) {
-    let fn_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
+    let fn_start = crate::filename_start(input);
     let filename = &input[fn_start..];
     // ⚠️ Fragile: assumes bracket-prefix = anime. Should use context instead.
     let is_anime_style = filename.starts_with('[') || filename.contains('_');
@@ -925,7 +940,7 @@ fn try_digit_decomposition(input: &str, matches: &mut Vec<MatchSpan>) {
                     Property::Episode,
                     num.to_string(),
                 )
-                .with_priority(0)
+                .with_priority(crate::priority::DEFAULT)
                 .with_source(Source::Heuristic),
             );
             break;
@@ -946,7 +961,7 @@ fn try_digit_decomposition(input: &str, matches: &mut Vec<MatchSpan>) {
                     Property::Season,
                     season.to_string(),
                 )
-                .with_priority(0)
+                .with_priority(crate::priority::DEFAULT)
                 .with_source(Source::Heuristic),
             );
             matches.push(
@@ -956,7 +971,7 @@ fn try_digit_decomposition(input: &str, matches: &mut Vec<MatchSpan>) {
                     Property::Episode,
                     episode.to_string(),
                 )
-                .with_priority(0)
+                .with_priority(crate::priority::DEFAULT)
                 .with_source(Source::Heuristic),
             );
             break;
@@ -990,7 +1005,7 @@ fn detect_absolute_episodes(input: &str, matches: &mut Vec<MatchSpan>) {
     let in_se_span = |pos: usize| -> bool { se_spans.iter().any(|(s, e)| pos >= *s && pos < *e) };
 
     let first_se_start = se_spans.iter().map(|(s, _)| *s).min().unwrap_or(usize::MAX);
-    let fn_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
+    let fn_start = crate::filename_start(input);
     let bytes = input.as_bytes();
 
     static NUM_RANGE: LazyLock<regex::Regex> =

--- a/src/properties/language.rs
+++ b/src/properties/language.rs
@@ -23,7 +23,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
             if let Some(lang) = lang_code_to_name(code) {
                 matches.push(
                     MatchSpan::new(cap.start(), cap.end(), Property::Language, lang)
-                        .with_priority(0),
+                        .with_priority(crate::priority::DEFAULT),
                 );
             }
         }

--- a/src/properties/part.rs
+++ b/src/properties/part.rs
@@ -101,7 +101,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
             if !value.is_empty() {
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Part, &value)
-                        .with_priority(1),
+                        .with_priority(crate::priority::VOCABULARY),
                 );
             }
         }
@@ -116,7 +116,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
             for n in disc_nums {
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Disc, n.to_string())
-                        .with_priority(1),
+                        .with_priority(crate::priority::VOCABULARY),
                 );
             }
         }
@@ -129,7 +129,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
         if check_boundary(bytes, full.start(), full.end(), &ALPHADIGIT_BOTH) {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::CdCount, num.as_str())
-                    .with_priority(1),
+                    .with_priority(crate::priority::VOCABULARY),
             );
         }
     }
@@ -141,7 +141,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
         if check_boundary(bytes, full.start(), full.end(), &ALPHA_ALPHADIGIT) {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::Cd, num.as_str())
-                    .with_priority(1),
+                    .with_priority(crate::priority::VOCABULARY),
             );
         }
     }
@@ -155,7 +155,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
             if n > 0 {
                 matches.push(
                     MatchSpan::new(full.start(), full.end(), Property::Film, n.to_string())
-                        .with_priority(1),
+                        .with_priority(crate::priority::VOCABULARY),
                 );
             }
         }
@@ -169,7 +169,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
         if check_boundary(bytes, full.start(), full.end(), &ALPHA_ALPHADIGIT) {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::Part, num.as_str())
-                    .with_priority(1),
+                    .with_priority(crate::priority::VOCABULARY),
             );
         }
     }

--- a/src/properties/release_group/mod.rs
+++ b/src/properties/release_group/mod.rs
@@ -110,7 +110,8 @@ pub fn find_matches(
 
         if !is_rejected_group(&value, abs_start, abs_end, resolved) {
             matches.push(
-                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value).with_priority(-1),
+                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value)
+                    .with_priority(crate::priority::HEURISTIC),
             );
         }
     }
@@ -149,7 +150,7 @@ pub fn find_matches(
                 if !is_rejected_group(&value, abs_start, abs_end, resolved) {
                     matches.push(
                         MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value)
-                            .with_priority(-1),
+                            .with_priority(crate::priority::HEURISTIC),
                     );
                 }
             }
@@ -166,7 +167,8 @@ pub fn find_matches(
         let abs_end = filename_start + group.end();
         if !is_rejected_group(value, abs_start, abs_end, resolved) {
             matches.push(
-                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value).with_priority(-2),
+                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value)
+                    .with_priority(crate::priority::POSITIONAL),
             );
         }
     }
@@ -181,7 +183,8 @@ pub fn find_matches(
         let abs_end = filename_start + group.end();
         if !is_rejected_group(value, abs_start, abs_end, resolved) {
             matches.push(
-                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value).with_priority(-2),
+                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value)
+                    .with_priority(crate::priority::POSITIONAL),
             );
         }
     }
@@ -209,7 +212,8 @@ pub fn find_matches(
             && !is_hex_crc(value)
         {
             matches.push(
-                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value).with_priority(-2),
+                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value)
+                    .with_priority(crate::priority::POSITIONAL),
             );
         }
     }
@@ -227,7 +231,8 @@ pub fn find_matches(
             && !is_hex_crc(value)
         {
             matches.push(
-                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value).with_priority(-2),
+                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value)
+                    .with_priority(crate::priority::POSITIONAL),
             );
         }
     }
@@ -242,7 +247,8 @@ pub fn find_matches(
         let abs_end = filename_start + group.end();
         if !is_rejected_group(value, abs_start, abs_end, resolved) && !is_hex_crc(value) {
             matches.push(
-                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value).with_priority(-1),
+                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value)
+                    .with_priority(crate::priority::HEURISTIC),
             );
         }
     }
@@ -258,7 +264,8 @@ pub fn find_matches(
         let abs_end = filename_start + group.end();
         if !is_rejected_group(value, abs_start, abs_end, resolved) && value.len() >= 3 {
             matches.push(
-                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value).with_priority(-4),
+                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value)
+                    .with_priority(crate::priority::POSITIONAL - 2),
             );
         }
     }
@@ -293,7 +300,7 @@ pub fn find_matches(
             }
             matches.push(
                 MatchSpan::new(merged_start, abs_end, Property::ReleaseGroup, merged_value)
-                    .with_priority(-3),
+                    .with_priority(crate::priority::POSITIONAL - 1),
             );
         }
     }
@@ -321,7 +328,7 @@ pub fn find_matches(
             {
                 matches.push(
                     MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, content)
-                        .with_priority(-4),
+                        .with_priority(crate::priority::POSITIONAL - 2),
                 );
                 break;
             }
@@ -351,7 +358,7 @@ pub fn find_matches(
                     }
                     matches.push(
                         MatchSpan::new(0, 0, Property::ReleaseGroup, parent_value)
-                            .with_priority(-3),
+                            .with_priority(crate::priority::POSITIONAL - 1),
                     );
                 }
             }
@@ -452,7 +459,7 @@ fn find_compound_bracket_group_from_tokenstream(
                     Property::ReleaseGroup,
                     merged,
                 )
-                .with_priority(-2),
+                .with_priority(crate::priority::POSITIONAL),
             )
         }
         _ => None,

--- a/src/properties/size.rs
+++ b/src/properties/size.rs
@@ -28,7 +28,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
     {
         matches.push(
             MatchSpan::new(size.start(), size.end(), Property::Size, size.as_str())
-                .with_priority(1),
+                .with_priority(crate::priority::VOCABULARY),
         );
     }
     matches

--- a/src/properties/subtitle_language.rs
+++ b/src/properties/subtitle_language.rs
@@ -139,7 +139,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                 Property::SubtitleLanguage,
                 normalized,
             )
-            .with_priority(2),
+            .with_priority(crate::priority::KEYWORD),
         );
     }
 
@@ -153,7 +153,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
         {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::SubtitleLanguage, lang)
-                    .with_priority(2),
+                    .with_priority(crate::priority::KEYWORD),
             );
         }
     }
@@ -174,7 +174,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
         {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::SubtitleLanguage, lang)
-                    .with_priority(2),
+                    .with_priority(crate::priority::KEYWORD),
             );
         }
     }
@@ -189,7 +189,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
         if check_boundary(bytes, full.start(), full.end(), b) {
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::SubtitleLanguage, lang)
-                    .with_priority(2),
+                    .with_priority(crate::priority::KEYWORD),
             );
         }
     }
@@ -219,7 +219,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                             Property::SubtitleLanguage,
                             normalized,
                         )
-                        .with_priority(1),
+                        .with_priority(crate::priority::VOCABULARY),
                     );
                 }
             }
@@ -238,7 +238,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                 .unwrap_or("und");
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::SubtitleLanguage, lang)
-                    .with_priority(0),
+                    .with_priority(crate::priority::DEFAULT),
             );
         }
     }
@@ -255,7 +255,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                 .unwrap_or("und");
             matches.push(
                 MatchSpan::new(full.start(), full.end(), Property::SubtitleLanguage, lang)
-                    .with_priority(0),
+                    .with_priority(crate::priority::DEFAULT),
             );
         }
     }

--- a/src/properties/title/secondary.rs
+++ b/src/properties/title/secondary.rs
@@ -231,7 +231,7 @@ pub fn extract_film_title(
     let film_match = matches.iter().find(|m| m.property == Property::Film)?;
     let _title_match = matches.iter().find(|m| m.property == Property::Title)?;
 
-    let fn_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
+    let fn_start = crate::filename_start(input);
 
     if film_match.start <= fn_start {
         return None;
@@ -300,7 +300,7 @@ pub fn extract_alternative_titles(
     matches: &[MatchSpan],
     _token_stream: &TokenStream,
 ) -> Vec<MatchSpan> {
-    let filename_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
+    let filename_start = crate::filename_start(input);
 
     let first_match = matches
         .iter()

--- a/src/properties/uuid.rs
+++ b/src/properties/uuid.rs
@@ -27,7 +27,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
         if let Some(uuid) = cap.name("uuid") {
             matches.push(
                 MatchSpan::new(uuid.start(), uuid.end(), Property::Uuid, uuid.as_str())
-                    .with_priority(2),
+                    .with_priority(crate::priority::KEYWORD),
             );
         }
     }
@@ -38,7 +38,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
             if let Some(uuid) = cap.name("uuid") {
                 matches.push(
                     MatchSpan::new(uuid.start(), uuid.end(), Property::Uuid, uuid.as_str())
-                        .with_priority(2),
+                        .with_priority(crate::priority::KEYWORD),
                 );
             }
         }

--- a/src/properties/website.rs
+++ b/src/properties/website.rs
@@ -54,7 +54,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
             if has_known_tld(val) {
                 matches.push(
                     MatchSpan::new(site.start(), site.end(), Property::Website, val)
-                        .with_priority(2),
+                        .with_priority(crate::priority::KEYWORD),
                 );
             }
         }
@@ -74,7 +74,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
         {
             matches.push(
                 MatchSpan::new(site.start(), site.end(), Property::Website, site.as_str())
-                    .with_priority(1),
+                    .with_priority(crate::priority::VOCABULARY),
             );
         }
     }
@@ -89,7 +89,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
                 if val.len() > 7 {
                     matches.push(
                         MatchSpan::new(site.start(), site.end(), Property::Website, val)
-                            .with_priority(0),
+                            .with_priority(crate::priority::DEFAULT),
                     );
                 }
             }

--- a/src/properties/year.rs
+++ b/src/properties/year.rs
@@ -47,7 +47,10 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
             continue;
         }
 
-        matches.push(MatchSpan::new(m.start(), m.end(), Property::Year, raw).with_priority(-1));
+        matches.push(
+            MatchSpan::new(m.start(), m.end(), Property::Year, raw)
+                .with_priority(crate::priority::HEURISTIC),
+        );
         pos = m.end();
     }
     matches

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -174,7 +174,7 @@ pub struct TokenStream {
 /// Dot-acronyms like `S.H.I.E.L.D.` are preserved as single tokens.
 /// Bracket groups like `[rarbg]` are marked with `in_brackets: true`.
 pub fn tokenize(input: &str) -> TokenStream {
-    let filename_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
+    let filename_start = crate::filename_start(input);
 
     // Split input into raw path segments.
     let raw_parts = split_path_segments(input);


### PR DESCRIPTION
Addresses review items #2, #4, #5 from #82. Zero behavior changes — all 414 tests pass.

## Priority constants (#5)

New `src/priority.rs` module with named tiers:

| Constant | Value | Meaning |
|---|---|---|
| EXTENSION | 10 | File extension → container |
| STRUCTURAL | 5 | SxxExx, parenthesized year |
| PATTERN | 3 | NxN, Cap.NNN, CJK brackets |
| KEYWORD | 2 | "Episode 1", dates, CRC32, UUID |
| VOCABULARY | 1 | "Season 1", Part, size |
| DEFAULT | 0 | TOML exact/pattern matches |
| HEURISTIC | -1 | Bare year, bare episode |
| POSITIONAL | -2 | Release group fallbacks |
| DIR_PENALTY | -5 | Directory segment penalty |

Replaced magic integers across 15 source files. Sub-tier offsets use arithmetic (`STRUCTURAL - 1`).

## Shared `filename_start` (#4)

- Added `crate::filename_start(input) -> usize` as the single source of truth.
- Replaced 12 inline `input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0)` calls across 8 files.
- The tokenizer now calls this too, so there's exactly one implementation.

## Legacy matcher categorization (#2)

Replaced the misleading "not expressible in TOML" comment with a categorized inventory:
- **Algorithmic** (genuinely need Rust): episodes, date, language, etc.
- **Migration candidates**: crc32, uuid, version, size, bonus

Refs: #82