### PR TITLE
refactor(part): mark Part reclaimable when Episode present, drop absorb_part_into_title

### DIFF
--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -596,6 +596,13 @@ impl Pipeline {
             pre_zone_count,
             all_matches.len()
         );
+
+        // Step 4b: Mark Part reclaimable when an Episode is present so
+        // the standard title absorption flow handles anime titles
+        // containing "Part N" (see #128 Debt #3, replaces the post-hoc
+        // `absorb_part_into_title` corrector).
+        part::mark_reclaimable_when_episode_present(&mut all_matches);
+
         for m in &all_matches {
             trace!(
                 "  resolved: {:?}={} at {}..{}",
@@ -684,10 +691,10 @@ impl Pipeline {
                 title_match.value, title_match.start, title_match.end
             );
             // Remove reclaimable matches absorbed into the title.
+            // (This is also where Part matches inside anime titles like
+            // "Show Part 2 - 13" get dropped — they were marked reclaimable
+            // in pass1 step 4b when an Episode was present.)
             title::absorb_reclaimable(&title_match, all_matches);
-            // Drop Part matches that ended up inside the title (e.g. anime
-            // titles containing "Part N").
-            title::absorb_part_into_title(&title_match, all_matches);
             all_matches.push(title_match);
         }
         // Film title: when -fNN- marker exists, split franchise from movie title.

--- a/src/properties/part.rs
+++ b/src/properties/part.rs
@@ -177,6 +177,31 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
     matches
 }
 
+/// Mark every `Part` match as reclaimable when an `Episode` match is also
+/// present in the same set.
+///
+/// In anime bracket releases like
+/// `[Group] Show - San no Shou Part 2 - 13 [tags].mkv`, the `Part 2` is
+/// title content rather than a standalone part property. The Episode is
+/// the real structural boundary. Marking Part as reclaimable lets the
+/// existing `title::absorb_reclaimable` step handle absorption uniformly
+/// — no custom post-hoc corrector needed (see #128 D10 tripwire on
+/// post-hoc correctors).
+///
+/// For movie-style files (`Movie.Part.3.mkv`) there is no Episode match,
+/// so Part stays confident and remains the title boundary.
+pub fn mark_reclaimable_when_episode_present(matches: &mut [MatchSpan]) {
+    let has_episode = matches.iter().any(|m| m.property == Property::Episode);
+    if !has_episode {
+        return;
+    }
+    for m in matches.iter_mut() {
+        if m.property == Property::Part {
+            m.reclaimable = true;
+        }
+    }
+}
+
 /// Parse disc number string with ranges and separators.
 /// "2" → [2], "2.3-5" → [2, 3, 4, 5], "2&4-6&8" → [2, 4, 5, 6, 8]
 fn parse_disc_nums(s: &str) -> Vec<u32> {
@@ -238,5 +263,49 @@ mod tests {
             m.iter()
                 .any(|x| x.property == Property::Film && x.value == "21")
         );
+    }
+
+    // ── mark_reclaimable_when_episode_present ────────────────
+
+    #[test]
+    fn mark_reclaimable_no_episode_keeps_part_confident() {
+        // `Movie.Part.3.mkv` style: no Episode → Part stays the title boundary.
+        let mut matches = vec![MatchSpan::new(6, 12, Property::Part, "3")];
+        mark_reclaimable_when_episode_present(&mut matches);
+        assert!(
+            !matches[0].reclaimable,
+            "Part must NOT be reclaimable when no Episode is present"
+        );
+    }
+
+    #[test]
+    fn mark_reclaimable_with_episode_marks_all_parts() {
+        // Anime-style: Episode + Part both present → Part becomes reclaimable
+        // so the title absorber will pull "Part N" into the title span.
+        let mut matches = vec![
+            MatchSpan::new(20, 26, Property::Part, "2"),
+            MatchSpan::new(30, 32, Property::Episode, "13"),
+        ];
+        mark_reclaimable_when_episode_present(&mut matches);
+        assert!(matches[0].reclaimable, "Part should be reclaimable");
+        assert!(
+            !matches[1].reclaimable,
+            "Episode itself must remain confident"
+        );
+    }
+
+    #[test]
+    fn mark_reclaimable_leaves_other_properties_alone() {
+        // Only Part is touched; other properties (Disc, Cd, Film, ...) keep
+        // whatever reclaimable bit they had.
+        let mut matches = vec![
+            MatchSpan::new(0, 5, Property::Disc, "1"),
+            MatchSpan::new(10, 15, Property::Part, "2"),
+            MatchSpan::new(20, 25, Property::Episode, "3"),
+        ];
+        mark_reclaimable_when_episode_present(&mut matches);
+        assert!(!matches[0].reclaimable, "Disc should not be touched");
+        assert!(matches[1].reclaimable, "Part should be reclaimable");
+        assert!(!matches[2].reclaimable, "Episode should not be touched");
     }
 }

