### PR TITLE
fix(title): preserve dashes and "Part N" inside anime bracket titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Anime titles containing `" - "` and `"Part N"`** — in `[Group] Show - Sub
+  Part 2 - 13 [tags]` style filenames, the title is now extracted as the full
+  `Show - Sub Part 2`. Previously the parser truncated at the first `" - "`
+  and incorrectly extracted `Part 2` as a standalone `part` property. (#124)
+
 ## [1.1.7] - 2026-03-23
 
 ### Fixed

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -685,6 +685,9 @@ impl Pipeline {
             );
             // Remove reclaimable matches absorbed into the title.
             title::absorb_reclaimable(&title_match, all_matches);
+            // Drop Part matches that ended up inside the title (e.g. anime
+            // titles containing "Part N").
+            title::absorb_part_into_title(&title_match, all_matches);
             all_matches.push(title_match);
         }
         // Film title: when -fNN- marker exists, split franchise from movie title.

--- a/src/properties/title/clean.rs
+++ b/src/properties/title/clean.rs
@@ -12,6 +12,27 @@ pub(super) fn clean_episode_title(raw: &str) -> String {
     clean_title_inner(trimmed, false)
 }
 
+/// Clean up a raw title while preserving internal `" - "` (and equivalents)
+/// as literal `" - "` separators, and without stripping trailing `Part N`
+/// keywords.
+///
+/// Use this when the title boundary has already been correctly identified
+/// by upstream logic (e.g., anime bracket releases
+/// `[Group] Show - Sub Part 2 - 13 [tags]`) and the dashes/`Part N` are
+/// genuinely part of the title.
+pub(super) fn clean_title_preserve_dashes(raw: &str) -> String {
+    // Stash structural separators behind sentinels that cannot collide with
+    // any real input character, then run the standard pipeline (with the
+    // trailing-keyword stripper disabled), then restore them.
+    const PLACEHOLDER: &str = "\u{F8FF}DASH\u{F8FF}";
+    let protected = raw
+        .replace(" - ", PLACEHOLDER)
+        .replace("_-_", PLACEHOLDER)
+        .replace(".-.", PLACEHOLDER);
+    let cleaned = clean_title_inner(&protected, false);
+    cleaned.replace(PLACEHOLDER, " - ")
+}
+
 fn clean_title_inner(raw: &str, strip_season_part: bool) -> String {
     let mut s = raw.to_string();
 
@@ -401,6 +422,27 @@ mod tests {
     #[test]
     fn test_strip_paren_year() {
         assert_eq!(clean_title("Movie Name (2005)"), "Movie Name");
+    }
+
+    #[test]
+    fn preserve_dashes_keeps_inner_separator() {
+        // Standard clean_title collapses " - " into a single space.
+        assert_eq!(clean_title("Show - Subtitle"), "Show Subtitle");
+        // The preserve variant keeps the structural separator literal.
+        assert_eq!(
+            clean_title_preserve_dashes("Show - Subtitle"),
+            "Show - Subtitle"
+        );
+        // And it does not strip a trailing "Part N" (which is genuine title content).
+        assert_eq!(
+            clean_title_preserve_dashes("San no Shou Part 2"),
+            "San no Shou Part 2"
+        );
+        // "_-_" and ".-." should normalize to " - " too.
+        assert_eq!(
+            clean_title_preserve_dashes("Show_-_Sub_-_Final"),
+            "Show - Sub - Final"
+        );
     }
 
     // ── is_generic_dir ──────────────────────────────────────────────

--- a/src/properties/title/mod.rs
+++ b/src/properties/title/mod.rs
@@ -17,7 +17,8 @@ use crate::matcher::span::{MatchSpan, Property};
 use crate::tokenizer::TokenStream;
 use crate::zone_map::ZoneMap;
 use clean::{
-    clean_title, is_abbreviated, is_likely_extension, pick_better_casing, strip_extension,
+    clean_title, clean_title_preserve_dashes, is_abbreviated, is_likely_extension,
+    pick_better_casing, strip_extension,
 };
 
 /// Characters we strip from title boundaries.
@@ -168,6 +169,29 @@ pub fn absorb_reclaimable(title: &MatchSpan, matches: &mut Vec<MatchSpan>) {
             return true;
         }
         // Drop if this match falls within the title span.
+        !(m.start >= title.start && m.end <= title.end)
+    });
+}
+
+/// Remove `Part` matches whose byte range falls inside the title span.
+///
+/// In anime bracket releases like
+/// `[Group] Show - San no Shou Part 2 - 13 [tags].mkv`, "Part 2" belongs to
+/// the title rather than being a standalone part property. Once the title
+/// extractor has claimed those bytes, drop the redundant Part match.
+///
+/// Only fires when there's also an `Episode` match present, which is what
+/// distinguishes anime episode files from movie-style "Filename Part 3"
+/// where Part really is the part property.
+pub fn absorb_part_into_title(title: &MatchSpan, matches: &mut Vec<MatchSpan>) {
+    let has_episode = matches.iter().any(|m| m.property == Property::Episode);
+    if !has_episode {
+        return;
+    }
+    matches.retain(|m| {
+        if m.property != Property::Part {
+            return true;
+        }
         !(m.start >= title.start && m.end <= title.end)
     });
 }
