### PR TITLE
fix: bracket content leaks into episode_title and release_group (#91)

### DIFF
--- a/src/properties/release_group/mod.rs
+++ b/src/properties/release_group/mod.rs
@@ -189,9 +189,27 @@ pub fn find_matches(
         }
     }
 
-    // 3c. Compound bracket merging using tokenizer's bracket model.
-    // Must run BEFORE individual bracket steps (4-6) to catch
-    // `(Tigole) [QxR]`, `(JBENT)[TAoE]` patterns.
+    // 3c. `[GROUP]` at start (anime/fansub style).
+    // Runs before compound bracket detection so that CJK fansub patterns
+    // like `[Prejudice-Studio] Title - 01 [metadata]` correctly pick up
+    // the first bracket as the release group. (#91)
+    if matches.is_empty()
+        && let Some(cap) = RELEASE_GROUP_START_BRACKET.captures(filename)
+        && let Some(group) = cap.name("group")
+    {
+        let value = group.as_str().trim();
+        let abs_start = filename_start + group.start();
+        let abs_end = filename_start + group.end();
+        if !is_rejected_group(value, abs_start, abs_end, resolved) && !is_hex_crc(value) {
+            matches.push(
+                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value)
+                    .with_priority(crate::priority::HEURISTIC),
+            );
+        }
+    }
+
+    // 3d. Compound bracket merging using tokenizer's bracket model.
+    // Catches `(Tigole) [QxR]`, `(JBENT)[TAoE]` patterns.
     if matches.is_empty()
         && let Some(compound) =
             find_compound_bracket_group_from_tokenstream(token_stream, filename_start, resolved)
@@ -237,23 +255,7 @@ pub fn find_matches(
         }
     }
 
-    // 6. `[GROUP]` at start (anime style).
-    if matches.is_empty()
-        && let Some(cap) = RELEASE_GROUP_START_BRACKET.captures(filename)
-        && let Some(group) = cap.name("group")
-    {
-        let value = group.as_str().trim();
-        let abs_start = filename_start + group.start();
-        let abs_end = filename_start + group.end();
-        if !is_rejected_group(value, abs_start, abs_end, resolved) && !is_hex_crc(value) {
-            matches.push(
-                MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value)
-                    .with_priority(crate::priority::HEURISTIC),
-            );
-        }
-    }
-
-    // 7. Space-separated at end (requires tech zone anchors).
+    // 6. Space-separated at end (requires tech zone anchors).
     if matches.is_empty()
         && zone_map.has_anchors
         && let Some(cap) = RELEASE_GROUP_SPACE_END.captures(filename)
@@ -270,7 +272,7 @@ pub fn find_matches(
         }
     }
 
-    // 8. Last dot-segment as fallback (requires tech zone anchors).
+    // 7. Last dot-segment as fallback (requires tech zone anchors).
     //    Also tries to merge preceding dot-segments (e.g., `YTS.LT` → "YTS.LT").
     if matches.is_empty()
         && zone_map.has_anchors
@@ -305,7 +307,7 @@ pub fn find_matches(
         }
     }
 
-    // 8b. Mid-filename bracket group containing a single non-tech word.
+    // 7b. Mid-filename bracket group containing a single non-tech word.
     // E.g., `[HorribleSubs]` in `Show!.Name.2.-.10.(2016).[HorribleSubs][WEBRip]..[HD.720p]`.
     if matches.is_empty() {
         for bg in &token_stream.bracket_groups {
@@ -335,7 +337,7 @@ pub fn find_matches(
         }
     }
 
-    // 9. Check parent directory for release group.
+    // 8. Check parent directory for release group.
     if filename_start > 0 {
         let parent = &input[..filename_start.saturating_sub(1)];
         let parent_name = parent.rsplit(['/', '\\']).next().unwrap_or("");
@@ -365,7 +367,7 @@ pub fn find_matches(
         }
     }
 
-    // 10. Merge `-GROUP [BRACKET]` when Step 2 found a dash-group
+    // 9. Merge `-GROUP [BRACKET]` when Step 2 found a dash-group
     // but missed an adjacent bracket suffix (separated by space).
     // E.g., `-0SEC [GloDLS].mkv` → "0SEC [GloDLS]" (was just "0SEC").
     if matches.len() == 1 {

--- a/src/properties/title/secondary.rs
+++ b/src/properties/title/secondary.rs
@@ -155,6 +155,8 @@ fn extract_episode_title_in_segment(
     };
 
     // Trim at opening brackets/parens (metadata, not title content).
+    // If the region starts with a bracket, there is no episode title —
+    // the bracket content is metadata (e.g., `[Bilibili WEB-DL ...]`).
     let ep_title_end = {
         if ep_title_end <= ep_title_start {
             return None;
@@ -167,8 +169,9 @@ fn extract_episode_title_in_segment(
             })
         });
         match bracket_pos {
-            Some(pos) if pos > 0 => ep_title_start + pos,
-            _ => ep_title_end,
+            Some(0) => return None, // bracket immediately — no episode title
+            Some(pos) => ep_title_start + pos,
+            None => ep_title_end,
         }
     };
 

