### PR TITLE
chore: prepare v1.1.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.7] - 2026-03-23
+
+### Fixed
+
+- **Bracket metadata leakage** — bracketed metadata in CJK/anime filenames no
+  longer leaks into `episode_title`, and release-group extraction now prefers
+  the actual first bracket group instead of bracket fragments. (#92)
+- **Generic category directories** — library/category directories like
+  `English/`, `Japanese/`, `Anime/`, and CJK bonus folders are filtered more
+  aggressively so they do not become titles. (#95)
+- **Parent-context fallback in batch mode** — files in sparse extras/specials
+  subdirectories now fall back to parent-directory context more reliably during
+  recursive batch parsing. (#96)
+- **Empty intermediate directory propagation** — recursive batch parsing now
+  preserves useful parent context through empty/intermediate directory layers
+  instead of dropping title hints. (#98)
+- **Explicit movie signals override `tv/` path hints** — filenames and parent
+  directories containing strong movie cues such as `The Movie`, `... Movie`,
+  and `劇場版` now classify as `type=movie` even inside TV-oriented directory
+  trees. (#99)
+- **Natural-language first brackets** — filenames like
+  `[Kimetsu no Yaiba Mugen Ressha Hen][JPN+ENG]...` now treat the first bracket
+  as `title` when it looks like natural language instead of a release group.
+  (#100)
+
+### Docs
+
+- Added a README **Known Limitations** section documenting the main remaining
+  edge-case categories and their tradeoffs. (#103)
+
 ## [1.1.6] - 2026-03-22
 
 ### Added
@@ -652,6 +682,7 @@ source, audio_codec, screen_size, audio_channels, date.
 
 color_depth, streaming_service, bonus, episode_details, film.
 
+[1.1.7]: https://github.com/lijunzh/hunch/releases/tag/v1.1.7
 [1.1.6]: https://github.com/lijunzh/hunch/releases/tag/v1.1.6
 [1.1.5]: https://github.com/lijunzh/hunch/releases/tag/v1.1.5
 [1.1.4]: https://github.com/lijunzh/hunch/releases/tag/v1.1.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hunch"
-version = "1.1.6"
+version = "1.1.7"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hunch"
-version = "1.1.6"
+version = "1.1.7"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Lijun Zhu"]


### PR DESCRIPTION
## Summary
- bump crate version from `1.1.6` to `1.1.7`
- add `1.1.7` changelog entry covering the parser fixes and README limitations docs since `v1.1.6`
- keep release automation tag-driven via `.github/workflows/release.yml`

## Testing
- cargo test

## Release plan
1. Merge this PR
2. Tag `main` with `v1.1.7`
3. Push the tag
4. Let the GitHub release workflow publish binaries, create the GitHub release, and update the Homebrew tap

This PR intentionally does **not** create the tag yet.