### PR TITLE
refactor(title): rename find_title_boundary, document semantics, pin caveat

### DIFF
--- a/src/properties/title/mod.rs
+++ b/src/properties/title/mod.rs
@@ -105,7 +105,7 @@ pub fn extract_title(
     let raw_title = &input[filename_start..title_end_abs];
 
     // Truncate at structural separators (" - ", "--", "(").
-    let title_end_abs = find_title_boundary(raw_title)
+    let title_end_abs = find_first_structural_separator(raw_title)
         .map(|offset| filename_start + offset)
         .unwrap_or(title_end_abs);
     let raw_title = &input[filename_start..title_end_abs];
@@ -282,18 +282,49 @@ fn has_parent_dir(input: &str) -> bool {
     input.contains('/') || input.contains('\\')
 }
 
-/// Find the first structural separator in a raw title span.
+/// Return the byte offset of the **first** structural separator in `raw`,
+/// or `None` if the input has no separator that qualifies (or one occurs
+/// inside the leading 3 bytes — too short to be a real title prefix).
 ///
-/// Returns the byte offset within `raw` where the title should be truncated.
-pub(super) fn find_title_boundary(raw: &str) -> Option<usize> {
-    let min_title_len = 3;
+/// "Structural separators" are the punctuation patterns release-naming
+/// conventions use to split a title from its trailing metadata: `" ("`,
+/// `" - "`, `"--"`, and their `_`/`.`-flanked equivalents.
+///
+/// # Semantics: first wins
+///
+/// **All current callers want this**: a parenthesized year, alt-title,
+/// or `" - "` segment marks the *end* of the canonical title; everything
+/// after it is metadata or a sub-title. So the function returns the
+/// EARLIEST qualifying offset (`min` over per-separator `find` results).
+///
+/// # When NOT to use this
+///
+/// Some inputs legitimately contain `" - "` *inside* the title:
+///
+/// - Anime multi-segment releases:
+///   `[Group] Show - Sub-arc Part 2 - 13 [tags].mkv` — here the first
+///   `" - "` separates two title segments, NOT title from metadata.
+/// - Spider-style hyphenated names that survive `normalize_separators`
+///   are a separate concern (they keep the `-`, no surrounding spaces).
+///
+/// In those cases the caller already knows the boundary structurally
+/// (e.g. an Episode `MatchSpan` after the title) and should compute the
+/// trim point directly rather than asking this function. See
+/// `strategies::AfterBracketGroup` for the canonical example: it skips
+/// `find_first_structural_separator` on the anime-episode branch and
+/// trims trailing separators by hand instead. See also #124 / #127.
+pub(super) fn find_first_structural_separator(raw: &str) -> Option<usize> {
+    /// Minimum length the title prefix must have for a separator to count.
+    /// Guards against pathological inputs like `"a - b"` where `" - "`
+    /// at offset 1 would yield an empty title.
+    const MIN_TITLE_LEN: usize = 3;
 
-    // Find the earliest structural separator across all types.
-    let separators: &[&str] = &[" (", "_(", ".(", " - ", "_-_", ".-.", "--"];
+    // The earliest hit across any separator wins.
+    const SEPARATORS: &[&str] = &[" (", "_(", ".(", " - ", "_-_", ".-.", "--"];
 
-    separators
+    SEPARATORS
         .iter()
-        .filter_map(|sep| raw.find(sep).filter(|&pos| pos >= min_title_len))
+        .filter_map(|sep| raw.find(sep).filter(|&pos| pos >= MIN_TITLE_LEN))
         .min()
 }
 
@@ -310,6 +341,54 @@ mod tests {
 
     fn test_ts(input: &str) -> tokenizer::TokenStream {
         tokenizer::tokenize(input)
+    }
+
+    // ── find_first_structural_separator ──────────────────────────
+    //
+    // These tests pin the "first wins" semantic. They exist so that
+    // anyone tempted to change `min` to `max` (or to add an EpisodeAware
+    // mode without a use case) reads this comment first. See the rustdoc
+    // on the function for the rationale.
+
+    #[test]
+    fn first_separator_wins_picks_earliest_offset() {
+        // " - " at offset 4 wins over " (" at offset 12.
+        assert_eq!(
+            find_first_structural_separator("Show - Subtitle (2020)"),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn first_separator_skips_too_short_prefix() {
+        // "a - b": " - " at offset 1 < MIN_TITLE_LEN, so None.
+        assert_eq!(find_first_structural_separator("a - b"), None);
+        // "abc - d": offset 3 ≥ MIN_TITLE_LEN, accepted.
+        assert_eq!(find_first_structural_separator("abc - d"), Some(3));
+    }
+
+    #[test]
+    fn first_separator_returns_none_on_separatorless_input() {
+        assert_eq!(
+            find_first_structural_separator("PlainTitleNoSeparator"),
+            None
+        );
+    }
+
+    #[test]
+    fn first_separator_caveat_anime_multi_segment() {
+        // KNOWN LIMITATION (documented on the function): for anime-style
+        // multi-segment titles, the FIRST " - " is INSIDE the title, not at
+        // the boundary. Callers facing this case must NOT use this function.
+        // This test pins the limitation so a future "fix" doesn't silently
+        // break `strategies::AfterBracketGroup`'s anime-episode branch.
+        let raw = "Enen no Shouboutai - San no Shou Part 2";
+        assert_eq!(
+            find_first_structural_separator(raw),
+            Some(18),
+            "function returns the first \" - \"; AfterBracketGroup must \
+             bypass it on the anime-episode branch (#124 / #127)"
+        );
     }
 
     #[test]

--- a/src/properties/title/secondary.rs
+++ b/src/properties/title/secondary.rs
@@ -1,7 +1,7 @@
 //! Secondary title extractors — episode title, film title, alternative title.
 
 use super::clean::{clean_episode_title, clean_title};
-use super::find_title_boundary;
+use super::find_first_structural_separator;
 use crate::matcher::span::{MatchSpan, Property};
 use crate::tokenizer::TokenStream;
 
@@ -277,7 +277,7 @@ pub fn extract_film_title(
         return None;
     }
 
-    let title_end = find_title_boundary(&title_cleaned)
+    let title_end = find_first_structural_separator(&title_cleaned)
         .map(|offset| title_cleaned[..offset].trim().to_string())
         .unwrap_or(title_cleaned);
 
@@ -334,7 +334,7 @@ pub fn extract_alternative_titles(
     }
 
     let raw_title = &input[filename_start..title_end_abs];
-    let boundary_offset = match find_title_boundary(raw_title) {
+    let boundary_offset = match find_first_structural_separator(raw_title) {
         Some(offset) => offset,
         None => return Vec::new(),
     };

--- a/src/properties/title/strategies/after_bracket_group.rs
+++ b/src/properties/title/strategies/after_bracket_group.rs
@@ -9,7 +9,7 @@ use crate::FILENAME_SEPS as SEPS;
 use crate::matcher::span::{MatchSpan, Property};
 
 use super::super::clean::{clean_title, clean_title_preserve_dashes};
-use super::super::find_title_boundary;
+use super::super::find_first_structural_separator;
 use super::{StrategyContext, TitleStrategy};
 
 pub(crate) struct AfterBracketGroup;
@@ -85,7 +85,7 @@ impl TitleStrategy for AfterBracketGroup {
 
         // When the next match is the Episode (anime `Title - Ep` pattern),
         // the structural boundary is the " - " right before the episode number.
-        // Trim trailing separators rather than letting find_title_boundary chop at
+        // Trim trailing separators rather than letting find_first_structural_separator chop at
         // the *first* in-title " - " — that would lose multi-segment titles like
         // "Enen no Shouboutai - San no Shou Part 2".
         let is_anime_episode_boundary = next_match.map(|m| m.property) == Some(Property::Episode);
@@ -93,7 +93,7 @@ impl TitleStrategy for AfterBracketGroup {
             let trimmed = raw.trim_end_matches([' ', '.', '_', '-']);
             title_start_abs + trimmed.len()
         } else {
-            find_title_boundary(raw)
+            find_first_structural_separator(raw)
                 .map(|offset| title_start_abs + offset)
                 .unwrap_or(title_end_abs)
         };


### PR DESCRIPTION
Implements **Debt #4** from #128. Pure refactor (rename + docs + tests). Behavior-neutral.

## Problem

`find_title_boundary` had implicit context-dependent semantics: its name suggested *the* boundary but it actually returned the *first* qualifying separator offset — which is right for 4 of 4 current callers but wrong for anime multi-segment titles ("Show - Sub - Ep"), as #127 discovered the hard way.

## What changed

### 1. Rename: intent revealed in name

```diff
- pub(super) fn find_title_boundary(raw: &str) -> Option<usize>
+ pub(super) fn find_first_structural_separator(raw: &str) -> Option<usize>
```

### 2. Expanded rustdoc

The doc now spells out:
- **WHAT** it returns (earliest qualifying offset, with min-prefix guard)
- **WHY** all current callers want it (year/alt-title/` - ` terminates the canonical title)
- **WHEN NOT to use it** (multi-segment titles where the first ` - ` is title-internal; cite #124 / #127 + the canonical bypass in `strategies::AfterBracketGroup`)

### 3. Pinned the caveat with 4 unit tests

```
first_separator_wins_picks_earliest_offset
first_separator_skips_too_short_prefix
first_separator_returns_none_on_separatorless_input
first_separator_caveat_anime_multi_segment   ← documents the limitation
```

The caveat test exists so a future contributor who 'fixes' the function to return the *last* separator (or some smarter heuristic) will trip on this test and read the comment explaining why `AfterBracketGroup` deliberately bypasses it on the anime-episode branch.

### 4. Const-ified internals

`min_title_len` and the separator list become `const` (compile-time constants, not runtime locals).

## Why not a `BoundaryStrategy` enum?

#128 offered two options for Debt #4: (a) add a `First | Last | EpisodeAware` enum, or (b) rename + document.

**All 4 current callers want "First".** Adding an enum with one variant in active use is YAGNI; adding the others speculatively violates D10 (refactor when there's a real second use, not before). The rename + docs + tests give us the clarity benefit at zero abstraction cost. When a real second mode appears, this PR's tests + docs make the enum extension trivial.

## Behavior

**Strictly neutral.** Rename + docs only. Verified by:

- **270** lib unit tests (266 → 270, +4 new) all pass
- All integration tests pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## Diff

| File | Δ |
|---|---|
| `src/properties/title/mod.rs` | +94 (rename, expanded rustdoc, 4 unit tests, const-ifications) |
| `src/properties/title/secondary.rs` | ±3 (rename only, 2 sites) |
| `src/properties/title/strategies/after_bracket_group.rs` | ±3 (rename only, 2 sites) |

## What's left in #128

- **Debt #5** — split `pipeline/mod.rs` (cosmetic, not urgent)

After this PR merges, **4 of 5 debts are addressed** and the title-extraction subsystem is in a much healthier state than before #127.

Refs #128. No public API changes.