@@ -509,9 +533,18 @@ fn extract_after_bracket_group(
 
     let title_start_abs = filename_start + pos;
 
+    // Anime bracket releases follow `[Group] <Title> - <epnum> [tags]`. When an
+    // Episode match exists later in the filename, the " - <epnum>" pair is the
+    // structural boundary; any `Part N` *inside* the title (e.g.
+    // "San no Shou Part 2") must not pre-empt it. See issue #124.
+    let has_episode_after = matches.iter().any(|m| {
+        m.property == Property::Episode && m.start >= title_start_abs && m.start < filename_end
+    });
+
     let next_match = matches
         .iter()
         .filter(|m| m.start >= title_start_abs && m.start < filename_end && !m.is_extension)
+        .filter(|m| !(has_episode_after && m.property == Property::Part))
         .min_by_key(|m| m.start);
 
     let title_end_abs = match next_match {
@@ -537,13 +570,27 @@ fn extract_after_bracket_group(
 
     let raw = &input[title_start_abs..title_end_abs];
 
-    // Apply structural boundary detection (" - ", "--", "(").
-    let title_end_abs = find_title_boundary(raw)
-        .map(|offset| title_start_abs + offset)
-        .unwrap_or(title_end_abs);
+    // When the next match is the Episode (anime `Title - Ep` pattern),
+    // the structural boundary is the " - " right before the episode number.
+    // Trim trailing separators rather than letting find_title_boundary chop at
+    // the *first* in-title " - " — that would lose multi-segment titles like
+    // "Enen no Shouboutai - San no Shou Part 2".
+    let is_anime_episode_boundary = next_match.map(|m| m.property) == Some(Property::Episode);
+    let title_end_abs = if is_anime_episode_boundary {
+        let trimmed = raw.trim_end_matches([' ', '.', '_', '-']);
+        title_start_abs + trimmed.len()
+    } else {
+        find_title_boundary(raw)
+            .map(|offset| title_start_abs + offset)
+            .unwrap_or(title_end_abs)
+    };
     let raw = &input[title_start_abs..title_end_abs];
 
-    let cleaned = clean_title(raw);
+    let cleaned = if is_anime_episode_boundary {
+        clean_title_preserve_dashes(raw)
+    } else {
+        clean_title(raw)
+    };
     if cleaned.is_empty() {
         return None;
     }

--- a/tests/fixtures/episodes.yml
+++ b/tests/fixtures/episodes.yml
@@ -4722,6 +4722,20 @@
   container: mkv
   type: episode
 
+# Issue #124: anime title containing " - " and "Part N" must not be truncated.
+? '[Erai-raws] Enen no Shouboutai - San no Shou Part 2 - 13 [1080p CR WEB-DL AVC AAC][MultiSub][7FF9B816].mkv'
+: release_group: Erai-raws
+  title: Enen no Shouboutai - San no Shou Part 2
+  episode: 13
+  screen_size: 1080p
+  source: Web
+  video_codec: H.264
+  audio_codec: AAC
+  subtitle_language: und
+  crc32: 7FF9B816
+  container: mkv
+  type: episode
+
 ? Mom.S06E08.Jell-O.Shots.and.the.Truth.About.Santa.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb.mkv
 : title: Mom
   season: 6


### PR DESCRIPTION
Closes #124.

## The bug

`[Erai-raws] Enen no Shouboutai - San no Shou Part 2 - 13 [1080p ...].mkv`
parsed as `title: "Enen no Shouboutai"`, `part: 2`, losing the rest of the
title.

## The fix

Two changes in `extract_after_bracket_group`:

1. Skip `Part` matches when picking the structural `next_match` boundary,
   *if* an `Episode` match also exists later (the anime `Title - Ep` signal).
   This lets the raw title extend through "Part 2" up to the real episode
   separator.
2. When the boundary IS the Episode, trim trailing structural separators
   instead of calling `find_title_boundary` \u2014 the latter chops at the
   *first* `" - "` and would still discard "- San no Shou Part 2".

Plus:

- New `clean_title_preserve_dashes` keeps internal `" - "` (and `_-_`,
  `.-.`) literal and skips trailing-keyword stripping.
- New `absorb_part_into_title` removes the redundant `Part` match once it
  has been claimed by the title span. Gated on the presence of an
  `Episode` match so movie-style `Filename Part 3.mkv` is unaffected.

## Verification

- `cargo test` \u2705 (251 unit + all integration tests, including the existing
  `[Erai-raws] Fumetsu no Anata e - 03` fixture)
- `cargo clippy --all-targets -- -D warnings` \u2705
- `cargo fmt --check` \u2705
- New regression fixture added in `tests/fixtures/episodes.yml`.

### Sample outputs

| filename | title | episode | part |
|---|---|---|---|
| Issue #124 case | `Enen no Shouboutai - San no Shou Part 2` | 13 | \u2014 |
| `[Group] Spider-Man - Into the Spider-Verse - 01` | `Spider-Man - Into the Spider-Verse` | 1 | \u2014 |
| `Show.Name.Part.3.HDTV.XViD-Group` | `Show Name` | \u2014 | 3 |
| `The Godfather Part 3.mkv` | `The Godfather` | \u2014 | 3 |
| `Part 3` | `Part 3` | \u2014 | 3 |