### PR TITLE
feat: add MediaType::Extra for bonus/supplementary content

### DIFF
--- a/src/hunch_result.rs
+++ b/src/hunch_result.rs
@@ -41,6 +41,10 @@ pub enum MediaType {
     Movie,
     /// A TV series episode (has season/episode markers).
     Episode,
+    /// Supplementary content: bonus features, openings, endings, previews,
+    /// specials (SP/OVA/OAD/ONA), commercials, menus, tokuten.
+    /// The specific marker is available via [`episode_details`](HunchResult::episode_details).
+    Extra,
 }
 
 /// The result of parsing a media filename.
@@ -217,6 +221,7 @@ impl HunchResult {
         match self.first(Property::MediaType)?.to_lowercase().as_str() {
             "movie" => Some(MediaType::Movie),
             "episode" => Some(MediaType::Episode),
+            "extra" => Some(MediaType::Extra),
             _ => None,
         }
     }

--- a/src/properties/title/secondary.rs
+++ b/src/properties/title/secondary.rs
@@ -441,6 +441,13 @@ pub fn infer_media_type(input: &str, matches: &[MatchSpan]) -> &'static str {
         .any(|m| m.property == Property::Episode && m.priority > crate::priority::HEURISTIC);
     let weak_episode = !strong_episode && matches.iter().any(|m| m.property == Property::Episode);
 
+    // Episode details (NCED, OP, SP, PV, CM, etc.) WITHOUT episode/season
+    // markers are supplementary content — "extra", not "episode".
+    // With episode/season (e.g., S01E00 Special), it's still an episode.
+    if has_episode_details && !strong_episode && !weak_episode && !has_season && !has_date {
+        return "extra";
+    }
+
     // 2. Strong structural signals always win — SxxExx, "Episode 1", etc.
     if strong_episode || has_season || has_date || has_episode_details || has_bonus_no_film {
         return "episode";
@@ -456,6 +463,7 @@ pub fn infer_media_type(input: &str, matches: &[MatchSpan]) -> &'static str {
             return "movie";
         }
     }
+
     if path_hints_episode(input) {
         return "episode";
     }

--- a/tests/wrong_type.rs
+++ b/tests/wrong_type.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests three layers of fix:
 //! 1. Structural: CJK episode markers (第N話/第N集) — pattern recognition
-//! 2. Vocabulary: Anime bonus tokens (NCOP/NCED/PV/CM) → EpisodeDetails
+//! 2. Vocabulary: Anime bonus tokens (NCOP/NCED/PV/CM) → EpisodeDetails → Extra
 //! 3. Architectural: Path-based type inference (tv/ → episode)
 
 use hunch::matcher::span::Property;
@@ -43,15 +43,27 @@ fn nced_is_episode_details() {
     let r = hunch("[DBD-Raws][Saki][NCED1][1080P][BDRip][HEVC-10bit][FLAC].mkv");
     assert_eq!(
         r.media_type(),
-        Some(MediaType::Episode),
-        "NCED → EpisodeDetails → episode"
+        Some(MediaType::Extra),
+        "NCED → EpisodeDetails (no ep/season) → extra"
     );
+}
+
+#[test]
+fn episode_details_with_season_stays_episode() {
+    // S01E00 Special: has episode + season + episode_details → episode, not extra.
+    let r = hunch("Show.S01E00.Special.mkv");
+    assert_eq!(
+        r.media_type(),
+        Some(MediaType::Episode),
+        "episode_details + ep/season → episode"
+    );
+    assert_eq!(r.first(Property::EpisodeDetails), Some("Special"));
 }
 
 #[test]
 fn pv_is_episode_details() {
     let r = hunch("[DBD-Raws][Natsume Yuujinchou Shichi][PV][1080P][BDRip][HEVC-10bit][FLAC].mkv");
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
 }
 
 #[test]
