### PR TITLE
fix: Movie N in movie/ dir no longer parsed as episode

### DIFF
--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -639,7 +639,16 @@ impl Pipeline {
         let media_type = title::infer_media_type(input, all_matches);
         let proper_count = proper_count::compute_proper_count(input, all_matches);
 
-        // Step 5e: Strip video/audio tech properties from subtitle containers.
+        // Step 5e: When media_type is "movie", drop heuristic-only episode
+        // matches — bare numbers like "10" in "Movie.10" are franchise
+        // numbers, not episodes. Strong episode signals (SxxExx) are kept.
+        if media_type == "movie" {
+            all_matches.retain(|m| {
+                !(m.property == Property::Episode && m.priority <= priority::HEURISTIC)
+            });
+        }
+
+        // Step 5f: Strip video/audio tech properties from subtitle containers.
         // Files like .ass, .srt, .sub should not carry video_codec, color_depth, etc.
         pass2_helpers::strip_tech_from_subtitle_containers(all_matches);
 

--- a/src/properties/title/mod.rs
+++ b/src/properties/title/mod.rs
@@ -668,4 +668,34 @@ mod tests {
         let matches = vec![MatchSpan::new(0, 4, Property::Year, "2024")];
         assert_eq!(infer_media_type("Movie.2024.mkv", &matches), "movie");
     }
+
+    #[test]
+    fn test_movie_dir_suppresses_heuristic_episode() {
+        // "Movie 10" in a movie/ directory: bare number is a franchise number,
+        // not an episode. Path context should win over heuristic episode.
+        let matches = vec![
+            MatchSpan::new(52, 56, Property::Episode, "10")
+                .with_priority(crate::priority::HEURISTIC),
+        ];
+        assert_eq!(
+            infer_media_type(
+                "movie/Japanese/Detective Conan/Detective.Conan.Movie.10.mkv",
+                &matches
+            ),
+            "movie"
+        );
+    }
+
+    #[test]
+    fn test_movie_dir_keeps_strong_episode() {
+        // SxxExx in a movie/ directory: strong signal overrides path context.
+        let matches = vec![
+            MatchSpan::new(0, 6, Property::Season, "1"),
+            MatchSpan::new(0, 6, Property::Episode, "3").with_priority(crate::priority::STRUCTURAL),
+        ];
+        assert_eq!(
+            infer_media_type("movie/Show.S01E03.mkv", &matches),
+            "episode"
+        );
+    }
 }

--- a/src/properties/title/secondary.rs
+++ b/src/properties/title/secondary.rs
@@ -422,7 +422,6 @@ fn split_on_separators<'a>(s: &'a str, separators: &[&str]) -> Vec<&'a str> {
 /// Infer media type from the set of matched properties.
 pub fn infer_media_type(input: &str, matches: &[MatchSpan]) -> &'static str {
     // 1. Structural signals from matched properties.
-    let has_episode = matches.iter().any(|m| m.property == Property::Episode);
     let has_season = matches.iter().any(|m| m.property == Property::Season);
     let has_date = matches.iter().any(|m| m.property == Property::Date);
     let has_episode_details = matches
@@ -434,20 +433,56 @@ pub fn infer_media_type(input: &str, matches: &[MatchSpan]) -> &'static str {
         && !matches.iter().any(|m| m.property == Property::Film)
         && !matches.iter().any(|m| m.property == Property::Year);
 
-    if has_episode || has_season || has_date || has_episode_details || has_bonus_no_film {
+    // Episode signal strength: only consider episodes above HEURISTIC priority
+    // as strong evidence. Bare numbers (pri ≤ HEURISTIC) are guesses that
+    // path context can override.
+    let strong_episode = matches
+        .iter()
+        .any(|m| m.property == Property::Episode && m.priority > crate::priority::HEURISTIC);
+    let weak_episode = !strong_episode && matches.iter().any(|m| m.property == Property::Episode);
+
+    // 2. Strong structural signals always win — SxxExx, "Episode 1", etc.
+    if strong_episode || has_season || has_date || has_episode_details || has_bonus_no_film {
         return "episode";
     }
 
-    // 2. Path-based context: directory names are strong evidence.
-    //    "tv/", "TV Shows/", "Series/", "Anime/" → episode.
-    //    This is the architectural fix for WRONG_TYPE (#46) — instead of
-    //    adding keyword rules for every bonus marker (NCOP, PV, SP, etc.),
-    //    the directory structure tells us what the content is.
+    // 3. Path-based context (D6: smart context overrides dumb engine).
+    //    Movie directory context suppresses weak (heuristic) episode signals.
+    //    Episode directory context promotes to episode even without structural markers.
+    if path_hints_movie(input) {
+        // Movie dir + only a heuristic episode guess → movie wins.
+        // The bare number is likely a franchise number, not an episode.
+        if weak_episode {
+            return "movie";
+        }
+    }
     if path_hints_episode(input) {
         return "episode";
     }
 
+    // 4. Weak episode signal with no path context → still episode.
+    if weak_episode {
+        return "episode";
+    }
+
     "movie"
+}
+
+/// Check if the input path's directory components hint at movie content.
+///
+/// Recognises common media library directory conventions:
+/// - `movie/`, `movies/`, `film/`, `films/`
+///
+/// Conservative: only unambiguous movie indicators.
+fn path_hints_movie(input: &str) -> bool {
+    let dir_part = match input.rfind(['/', '\\']) {
+        Some(i) => &input[..i],
+        None => return false,
+    };
+    let lower = dir_part.to_lowercase();
+    lower
+        .split(['/', '\\'])
+        .any(|c| matches!(c, "movie" | "movies" | "film" | "films"))
 }
 
 /// Check if the input path's directory components hint at TV/episode content.


### PR DESCRIPTION
Fixes Bug 2 from #87 (27 Detective Conan movie files).

## Problem

`Detective.Conan.Movie.10...` in `movie/Japanese/Detective Conan/` was parsed as `type=episode, episode=10`. The bare number `10` matched at HEURISTIC priority (-1), and `infer_media_type` checked `has_episode` before path context.

## Fix

**D6 (smart context overrides dumb engine):**

1. Add `path_hints_movie()` — detects `movie/`, `movies/`, `film/`, `films/` directories
2. Episode signal strength: classify episodes as `strong` (KEYWORD+, e.g., SxxExx) or `weak` (HEURISTIC, bare numbers)
3. Movie path + weak episode → `movie` (path wins)
4. Movie path + strong episode → `episode` (strong signal wins)
5. Pipeline drops heuristic episode matches when `media_type=movie`

## Before/After

```
# Before
type=episode, episode=10, title="Detective Conan Movie"

# After
type=movie, title="Detective Conan Movie"
```

416 tests pass (2 new for path_hints_movie behavior).

Refs: #87