### PR TITLE
fix(clippy): satisfy unnecessary_sort_by lint in title secondary

### DIFF
--- a/src/properties/title/secondary.rs
+++ b/src/properties/title/secondary.rs
@@ -56,7 +56,7 @@ pub fn extract_episode_title(
         .collect();
 
     // Deepest first: prefer closer-to-leaf segments.
-    anchor_segments.sort_by(|a, b| b.0.cmp(&a.0));
+    anchor_segments.sort_by_key(|s| std::cmp::Reverse(s.0));
 
     for (seg_start, seg_end) in &anchor_segments {
         if let Some(result) = extract_episode_title_in_segment(input, matches, *seg_start, *seg_end)


### PR DESCRIPTION
Rust 1.95.0's clippy promoted `unnecessary_sort_by` which is breaking CI on every PR (including the dependabot bump in #125).

Replaces the manual `sort_by(|a, b| b.0.cmp(&a.0))` with `sort_by_key(|s| std::cmp::Reverse(s.0))` — same behavior, less ceremony, and clippy is happy.

Verified locally:
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib properties::title` ✅ (23 passed)