### PR TITLE
ci: fix dependabot auto-merge — use pull_request_target + squash

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,11 @@
 name: Dependabot Auto-Merge
 
-on: pull_request
+# pull_request_target runs in the base-branch context and grants write
+# permissions to the GITHUB_TOKEN — required for Dependabot PRs, which
+# receive a read-only token under the plain `pull_request` trigger.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: write
@@ -17,7 +22,10 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge (squash)
+      - name: Enable auto-merge (squash — linear history)
+        # --auto tells GitHub to merge once all required status checks pass.
+        # The repo ruleset enforces those checks, so this is safe without an
+        # extra "wait" step.  Squash keeps the main history linear.
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Problem

PRs #117 and #118 could not auto-merge because of two bugs in the workflow:

1. **Wrong trigger** — `on: pull_request` gives Dependabot a **read-only** `GITHUB_TOKEN`. Both the approve step and the merge step silently failed with permission errors.

2. **`--auto` used without enforcement** — `gh pr merge --auto` requires branch protection rules / rulesets with required status checks. When those aren't detected the call is a no-op and the PR never merges. (The repo *does* have a ruleset with 5 required checks, but the token lacked write access to even register the request.)

## Fix

| | Before | After |
|---|---|---|
| Trigger | `on: pull_request` | `on: pull_request_target` |
| Token scope | read-only for bots | write (base-branch context) |
| Merge strategy | `--auto --squash` (broken) | `--auto --squash` (works — token now has permissions) |

Switching to `pull_request_target` is safe here because we never check out or execute code from the PR; we only call `gh pr review` and `gh pr merge` against the PR URL.

## Verification

Next Dependabot PR should:
1. Trigger this workflow immediately on open
2. Auto-approve
3. Queue a squash merge that fires once all 5 required CI checks pass