### PR TITLE
fix: treat natural-language first brackets as titles (#100)

### DIFF
--- a/src/properties/release_group/mod.rs
+++ b/src/properties/release_group/mod.rs
@@ -76,7 +76,43 @@ static RELEASE_GROUP_LAST_DOT: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\.(?P<group>[A-Za-z][A-Za-z0-9]{1,15})(?:\.[a-z0-9]{2,5})?$").unwrap()
 });
 
-// ── Matching logic (post-resolution) ──────────────────────────────────────
+// ── Matching logic (post-resolution) ───────────────────────────────────────────
+
+/// Heuristic: reject first-bracket candidates that look like natural-language
+/// titles rather than release groups.
+///
+/// Release groups are usually short and formatted (`DBD-Raws`, `EMBER`,
+/// `TxxZ&POPGO&MGRT`). Titles are often multi-word phrases with regular words
+/// and spaces (`Kimetsu no Yaiba Mugen Ressha Hen`).
+fn looks_like_natural_language_title(candidate: &str) -> bool {
+    let trimmed = candidate.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if trimmed.contains(['&', '/', '@']) {
+        return false;
+    }
+
+    let words: Vec<&str> = trimmed
+        .split_whitespace()
+        .filter(|word| !word.is_empty())
+        .collect();
+
+    if words.len() < 4 {
+        return false;
+    }
+
+    if words.iter().any(|word| {
+        word.contains('-')
+            || word.chars().any(|c| !c.is_alphanumeric() && c != '\'' && c != '!')
+            || word.chars().all(|c| c.is_ascii_uppercase())
+    }) {
+        return false;
+    }
+
+    words.iter().filter(|word| word.len() >= 2).count() >= 4
+}
 
 /// Find release group matches using resolved tech match positions.
 ///
@@ -200,7 +236,10 @@ pub fn find_matches(
         let value = group.as_str().trim();
         let abs_start = filename_start + group.start();
         let abs_end = filename_start + group.end();
-        if !is_rejected_group(value, abs_start, abs_end, resolved) && !is_hex_crc(value) {
+        if !is_rejected_group(value, abs_start, abs_end, resolved)
+            && !is_hex_crc(value)
+            && !looks_like_natural_language_title(value)
+        {
             matches.push(
                 MatchSpan::new(abs_start, abs_end, Property::ReleaseGroup, value)
                     .with_priority(crate::priority::HEURISTIC),

--- a/src/properties/release_group/mod.rs
+++ b/src/properties/release_group/mod.rs
@@ -105,7 +105,9 @@ fn looks_like_natural_language_title(candidate: &str) -> bool {
 
     if words.iter().any(|word| {
         word.contains('-')
-            || word.chars().any(|c| !c.is_alphanumeric() && c != '\'' && c != '!')
+            || word
+                .chars()
+                .any(|c| !c.is_alphanumeric() && c != '\'' && c != '!')
             || word.chars().all(|c| c.is_ascii_uppercase())
     }) {
         return false;

--- a/src/properties/title/mod.rs
+++ b/src/properties/title/mod.rs
@@ -391,8 +391,11 @@ fn extract_unclaimed_bracket_title(
         return None;
     }
 
-    // Find the first unclaimed bracket group (skip the first one = release group).
-    for &(abs_start, abs_end, content) in &brackets[1..] {
+    // Find the first unclaimed bracket group. Prefer skipping the first bracket
+    // (typically a release group), but allow it when no release group was
+    // detected and the first bracket is the only plausible title (#100).
+    let start_index = usize::from(matches.iter().any(|m| m.property == Property::ReleaseGroup));
+    for &(abs_start, abs_end, content) in &brackets[start_index..] {
         if content.is_empty() || content.chars().all(|c| c.is_ascii_digit()) {
             continue;
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -654,9 +654,8 @@ fn issue_100_first_bracket_is_title_when_natural_language() {
 
 #[test]
 fn issue_100_real_release_group_still_detected() {
-    let r = hunch(
-        "[Prejudice-Studio][Kimetsu no Yaiba Mugen Ressha Hen][JPN+ENG][BDRIP][1080P].mkv",
-    );
+    let r =
+        hunch("[Prejudice-Studio][Kimetsu no Yaiba Mugen Ressha Hen][JPN+ENG][BDRIP][1080P].mkv");
     assert_eq!(r.release_group(), Some("Prejudice-Studio"));
     assert_eq!(r.title(), Some("Kimetsu no Yaiba Mugen Ressha Hen"));
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -643,7 +643,25 @@ fn issue_39_cjk_cowboy_bebop_sp02() {
     assert_eq!(r.first(Property::Crc), Some("31C5B7B3"));
 }
 
-// ── Issue #35 regression: subtitle containers strip video tech ────────────
+#[test]
+fn issue_100_first_bracket_is_title_when_natural_language() {
+    let r = hunch(
+        "[Kimetsu no Yaiba Mugen Ressha Hen][JPN+ENG][BDRIP][1080P][H264_FLACx3_DTS-HDMA].mkv",
+    );
+    assert_eq!(r.title(), Some("Kimetsu no Yaiba Mugen Ressha Hen"));
+    assert_eq!(r.release_group(), None);
+}
+
+#[test]
+fn issue_100_real_release_group_still_detected() {
+    let r = hunch(
+        "[Prejudice-Studio][Kimetsu no Yaiba Mugen Ressha Hen][JPN+ENG][BDRIP][1080P].mkv",
+    );
+    assert_eq!(r.release_group(), Some("Prejudice-Studio"));
+    assert_eq!(r.title(), Some("Kimetsu no Yaiba Mugen Ressha Hen"));
+}
+
+// ── Issue #35 regression: subtitle containers strip video tech ──────────────────
 
 #[test]
 fn issue_35_western_srt_no_video_props() {


### PR DESCRIPTION
## Summary
- reject first bracket as release group when it looks like a natural-language title
- allow first unclaimed bracket to become the title when no release group was detected
- add regressions for bracketed title-first movie names and release-group preservation

## Testing
- cargo test

Closes #100