--- a/src/properties/title/mod.rs
+++ b/src/properties/title/mod.rs
@@ -173,29 +173,6 @@ pub fn absorb_reclaimable(title: &MatchSpan, matches: &mut Vec<MatchSpan>) {
     });
 }
 
-/// Remove `Part` matches whose byte range falls inside the title span.
-///
-/// In anime bracket releases like
-/// `[Group] Show - San no Shou Part 2 - 13 [tags].mkv`, "Part 2" belongs to
-/// the title rather than being a standalone part property. Once the title
-/// extractor has claimed those bytes, drop the redundant Part match.
-///
-/// Only fires when there's also an `Episode` match present, which is what
-/// distinguishes anime episode files from movie-style "Filename Part 3"
-/// where Part really is the part property.
-pub fn absorb_part_into_title(title: &MatchSpan, matches: &mut Vec<MatchSpan>) {
-    let has_episode = matches.iter().any(|m| m.property == Property::Episode);
-    if !has_episode {
-        return;
-    }
-    matches.retain(|m| {
-        if m.property != Property::Part {
-            return true;
-        }
-        !(m.start >= title.start && m.end <= title.end)
-    });
-}
-
 /// Handle the case where title_end_abs <= filename_start (empty title zone).
 fn handle_empty_title(
     input: &str,


### PR DESCRIPTION
Implements **Debt #3** from #128. Behavior-neutral. Tiny diff.

## What changed

Replace #127's post-hoc `title::absorb_part_into_title` corrector with the principled `reclaimable` mechanism that `MatchSpan` already supports.

### New helper (`properties/part.rs`)

```rust
pub fn mark_reclaimable_when_episode_present(matches: &mut [MatchSpan])
```

Called once at the end of pass1. When any `Episode` match exists, all `Part` matches in the set get marked reclaimable.

### What that gets us for free

- `extract_title`'s `first_match_in_filename` **already** skips reclaimable matches → the title boundary lands on the Episode (or whatever follows Part) instead of on Part itself.
- `absorb_reclaimable` (already running after title extraction) drops any reclaimable match whose bytes fall inside the title span. This is *exactly* what `absorb_part_into_title` was doing manually.

For movie-style files (`Movie.Part.3.mkv`) there is no Episode match, so Part stays confident and remains the title boundary — same behavior as before.

## Why this is better

Per #128 D10 (3rd post-hoc `absorb_*` corrector tripwire): `absorb_part_into_title` was a property-specific post-hoc fix-up that duplicated logic the engine already had. The `reclaimable` system is the generic mechanism for "this match might be absorbed by a stronger structural claim"; `Part` is exactly that case in anime episode contexts.

This is the cleanest possible cleanup of #127's bandaid.

## Diff summary

| File | Δ |
|---|---|
| `src/properties/part.rs` | +47 (helper + 3 unit tests) |
| `src/pipeline/mod.rs` | +6 / -1 (call site at end of pass1) |
| `src/properties/title/mod.rs` | **-22** (delete `absorb_part_into_title` + caller) |

Net: **+79 / -26**. Removed the bandaid, added a real mechanism, gained tests.

## Verified

- All **266** lib unit tests + all integration tests pass unchanged (including the #124 anime-title regression fixture from #127)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- New unit tests in `part.rs` pin the marker behavior:
  - no Episode → Part stays confident
  - Episode present → Part(s) marked reclaimable, Episode untouched
  - other properties (Disc, Cd, Film, ...) never affected

Refs #128. Closes the last bandaid from #127. No public API changes.