### PR TITLE
docs: simplify compatibility guidance

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,178 +1,93 @@
-# Hunch vs guessit — Compatibility Report
+# Hunch vs guessit — Compatibility
 
-Hunch is a **Rust port** of Python's [guessit](https://github.com/guessit-io/guessit).
-This document tracks how closely hunch reproduces guessit's behavior, measured
-by running hunch against guessit's own test suite (1,309 test cases across 22
-YAML files).
+Hunch started as a Rust port inspired by Python's
+[guessit](https://github.com/guessit-io/guessit), and we still run hunch
+against guessit's test suite as a **secondary benchmark**.
 
-> **Last updated:** 2026-03-20 (v1.1.5)
+But guessit compatibility is no longer the primary optimization target.
+Hunch is tuned first for **real-world media-library accuracy**, with guessit
+compatibility used as a reference point rather than a product goal.
 
----
-
-## Overall Results
-
-| Metric | Value |
-|---|---|
-| Total test cases | 1,309 |
-| Passed (all props correct) | 1,071 |
-| Failed (any prop wrong) | 238 |
-| **Pass rate** | **81.8%** |
-| Properties implemented | 49 / 49 |
-| Properties intentionally diverged | 3 |
-
-guessit passes 100% of its own tests by definition. Hunch currently
-reproduces 82.2% of those results identically.
+> **Last updated:** 2026-03-23 (`main` after #108)
 
 ---
 
-## Pass Rate by Test File
+## Current snapshot
 
-| Test file | Passed | Total | Rate |
-|---|---|---|---|
-| rules/audio_codec.yml | 17 | 17 | **100%** |
-| rules/edition.yml | 44 | 44 | **100%** |
-| rules/language.yml | 9 | 9 | **100%** |
-| rules/other.yml | 46 | 46 | **100%** |
-| rules/part.yml | 9 | 9 | **100%** |
-| rules/release_group.yml | 19 | 19 | **100%** |
-| rules/screen_size.yml | 9 | 9 | **100%** |
-| rules/size.yml | 3 | 3 | **100%** |
-| rules/source.yml | 23 | 23 | **100%** |
-| rules/video_codec.yml | 45 | 45 | **100%** |
-| rules/common_words.yml | 155 | 156 | **99%** |
-| rules/episodes.yml | 77 | 79 | 98% |
-| rules/date.yml | 7 | 8 | 88% |
-| movies.yml | 160 | 199 | 80% |
-| rules/title.yml | 14 | 18 | 78% |
-| various.yml | 89 | 124 | 72% |
-| episodes.yml | 337 | 488 | 69% |
-| rules/bonus.yml | 2 | 3 | 67% |
-| rules/country.yml | 2 | 3 | 67% |
-| rules/film.yml | 2 | 3 | 67% |
-| rules/cd.yml | 1 | 2 | 50% |
-| rules/website.yml | 1 | 2 | 50% |
-
----
-
-## Pass Rate by Property
-
-Each row shows how often hunch produces the correct value for that
-property, across all test cases that assert it.
-
-### ✅ Perfect (100%)
-
-| Property | Passed | Failed | Rate |
-|---|---|---|---|
-| aspect_ratio | 2 | 0 | **100.0%** |
-| bonus | 13 | 0 | **100.0%** |
-| color_depth | 28 | 0 | **100.0%** |
-| date | 26 | 0 | **100.0%** |
-| disc | 6 | 0 | **100.0%** |
-| edition | 83 | 0 | **100.0%** |
-| episode_count | 6 | 0 | **100.0%** |
-| episode_format | 2 | 0 | **100.0%** |
-| film | 8 | 0 | **100.0%** |
-| frame_rate | 7 | 0 | **100.0%** |
-| proper_count | 31 | 0 | **100.0%** |
-| season_count | 2 | 0 | **100.0%** |
-| size | 9 | 0 | **100.0%** |
-| version | 13 | 0 | **100.0%** |
-| video_api | 3 | 0 | **100.0%** |
-| week | 1 | 0 | **100.0%** |
-
-### ✅ Excellent (95%+)
-
-| Property | Passed | Failed | Rate |
-|---|---|---|---|
-| screen_size | 421 | 7 | 98.4% |
-| audio_codec | 220 | 6 | 97.3% |
-| video_codec | 488 | 16 | 96.8% |
-| year | 222 | 8 | 96.5% |
-| source | 538 | 22 | 96.1% |
-| crc32 | 24 | 1 | 96.0% |
-
-### ✅ Good (90–95%)
-
-| Property | Passed | Failed | Rate |
-|---|---|---|---|
-| audio_channels | 112 | 6 | 94.9% |
-| container | 143 | 8 | 94.7% |
-| season | 445 | 29 | 93.9% |
-| type | 769 | 53 | 93.6% |
-| title | 972 | 84 | 92.0% |
-| website | 20 | 2 | 90.9% |
-| episode | 503 | 52 | 90.6% |
-| release_group | 487 | 52 | 90.4% |
-| streaming_service | 28 | 3 | 90.3% |
-
-### 🟡 Solid (80–90%)
-
-| Property | Passed | Failed | Rate |
-|---|---|---|---|
-| other | 311 | 38 | 89.1% |
-| film_title | 7 | 1 | 87.5% |
-| uuid | 7 | 1 | 87.5% |
-| video_profile | 12 | 2 | 85.7% |
-| audio_profile | 29 | 5 | 85.3% |
-| part | 16 | 3 | 84.2% |
-| episode_details | 13 | 3 | 81.2% |
-| language | 115 | 27 | 81.0% |
-| subtitle_language | 65 | 16 | 80.2% |
-
-### ⚠️ Needs Work (50–80%)
-
-| Property | Passed | Failed | Rate |
-|---|---|---|---|
-| episode_title | 153 | 48 | 76.1% |
-| country | 9 | 4 | 69.2% |
-| bonus_title | 8 | 5 | 61.5% |
-| absolute_episode | 6 | 4 | 60.0% |
-| cd | 3 | 2 | 60.0% |
-| alternative_title | 9 | 7 | 56.2% |
-| cd_count | 2 | 2 | 50.0% |
-
-### ❌ Intentionally diverged
-
-| Property | Reason |
-|---|---|
-| audio_bit_rate | Hunch uses single `bit_rate` (see below) |
-| video_bit_rate | Hunch uses single `bit_rate` (see below) |
-| mimetype | Trivially derived from `container`; not implemented |
-
----
-
-## Known Gaps & Future Work
-
-See [GitHub Issues](https://github.com/lijunzh/hunch/issues) for tracked
-improvements. Key P3-aligned work:
-
-- [#52](https://github.com/lijunzh/hunch/issues/52) — Context-based episode detection (replace digit decomposition heuristic)
-- [#53](https://github.com/lijunzh/hunch/issues/53) — Context-based year disambiguation
-
----
-
-## Intentional Divergences
-
-### 1. `bit_rate` (combined)
-
-guessit splits bit rate into `audio_bit_rate` and `video_bit_rate`.
-Hunch emits a single `bit_rate` because the filename alone rarely
-contains enough context to disambiguate audio vs video bit rate.
-
-### 2. `mimetype`
-
-guessit derives MIME type from container extension (e.g., `mkv` →
-`video/x-matroska`). This is a trivial lookup that belongs in the
-consumer, not the parser.
-
----
-
-## How to Reproduce
+Latest compatibility rerun:
 
 ```bash
-# Run the full compatibility report:
+cargo test compatibility_report -- --ignored --nocapture
+```
+
+Results:
+
+- **1,071 / 1,309** cases passed
+- **81.8%** overall compatibility
+- **49 / 49** properties implemented
+- **3 intentional divergences**
+
+A few examples of still-strong property areas:
+
+- `source`: **96.1%**
+- `title`: **92.1%**
+- `episode`: **90.6%**
+- `release_group`: **90.4%**
+- `type`: **93.7%**
+
+---
+
+## How to interpret this
+
+guessit compatibility is useful for:
+
+- spotting regressions against a large public fixture set
+- finding parser blind spots we may have missed
+- measuring broad behavior drift over time
+
+It is **not** the final definition of correctness.
+
+Some guessit fixtures encode parser-specific conventions rather than universal
+truth. When compatibility and real-world behavior disagree, hunch prefers the
+behavior that is more accurate and maintainable for actual media libraries.
+
+---
+
+## Intentional divergences
+
+Hunch intentionally does not mirror guessit in a few places:
+
+- **`audio_bit_rate` / `video_bit_rate`**
+  - guessit splits these into separate properties
+  - hunch emits a single `bit_rate`, because filenames rarely contain enough
+    reliable context to disambiguate audio vs video bit rate cleanly
+
+- **`mimetype`**
+  - guessit derives MIME type from the file extension
+  - hunch does not emit it, because that is a trivial container lookup better
+    handled by the consumer
+
+---
+
+## Real-world accuracy matters more
+
+The main quality signal for hunch is behavior on real media libraries, not
+perfect reproduction of guessit's opinions.
+
+As of the latest audit referenced in the README, hunch achieved **99.8%**
+accuracy on a real-world library of 7,838 files, with the remaining edge cases
+tracked as known limitations.
+
+That is the benchmark we optimize for first.
+
+---
+
+## Reproducing the report
+
+```bash
+# Full compatibility snapshot
 cargo test compatibility_report -- --ignored --nocapture
 
-# Dump individual failures:
+# Include sampled failure details
 HUNCH_DUMP_FAILURES=50 cargo test compatibility_report -- --ignored --nocapture
 ```


### PR DESCRIPTION
## Summary
- simplify `docs/compatibility.md` into a short reference doc
- update the current compatibility snapshot to `1071/1309` (`81.8%`)
- clarify that guessit compatibility is now a secondary benchmark
- remove roadmap/planning content from markdown docs

## Why
We no longer want to treat guessit compatibility as the primary optimization target, and we do not want planning to live in markdown files. This keeps the doc factual, small, and honest.

## Testing
- reran `cargo test compatibility_report -- --ignored --nocapture` before updating the doc

Closes #110