--- a/tests/bracket_leak.rs
+++ b/tests/bracket_leak.rs
@@ -1,0 +1,84 @@
+//! Issue #91 regression: bracket content leaks into episode_title and release_group.
+//!
+//! CJK fansub bracket format: `[Group] Title - NN [metadata][subtitle_tag].ext`
+//! "Bilibili" (a streaming platform inside metadata brackets) was leaking as
+//! episode_title, and the release_group was picking up bracket fragments
+//! instead of the actual group name.
+
+use hunch::hunch;
+
+// ── Episode title must not leak bracket metadata ──────────────────────
+
+#[test]
+fn issue_91_no_episode_title_from_bracket() {
+    let r = hunch(
+        "[Prejudice-Studio] 鬼灭之刃 Kimetsu no Yaiba - 01 [Bilibili WEB-DL 1080P AVC 8bit AAC MP4][简体内嵌].mp4",
+    );
+    assert_eq!(r.title(), Some("鬼灭之刃 Kimetsu no Yaiba"));
+    assert_eq!(r.episode(), Some(1));
+    assert_eq!(
+        r.episode_title(),
+        None,
+        "bracket content 'Bilibili' must not leak into episode_title"
+    );
+    assert_eq!(r.source(), Some("Web"));
+}
+
+#[test]
+fn issue_91_no_episode_title_different_episode() {
+    let r = hunch(
+        "[Prejudice-Studio] 鬼灭之刃 Kimetsu no Yaiba - 12 [Bilibili WEB-DL 1080P AVC 8bit AAC MKV][简繁内封].mkv",
+    );
+    assert_eq!(r.title(), Some("鬼灭之刃 Kimetsu no Yaiba"));
+    assert_eq!(r.episode(), Some(12));
+    assert_eq!(
+        r.episode_title(),
+        None,
+        "bracket content must not leak regardless of episode number"
+    );
+}
+
+#[test]
+fn issue_91_real_episode_title_preserved() {
+    // Part1 is real episode title content (between ep number and bracket).
+    let r = hunch(
+        "[Prejudice-Studio] 鬼灭之刃 游郭篇 Kimetsu no Yaiba Yuukaku-hen - 01 Part1 [Bilibili WEB-DL 1080P AVC 8bit AAC MP4][简体内嵌].mp4",
+    );
+    assert_eq!(
+        r.title(),
+        Some("鬼灭之刃 游郭篇 Kimetsu no Yaiba Yuukaku-hen")
+    );
+    assert_eq!(r.episode(), Some(1));
+    // Part1 appears between the episode number and the bracket — it's real content.
+    assert!(r.episode_title().is_some(), "Part1 should be episode_title");
+}
+
+// ── Release group must be the first bracket, not bracket fragments ────
+
+#[test]
+fn issue_91_release_group_from_first_bracket() {
+    let r = hunch(
+        "[Prejudice-Studio] 鬼灭之刃 Kimetsu no Yaiba - 01 [Bilibili WEB-DL 1080P AVC 8bit AAC MP4][简体内嵌].mp4",
+    );
+    assert_eq!(
+        r.release_group(),
+        Some("Prejudice-Studio"),
+        "release_group must come from [Prejudice-Studio], not bracket fragments"
+    );
+}
+
+#[test]
+fn issue_91_release_group_consistent_across_episodes() {
+    let r = hunch(
+        "[Prejudice-Studio] 鬼灭之刃 Kimetsu no Yaiba - 12 [Bilibili WEB-DL 1080P AVC 8bit AAC MKV][简繁内封].mkv",
+    );
+    assert_eq!(r.release_group(), Some("Prejudice-Studio"));
+}
+
+#[test]
+fn issue_91_release_group_with_part_episode() {
+    let r = hunch(
+        "[Prejudice-Studio] 鬼灭之刃 游郭篇 Kimetsu no Yaiba Yuukaku-hen - 01 Part1 [Bilibili WEB-DL 1080P AVC 8bit AAC MP4][简体内嵌].mp4",
+    );
+    assert_eq!(r.release_group(), Some("Prejudice-Studio"));
+}


### PR DESCRIPTION
## Summary

Fixes #91 — bracket content (e.g., `Bilibili`) was leaking into `episode_title` and `release_group` in CJK fansub bracket format filenames.

## Root Causes

### 1. Episode title bracket leak (`secondary.rs`)
The bracket-trim guard `pos > 0` skipped `pos == 0`. When `[` appeared immediately after the episode number (byte position 0 of the title extraction region), the bracket content leaked through as episode title.

**Fix:** Return `None` when the region starts with a bracket — there's no episode title, just metadata.

### 2. Release group wrong source (`release_group/mod.rs`)
`[GROUP]` at start (anime/fansub style) ran as step 6, AFTER compound bracket detection (step 3c). So `[Bilibili WEB-DL...][简体内嵌]` was picked up as a compound group before `[Prejudice-Studio]` ever got a chance.

**Fix:** Promote start-bracket detection to step 3c (before compound bracket detection at 3d).

## Before / After

```
[Prejudice-Studio] 鬼灭之刃 Kimetsu no Yaiba - 01 [Bilibili WEB-DL 1080P AVC 8bit AAC MP4][简体内嵌].mp4
```

| Field | Before | After |
|-------|--------|-------|
| episode_title | `Bilibili` ❌ | `null` ✅ |
| release_group | `Bilibili 简体内嵌` ❌ | `Prejudice-Studio` ✅ |

## Tests

- 6 new regression tests in `tests/bracket_leak.rs`
- All 423 existing tests pass (0 regressions)