### PR TITLE
fix: keep special editions typed as movies

### DIFF
--- a/src/properties/title/secondary.rs
+++ b/src/properties/title/secondary.rs
@@ -430,6 +430,7 @@ pub fn infer_media_type(input: &str, matches: &[MatchSpan]) -> &'static str {
     let has_episode_details = matches
         .iter()
         .any(|m| m.property == Property::EpisodeDetails);
+    let has_edition = matches.iter().any(|m| m.property == Property::Edition);
     let has_strong_movie_signal = path_hints_movie(input) || has_movie_signal(input);
     // Bonus without Film or Year = TV series bonus (episode), not movie extra.
     // Movie extras typically have years: Moon_(2009)-x02-Making_Of
@@ -445,15 +446,19 @@ pub fn infer_media_type(input: &str, matches: &[MatchSpan]) -> &'static str {
         .any(|m| m.property == Property::Episode && m.priority > crate::priority::HEURISTIC);
     let weak_episode = !strong_episode && matches.iter().any(|m| m.property == Property::Episode);
 
+    let episode_details_signal = has_episode_details && !has_edition;
+
     // Episode details (NCED, OP, SP, PV, CM, etc.) WITHOUT episode/season
     // markers are supplementary content — "extra", not "episode".
     // With episode/season (e.g., S01E00 Special), it's still an episode.
-    if has_episode_details && !strong_episode && !weak_episode && !has_season && !has_date {
+    // But when "Special" is part of an edition marker ("Special Edition"),
+    // that's movie metadata, not episodic evidence.
+    if episode_details_signal && !strong_episode && !weak_episode && !has_season && !has_date {
         return "extra";
     }
 
     // 2. Strong structural signals always win — SxxExx, "Episode 1", etc.
-    if strong_episode || has_season || has_date || has_episode_details || has_bonus_no_film {
+    if strong_episode || has_season || has_date || episode_details_signal || has_bonus_no_film {
         return "episode";
     }
 

--- a/tests/wrong_type.rs
+++ b/tests/wrong_type.rs
@@ -132,6 +132,20 @@ fn movie_in_movies_dir_still_movie() {
 }
 
 #[test]
+fn special_edition_movie_stays_movie() {
+    let r = hunch("Star Wars: Episode IV - A New Hope (2004) Special Edition.MKV");
+    assert_eq!(r.media_type(), Some(MediaType::Movie));
+    assert_eq!(r.first(Property::Edition), Some("Special"));
+}
+
+#[test]
+fn special_edition_after_year_stays_movie() {
+    let r = hunch("A.Common.Title.2014.Special.Edition.avi");
+    assert_eq!(r.media_type(), Some(MediaType::Movie));
+    assert_eq!(r.first(Property::Edition), Some("Special"));
+}
+
+#[test]
 fn regular_episode_still_episode() {
     let r = hunch("Show.S01E03.720p.mkv");
     assert_eq!(r.media_type(), Some(MediaType::Episode));


### PR DESCRIPTION
## Summary
- fix #108 by preventing `edition=Special` from acting as episodic `episode_details` type evidence
- keep `Special Edition` movie files classified as `movie`
- add regression tests for movie-edition cases from the compatibility suite

## Why
`infer_media_type()` treated any `episode_details` match as episodic evidence. For filenames like `Special Edition`, that caused `Special` to incorrectly push the file toward `extra` instead of `movie`.

## Testing
- `cargo test --test wrong_type -- --nocapture`
- `cargo test`
- `cargo test compatibility_report -- --ignored --nocapture`

## Compatibility impact
After the fix, the compatibility report moved from:
- `1069/1309` passed (`81.7%`)

To:
- `1071/1309` passed (`81.8%`)

Not huge, which is fine — this is a real logic fix, not benchmark cosplay.

Fixes #108