@@ -59,33 +71,33 @@ fn cm_is_episode_details() {
     let r = hunch(
         "[TxxZ&POPGO&MGRT][Cowboy_Bebop][BDrip][BDBOX_SP02][CM][1920x1080_x264Hi10P_flac][31C5B7B3].mkv",
     );
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
 }
 
 // ── Layer 3: Path-based type inference (architectural fix) ──────────────
 
 #[test]
 fn tv_directory_overrides_movie_default() {
-    // SP without episode markers → would be "movie" by filename alone.
-    // But tv/ path → "episode".
+    // SP without episode markers → extra (supplementary content).
+    // tv/ path doesn't override: SP is still a special, not a regular episode.
     let r = hunch("tv/Japanese/Legal.High.SP.2013.BluRay.1080p.x265.10bit.FRDS.mkv");
     assert_eq!(
         r.media_type(),
-        Some(MediaType::Episode),
-        "tv/ directory should force episode type"
+        Some(MediaType::Extra),
+        "SP (no ep/season) → extra, even in tv/ dir"
     );
 }
 
 #[test]
 fn tv_shows_directory() {
     let r = hunch("TV Shows/Power Rangers/Power Rangers Special - Alpha's Magical Christmas.avi");
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
 }
 
 #[test]
 fn anime_directory() {
     let r = hunch("Anime/Saki/[DBD-Raws][Saki][SP][1080P][BDRip][HEVC-10bit][FLAC].mkv");
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
 }
 
 #[test]
@@ -199,14 +211,14 @@ fn s01_directory_shorthand() {
 // ── P0: SP regression guard ─────────────────────────────────────────────
 
 #[test]
-fn sp_without_path_context_is_episode() {
-    // SP is now recognized as EpisodeDetails → type: episode.
-    // "Legal High SP" is a TV special — episode is correct.
+fn sp_without_path_context_is_extra() {
+    // SP is recognized as EpisodeDetails → type: extra.
+    // "Legal High SP" is a TV special — supplementary content.
     let r = hunch("Legal.High.SP.2013.BluRay.1080p.x265.mkv");
     assert_eq!(
         r.media_type(),
-        Some(MediaType::Episode),
-        "SP → EpisodeDetails → episode"
+        Some(MediaType::Extra),
+        "SP → EpisodeDetails (no ep/season) → extra"
     );
 }
 
@@ -250,54 +262,54 @@ fn backslash_path_tv_directory() {
 #[test]
 fn sp_is_episode_details() {
     let r = hunch("[Group][Show][SP][1080P][BDRip].mkv");
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
     assert_eq!(r.first(Property::EpisodeDetails), Some("Special"));
 }
 
 #[test]
 fn ova_is_episode_details() {
     let r = hunch("[Group][Show][OVA][1080P][BDRip].mkv");
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
     assert_eq!(r.first(Property::EpisodeDetails), Some("OVA"));
 }
 
 #[test]
 fn oad_is_episode_details() {
     let r = hunch("[Group][Show][OAD][1080P][BDRip].mkv");
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
 }
 
 #[test]
 fn ona_is_episode_details() {
     let r = hunch("[Group][Show][ONA][1080P][BDRip].mkv");
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
 }
 
 #[test]
 fn op_is_episode_details() {
     let r = hunch("[Group][Show][OP1][1080P][BDRip].mkv");
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
     assert_eq!(r.first(Property::EpisodeDetails), Some("OP"));
 }
 
 #[test]
 fn ed_is_episode_details() {
     let r = hunch("[Group][Show][ED2][1080P][BDRip].mkv");
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
     assert_eq!(r.first(Property::EpisodeDetails), Some("ED"));
 }
 
 #[test]
 fn menu_is_episode_details() {
     let r = hunch("[Group][Show][MENU][1080P][BDRip].mkv");
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
 }
 
 #[test]
 fn sp_numbered_pattern() {
     // SP02 via regex pattern
     let r = hunch("[Group][Show][SP02][1080P][BDRip].mkv");
-    assert_eq!(r.media_type(), Some(MediaType::Episode));
+    assert_eq!(r.media_type(), Some(MediaType::Extra));
     assert_eq!(r.first(Property::EpisodeDetails), Some("Special"));
 }
 


### PR DESCRIPTION
Closes #72. Fixes Bug 1 from #87 (43 bonus propagation audit failures).

## Problem

Bonus content (NCED, OP, SP, PV, CM, Menu, OVA) was classified as `type: "episode"` via `episode_details`. But it's neither an episode nor a movie — it's supplementary material. Downstream consumers had to inspect `episode_details` directly to detect bonus content.

## Fix

Add `MediaType::Extra` variant. `infer_media_type` now returns `"extra"` when `episode_details` is present WITHOUT episode/season/date markers.

**Decision table:**

| Signals | Type |
|---|---|
| `episode_details` only | `extra` |
| `episode_details` + episode/season | `episode` |
| Episode/season/date (no details) | `episode` |
| None of the above | `movie` |

## Before/After

```
# Before: [NCED1][1080P][BDRip]
type=episode, episode_details=NCED

# After
type=extra, episode_details=NCED

# S01E00 Special — unchanged
type=episode, episode_details=Special, episode=0, season=1
```

415 tests pass (1 new for the episode_details+season→episode guard).