### PR TITLE
refactor(pipeline): extract rule_registry module

### DIFF
--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -9,90 +9,24 @@ mod invariance;
 mod matching;
 mod pass2_helpers;
 mod proper_count;
+mod rule_registry;
 pub(crate) mod token_context;
 mod zone_rules;
 
 use crate::hunch_result::HunchResult;
 use crate::matcher::engine;
-use crate::matcher::rule_loader::RuleSet;
 use crate::matcher::span::{MatchSpan, Property};
 use crate::tokenizer::{self, TokenStream};
 use crate::zone_map::{self, ZoneMap};
 use matching::MatchContext;
+use rule_registry::{LegacyMatcherFn, SegmentScope, TomlRule};
 
 use log::{debug, trace};
-use std::sync::LazyLock;
 
 use crate::priority;
-
-// ── TOML rule sets (embedded at compile time) ──────────────────────────────
-
-static VIDEO_CODEC_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/video_codec.toml")));
-static COLOR_DEPTH_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/color_depth.toml")));
-static COUNTRY_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/country.toml")));
-static STREAMING_SERVICE_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/streaming_service.toml")));
-static VIDEO_PROFILE_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/video_profile.toml")));
-static EPISODE_DETAILS_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/episode_details.toml")));
-static ANIME_BONUS_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/anime_bonus.toml")));
-static EDITION_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/edition.toml")));
-static AUDIO_CODEC_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/audio_codec.toml")));
-static AUDIO_PROFILE_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/audio_profile.toml")));
-static AUDIO_CHANNELS_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/audio_channels.toml")));
-static OTHER_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/other.toml")));
-static OTHER_POSITIONAL_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/other_positional.toml")));
-static VIDEO_API_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/video_api.toml")));
-static SOURCE_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/source.toml")));
-static SCREEN_SIZE_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/screen_size.toml")));
-static CONTAINER_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/container.toml")));
-static FRAME_RATE_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/frame_rate.toml")));
-static LANGUAGE_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/language.toml")));
-static SUBTITLE_LANGUAGE_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/subtitle_language.toml")));
-static EPISODE_FORMAT_RULES: LazyLock<RuleSet> =
-    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/episode_format.toml")));
-
-// ── Legacy matchers (not yet migrated to TOML) ─────────────────────────────
-
+use crate::properties::part;
+use crate::properties::release_group;
 use crate::properties::title;
-use crate::properties::{
-    aspect_ratio, bit_rate, bonus, crc32, date, episode_count, episodes, language, part,
-    release_group, size, subtitle_language, uuid, version, website, year,
-};
-
-/// A legacy matcher function: takes raw input, returns property matches.
-type LegacyMatcherFn = fn(&str) -> Vec<MatchSpan>;
-
-/// Whether a TOML rule set should match tokens from directory segments.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SegmentScope {
-    /// Match only filename tokens. Use for tech properties (source, codec, etc.)
-    /// where directory names like "TV Shows" or "HD" would cause false positives.
-    FilenameOnly,
-    /// Match tokens from all path segments. Directory matches receive a priority
-    /// penalty (`DIR_PRIORITY_PENALTY`) so filename matches always win in conflicts.
-    /// Use for contextual properties (season, year, language) where directories
-    /// carry genuine metadata ("Season 01/", "(2008)/", "VF/").
-    AllSegments,
-}
 
 /// The two-pass parsing pipeline.
 ///
@@ -104,9 +38,9 @@ enum SegmentScope {
 /// [`hunch`](crate::hunch) / [`hunch_with_context`](crate::hunch_with_context)
 /// for convenience.
 pub struct Pipeline {
-    /// TOML-driven rule sets: (rules, property, priority, segment_scope).
-    toml_rules: Vec<(&'static LazyLock<RuleSet>, Property, i32, SegmentScope)>,
-    /// Legacy matchers that run against raw input (to be migrated).
+    /// TOML-driven rule sets registered in [`rule_registry::build_toml_rules`].
+    toml_rules: Vec<TomlRule>,
+    /// Legacy matchers registered in [`rule_registry::build_legacy_matchers`].
     legacy_matchers: Vec<LegacyMatcherFn>,
 }
 
@@ -123,188 +57,9 @@ impl Pipeline {
     /// Construct a `Pipeline` directly when you want to reuse the same
     /// configuration across many inputs.
     pub fn new() -> Self {
-        let toml_rules: Vec<(&'static LazyLock<RuleSet>, Property, i32, SegmentScope)> = vec![
-            // Tech properties: unambiguous tokens safe for all segments.
-            // These were previously scanned across full paths by legacy matchers.
-            // Tokens like XviD, x264, 720p, AAC are unambiguous in directory names.
-            (
-                &VIDEO_CODEC_RULES,
-                Property::VideoCodec,
-                priority::DEFAULT,
-                SegmentScope::AllSegments,
-            ),
-            (
-                &COLOR_DEPTH_RULES,
-                Property::ColorDepth,
-                priority::DEFAULT,
-                SegmentScope::AllSegments,
-            ),
-            (
-                &AUDIO_CODEC_RULES,
-                Property::AudioCodec,
-                priority::DEFAULT,
-                SegmentScope::AllSegments,
-            ),
-            (
-                &AUDIO_PROFILE_RULES,
-                Property::AudioProfile,
-                priority::VOCABULARY,
-                SegmentScope::AllSegments,
-            ),
-            (
-                &AUDIO_CHANNELS_RULES,
-                Property::AudioChannels,
-                priority::HEURISTIC,
-                SegmentScope::AllSegments,
-            ),
-            (
-                &FRAME_RATE_RULES,
-                Property::FrameRate,
-                priority::DEFAULT,
-                SegmentScope::AllSegments,
-            ),
-            (
-                &SCREEN_SIZE_RULES,
-                Property::ScreenSize,
-                priority::DEFAULT,
-                SegmentScope::AllSegments,
-            ),
-            // Tech properties: ambiguous tokens, filename only.
-            // Short tokens (HD, DV, TV, TS) would false-positive in dir names.
-            (
-                &STREAMING_SERVICE_RULES,
-                Property::StreamingService,
-                priority::VOCABULARY,
-                SegmentScope::FilenameOnly,
-            ),
-            (
-                &VIDEO_PROFILE_RULES,
-                Property::VideoProfile,
-                priority::POSITIONAL,
-                SegmentScope::FilenameOnly,
-            ),
-            (
-                &EPISODE_DETAILS_RULES,
-                Property::EpisodeDetails,
-                priority::HEURISTIC,
-                SegmentScope::FilenameOnly,
-            ),
-            (
-                &ANIME_BONUS_RULES,
-                Property::EpisodeDetails,
-                priority::HEURISTIC,
-                SegmentScope::FilenameOnly,
-            ),
-            (
-                &EPISODE_FORMAT_RULES,
-                Property::EpisodeFormat,
-                priority::HEURISTIC,
-                SegmentScope::FilenameOnly,
-            ),
-            (
-                &EDITION_RULES,
-                Property::Edition,
-                priority::DEFAULT,
-                SegmentScope::AllSegments,
-            ),
-            // Other: AllSegments with dir priority penalty.
-            // Per-directory zone maps filter false positives in title zones.
-            (
-                &OTHER_RULES,
-                Property::Other,
-                priority::DEFAULT,
-                SegmentScope::AllSegments,
-            ),
-            (
-                &OTHER_POSITIONAL_RULES,
-                Property::Other,
-                priority::POSITIONAL,
-                SegmentScope::FilenameOnly,
-            ),
-            (
-                &VIDEO_API_RULES,
-                Property::VideoApi,
-                priority::DEFAULT,
-                SegmentScope::FilenameOnly,
-            ),
-            (
-                &SOURCE_RULES,
-                Property::Source,
-                priority::DEFAULT,
-                SegmentScope::AllSegments,
-            ),
-            (
-                &CONTAINER_RULES,
-                Property::Container,
-                priority::STRUCTURAL,
-                SegmentScope::FilenameOnly,
-            ),
-            // Contextual properties: match all segments (dirs carry real metadata)
-            // NOTE: Language, SubtitleLanguage, and Country are kept FilenameOnly
-            // for now because directory names contain title words that false-match
-            // language patterns (e.g., "Por" → Portuguese, "Fr" → French).
-            // Directory-level language/season/year extraction is handled by the
-            // legacy algorithmic matchers (language.rs, episodes.rs, year.rs)
-            // which run on the raw input string.
-            // When those legacy matchers are retired, we'll need segment-aware
-            // zone rules to filter directory title words from language matches.
-            (
-                &COUNTRY_RULES,
-                Property::Country,
-                priority::POSITIONAL,
-                SegmentScope::FilenameOnly,
-            ),
-            (
-                &LANGUAGE_RULES,
-                Property::Language,
-                priority::HEURISTIC,
-                SegmentScope::AllSegments,
-            ),
-            (
-                &SUBTITLE_LANGUAGE_RULES,
-                Property::SubtitleLanguage,
-                priority::HEURISTIC,
-                SegmentScope::FilenameOnly,
-            ),
-        ];
-
-        // Legacy matchers — algorithmic patterns that need Rust.
-        //
-        // **Algorithmic** (genuinely need Rust — branching, state, or position):
-        //   episodes, date, language, subtitle_language, episode_count,
-        //   release_group (Pass 2), part, website, aspect_ratio, bit_rate
-        //
-        // **Migration candidates** (could be expressed as TOML rules):
-        //   crc32     — single regex, bracket context expressible via zone_scope
-        //   uuid      — two regex patterns, no boundary logic beyond TOML's
-        //   version   — two regexes + CharClass boundaries (needs D8 extension)
-        //   size      — regex + unit parse (needs value normalization in TOML)
-        //   bonus     — regex + boundary check (borderline)
-        //
-        // NOTE: source is now fully TOML (source.toml with side_effects).
-        // audio_profile is handled entirely by audio_profile.toml.
-        let legacy_matchers: Vec<LegacyMatcherFn> = vec![
-            aspect_ratio::find_matches,
-            year::find_matches,
-            date::find_matches,
-            episodes::find_matches,
-            episode_count::find_matches,
-            language::find_matches,
-            subtitle_language::find_matches,
-            crc32::find_matches,
-            uuid::find_matches,
-            website::find_matches,
-            size::find_matches,
-            bit_rate::find_matches,
-            part::find_matches,
-            bonus::find_matches,
-            version::find_matches,
-            // NOTE: release_group is NOT here — it runs in Pass 2 (post-resolution).
-        ];
-
         Self {
-            toml_rules,
-            legacy_matchers,
+            toml_rules: rule_registry::build_toml_rules(),
+            legacy_matchers: rule_registry::build_legacy_matchers(),
         }
     }
 
@@ -786,20 +541,20 @@ impl Pipeline {
         // Each rule set declares its SegmentScope:
         //   FilenameOnly  → skip directory segments entirely
         //   AllSegments   → match dirs too, but with a priority penalty
-        for (rule_set, property, priority, scope) in &self.toml_rules {
+        for rule in &self.toml_rules {
             for (seg_idx, segment) in token_stream.segments.iter().enumerate() {
                 let is_dir = segment.kind == tokenizer::SegmentKind::Directory;
 
                 // Skip directory segments for filename-only rules.
-                if is_dir && *scope == SegmentScope::FilenameOnly {
+                if is_dir && rule.scope == SegmentScope::FilenameOnly {
                     continue;
                 }
 
                 // Directory matches get a priority penalty so filename wins in conflicts.
                 let effective_priority = if is_dir {
-                    *priority + priority::DIR_PENALTY
+                    rule.priority + priority::DIR_PENALTY
                 } else {
-                    *priority
+                    rule.priority
                 };
 
                 // Use per-directory zone map for directory segments.
@@ -817,8 +572,8 @@ impl Pipeline {
                     &MatchContext {
                         input,
                         tokens,
-                        rule_set,
-                        property: *property,
+                        rule_set: rule.rules,
+                        property: rule.property,
                         priority: effective_priority,
                         zone_map,
                         dir_zone,
@@ -915,17 +670,6 @@ fn is_path_dir_name(input: &str, title: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_toml_rules_load() {
-        // Smoke test: all TOML rule sets parse and have entries.
-        assert!(VIDEO_CODEC_RULES.exact_count() >= 10);
-        assert!(COLOR_DEPTH_RULES.exact_count() >= 3);
-        assert!(STREAMING_SERVICE_RULES.exact_count() >= 10);
-        assert!(VIDEO_PROFILE_RULES.exact_count() >= 2);
-        assert!(EPISODE_DETAILS_RULES.exact_count() >= 4);
-        assert!(EDITION_RULES.exact_count() >= 10);
-    }
 
     #[test]
     fn test_is_path_dir_name() {

--- a/src/pipeline/rule_registry.rs
+++ b/src/pipeline/rule_registry.rs
@@ -1,0 +1,240 @@
+//! Compile-time registration of all matcher rule sets and legacy matchers.
+//!
+//! This module is a **declarative configuration table**: it lists every
+//! TOML-driven rule set and every legacy matcher function the pipeline
+//! runs in Pass 1. The orchestration logic lives in [`super::Pipeline`];
+//! this module exists so that adding or tweaking a rule is a one-line
+//! diff in a flat list rather than a hunt through a 970-line orchestrator.
+//!
+//! ## Adding a rule set
+//!
+//! 1. Add a TOML file under `rules/`.
+//! 2. Add a `static FOO_RULES: LazyLock<RuleSet> = ...;` below.
+//! 3. Add one [`TomlRule`] entry to the vec returned by
+//!    [`build_toml_rules`].
+//!
+//! That's the entire surface area.
+//!
+//! ## Adding a legacy matcher
+//!
+//! Add the function pointer to [`build_legacy_matchers`]. The migration
+//! goal is to convert these to TOML over time; until then, the table here
+//! makes the inventory explicit.
+
+use std::sync::LazyLock;
+
+use crate::matcher::rule_loader::RuleSet;
+use crate::matcher::span::{MatchSpan, Property};
+use crate::priority;
+use crate::properties::{
+    aspect_ratio, bit_rate, bonus, crc32, date, episode_count, episodes, language, part, size,
+    subtitle_language, uuid, version, website, year,
+};
+
+// ── TOML rule sets (embedded at compile time) ──────────────────────────────
+
+pub(super) static VIDEO_CODEC_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/video_codec.toml")));
+pub(super) static COLOR_DEPTH_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/color_depth.toml")));
+pub(super) static COUNTRY_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/country.toml")));
+pub(super) static STREAMING_SERVICE_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/streaming_service.toml")));
+pub(super) static VIDEO_PROFILE_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/video_profile.toml")));
+pub(super) static EPISODE_DETAILS_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/episode_details.toml")));
+pub(super) static ANIME_BONUS_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/anime_bonus.toml")));
+pub(super) static EDITION_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/edition.toml")));
+pub(super) static AUDIO_CODEC_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/audio_codec.toml")));
+pub(super) static AUDIO_PROFILE_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/audio_profile.toml")));
+pub(super) static AUDIO_CHANNELS_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/audio_channels.toml")));
+pub(super) static OTHER_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/other.toml")));
+pub(super) static OTHER_POSITIONAL_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/other_positional.toml")));
+pub(super) static VIDEO_API_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/video_api.toml")));
+pub(super) static SOURCE_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/source.toml")));
+pub(super) static SCREEN_SIZE_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/screen_size.toml")));
+pub(super) static CONTAINER_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/container.toml")));
+pub(super) static FRAME_RATE_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/frame_rate.toml")));
+pub(super) static LANGUAGE_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/language.toml")));
+pub(super) static SUBTITLE_LANGUAGE_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/subtitle_language.toml")));
+pub(super) static EPISODE_FORMAT_RULES: LazyLock<RuleSet> =
+    LazyLock::new(|| RuleSet::from_toml(include_str!("../../rules/episode_format.toml")));
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+/// Whether a TOML rule set should match tokens from directory segments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SegmentScope {
+    /// Match only filename tokens. Use for tech properties (source, codec, etc.)
+    /// where directory names like "TV Shows" or "HD" would cause false positives.
+    FilenameOnly,
+    /// Match tokens from all path segments. Directory matches receive a priority
+    /// penalty (`DIR_PRIORITY_PENALTY`) so filename matches always win in conflicts.
+    /// Use for contextual properties (season, year, language) where directories
+    /// carry genuine metadata ("Season 01/", "(2008)/", "VF/").
+    AllSegments,
+}
+
+/// A legacy matcher function: takes raw input, returns property matches.
+///
+/// These are the matchers that have not yet been migrated to TOML. The
+/// long-term goal is to delete this type and the corresponding registry
+/// list once every property has a TOML rule set.
+pub(super) type LegacyMatcherFn = fn(&str) -> Vec<MatchSpan>;
+
+/// One TOML rule set's pipeline registration record.
+///
+/// Replaces the previous `(rules, property, priority, scope)` 4-tuple
+/// with named fields so the registration table reads as data, not as a
+/// puzzle.
+pub(super) struct TomlRule {
+    pub rules: &'static LazyLock<RuleSet>,
+    pub property: Property,
+    pub priority: i32,
+    pub scope: SegmentScope,
+}
+
+// ── Registry tables ────────────────────────────────────────────────────────
+
+// Local shorthands keep the tables one entry per line. `rustfmt` normally
+// wants to split a struct literal across lines; the `#[rustfmt::skip]` on
+// each table keeps them dense and grep-friendly.
+use SegmentScope::{AllSegments, FilenameOnly};
+use priority::{DEFAULT, HEURISTIC, POSITIONAL, STRUCTURAL, VOCABULARY};
+
+const fn r(
+    rules: &'static LazyLock<RuleSet>,
+    property: Property,
+    priority: i32,
+    scope: SegmentScope,
+) -> TomlRule {
+    TomlRule {
+        rules,
+        property,
+        priority,
+        scope,
+    }
+}
+
+/// All TOML-driven rule sets, in registration order.
+///
+/// **Order does not affect correctness** — Pass 1 conflict resolution
+/// resolves overlaps by priority, not by registration order. The grouping
+/// below is purely for human navigation.
+#[rustfmt::skip]
+pub(super) fn build_toml_rules() -> Vec<TomlRule> {
+    use Property::*;
+    vec![
+        // Tech properties: unambiguous tokens, safe across all path segments.
+        // (XviD, x264, 720p, AAC don't false-positive in directory names.)
+        r(&VIDEO_CODEC_RULES,       VideoCodec,       DEFAULT,    AllSegments),
+        r(&COLOR_DEPTH_RULES,       ColorDepth,       DEFAULT,    AllSegments),
+        r(&AUDIO_CODEC_RULES,       AudioCodec,       DEFAULT,    AllSegments),
+        r(&AUDIO_PROFILE_RULES,     AudioProfile,     VOCABULARY, AllSegments),
+        r(&AUDIO_CHANNELS_RULES,    AudioChannels,    HEURISTIC,  AllSegments),
+        r(&FRAME_RATE_RULES,        FrameRate,        DEFAULT,    AllSegments),
+        r(&SCREEN_SIZE_RULES,       ScreenSize,       DEFAULT,    AllSegments),
+
+        // Tech properties: ambiguous tokens, filename only.
+        // Short tokens (HD, DV, TV, TS) would false-positive in dir names.
+        r(&STREAMING_SERVICE_RULES, StreamingService, VOCABULARY, FilenameOnly),
+        r(&VIDEO_PROFILE_RULES,     VideoProfile,     POSITIONAL, FilenameOnly),
+        r(&EPISODE_DETAILS_RULES,   EpisodeDetails,   HEURISTIC,  FilenameOnly),
+        r(&ANIME_BONUS_RULES,       EpisodeDetails,   HEURISTIC,  FilenameOnly),
+        r(&EPISODE_FORMAT_RULES,    EpisodeFormat,    HEURISTIC,  FilenameOnly),
+
+        r(&EDITION_RULES,           Edition,          DEFAULT,    AllSegments),
+
+        // Other: AllSegments with dir priority penalty.
+        // Per-directory zone maps filter false positives in title zones.
+        r(&OTHER_RULES,             Other,            DEFAULT,    AllSegments),
+        r(&OTHER_POSITIONAL_RULES,  Other,            POSITIONAL, FilenameOnly),
+
+        r(&VIDEO_API_RULES,         VideoApi,         DEFAULT,    FilenameOnly),
+        r(&SOURCE_RULES,            Source,           DEFAULT,    AllSegments),
+        r(&CONTAINER_RULES,         Container,        STRUCTURAL, FilenameOnly),
+
+        // Contextual properties: match all segments (dirs carry real metadata).
+        // NOTE: Language, SubtitleLanguage, and Country are kept FilenameOnly
+        // (or HEURISTIC) because directory names contain title words that
+        // false-match language patterns (e.g. "Por" → Portuguese, "Fr" → French).
+        // Directory-level language/season/year extraction is handled by the
+        // legacy algorithmic matchers (language.rs, episodes.rs, year.rs).
+        // When those legacy matchers are retired, segment-aware zone rules
+        // will need to filter directory title words from language matches.
+        r(&COUNTRY_RULES,           Country,          POSITIONAL, FilenameOnly),
+        r(&LANGUAGE_RULES,          Language,         HEURISTIC,  AllSegments),
+        r(&SUBTITLE_LANGUAGE_RULES, SubtitleLanguage, HEURISTIC,  FilenameOnly),
+    ]
+}
+
+/// All legacy (non-TOML) matchers, in registration order.
+///
+/// `release_group` is intentionally absent — it runs in Pass 2 because it
+/// needs the resolved tech matches as anchors.
+#[rustfmt::skip]
+pub(super) fn build_legacy_matchers() -> Vec<LegacyMatcherFn> {
+    vec![
+        aspect_ratio::find_matches,
+        year::find_matches,
+        date::find_matches,
+        episodes::find_matches,
+        episode_count::find_matches,
+        language::find_matches,
+        subtitle_language::find_matches,
+        crc32::find_matches,
+        uuid::find_matches,
+        website::find_matches,
+        size::find_matches,
+        bit_rate::find_matches,
+        part::find_matches,
+        bonus::find_matches,
+        version::find_matches,
+        // NOTE: release_group is NOT here — it runs in Pass 2 (post-resolution).
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke test: every TOML rule set parses and contains at least the
+    /// minimum number of entries we'd expect after a successful build.
+    /// Catches "I emptied the rules file by accident" regressions.
+    #[test]
+    fn toml_rule_sets_parse_and_have_entries() {
+        assert!(VIDEO_CODEC_RULES.exact_count() >= 10);
+        assert!(COLOR_DEPTH_RULES.exact_count() >= 3);
+        assert!(STREAMING_SERVICE_RULES.exact_count() >= 10);
+        assert!(VIDEO_PROFILE_RULES.exact_count() >= 2);
+        assert!(EPISODE_DETAILS_RULES.exact_count() >= 4);
+        assert!(EDITION_RULES.exact_count() >= 10);
+    }
+
+    /// Sanity check: the registry tables build without panicking and have
+    /// non-trivial size. Catches accidental `vec![]` edits.
+    #[test]
+    fn registry_tables_are_populated() {
+        assert!(build_toml_rules().len() >= 20, "TOML rule registry shrank?");
+        assert!(
+            build_legacy_matchers().len() >= 10,
+            "legacy matcher registry shrank?"
+        );
+    }
+}

--- a/src/properties/title/mod.rs
+++ b/src/properties/title/mod.rs
@@ -105,7 +105,7 @@ pub fn extract_title(
     let raw_title = &input[filename_start..title_end_abs];
 
     // Truncate at structural separators (" - ", "--", "(").
-    let title_end_abs = find_title_boundary(raw_title)
+    let title_end_abs = find_first_structural_separator(raw_title)
         .map(|offset| filename_start + offset)
         .unwrap_or(title_end_abs);
     let raw_title = &input[filename_start..title_end_abs];
@@ -282,18 +282,49 @@ fn has_parent_dir(input: &str) -> bool {
     input.contains('/') || input.contains('\\')
 }
 
-/// Find the first structural separator in a raw title span.
+/// Return the byte offset of the **first** structural separator in `raw`,
+/// or `None` if the input has no separator that qualifies (or one occurs
+/// inside the leading 3 bytes — too short to be a real title prefix).
 ///
-/// Returns the byte offset within `raw` where the title should be truncated.
-pub(super) fn find_title_boundary(raw: &str) -> Option<usize> {
-    let min_title_len = 3;
+/// "Structural separators" are the punctuation patterns release-naming
+/// conventions use to split a title from its trailing metadata: `" ("`,
+/// `" - "`, `"--"`, and their `_`/`.`-flanked equivalents.
+///
+/// # Semantics: first wins
+///
+/// **All current callers want this**: a parenthesized year, alt-title,
+/// or `" - "` segment marks the *end* of the canonical title; everything
+/// after it is metadata or a sub-title. So the function returns the
+/// EARLIEST qualifying offset (`min` over per-separator `find` results).
+///
+/// # When NOT to use this
+///
+/// Some inputs legitimately contain `" - "` *inside* the title:
+///
+/// - Anime multi-segment releases:
+///   `[Group] Show - Sub-arc Part 2 - 13 [tags].mkv` — here the first
+///   `" - "` separates two title segments, NOT title from metadata.
+/// - Spider-style hyphenated names that survive `normalize_separators`
+///   are a separate concern (they keep the `-`, no surrounding spaces).
+///
+/// In those cases the caller already knows the boundary structurally
+/// (e.g. an Episode `MatchSpan` after the title) and should compute the
+/// trim point directly rather than asking this function. See
+/// `strategies::AfterBracketGroup` for the canonical example: it skips
+/// `find_first_structural_separator` on the anime-episode branch and
+/// trims trailing separators by hand instead. See also #124 / #127.
+pub(super) fn find_first_structural_separator(raw: &str) -> Option<usize> {
+    /// Minimum length the title prefix must have for a separator to count.
+    /// Guards against pathological inputs like `"a - b"` where `" - "`
+    /// at offset 1 would yield an empty title.
+    const MIN_TITLE_LEN: usize = 3;
 
-    // Find the earliest structural separator across all types.
-    let separators: &[&str] = &[" (", "_(", ".(", " - ", "_-_", ".-.", "--"];
+    // The earliest hit across any separator wins.
+    const SEPARATORS: &[&str] = &[" (", "_(", ".(", " - ", "_-_", ".-.", "--"];
 
-    separators
+    SEPARATORS
         .iter()
-        .filter_map(|sep| raw.find(sep).filter(|&pos| pos >= min_title_len))
+        .filter_map(|sep| raw.find(sep).filter(|&pos| pos >= MIN_TITLE_LEN))
         .min()
 }
 
@@ -310,6 +341,54 @@ mod tests {
 
     fn test_ts(input: &str) -> tokenizer::TokenStream {
         tokenizer::tokenize(input)
+    }
+
+    // ── find_first_structural_separator ──────────────────────────
+    //
+    // These tests pin the "first wins" semantic. They exist so that
+    // anyone tempted to change `min` to `max` (or to add an EpisodeAware
+    // mode without a use case) reads this comment first. See the rustdoc
+    // on the function for the rationale.
+
+    #[test]
+    fn first_separator_wins_picks_earliest_offset() {
+        // " - " at offset 4 wins over " (" at offset 12.
+        assert_eq!(
+            find_first_structural_separator("Show - Subtitle (2020)"),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn first_separator_skips_too_short_prefix() {
+        // "a - b": " - " at offset 1 < MIN_TITLE_LEN, so None.
+        assert_eq!(find_first_structural_separator("a - b"), None);
+        // "abc - d": offset 3 ≥ MIN_TITLE_LEN, accepted.
+        assert_eq!(find_first_structural_separator("abc - d"), Some(3));
+    }
+
+    #[test]
+    fn first_separator_returns_none_on_separatorless_input() {
+        assert_eq!(
+            find_first_structural_separator("PlainTitleNoSeparator"),
+            None
+        );
+    }
+
+    #[test]
+    fn first_separator_caveat_anime_multi_segment() {
+        // KNOWN LIMITATION (documented on the function): for anime-style
+        // multi-segment titles, the FIRST " - " is INSIDE the title, not at
+        // the boundary. Callers facing this case must NOT use this function.
+        // This test pins the limitation so a future "fix" doesn't silently
+        // break `strategies::AfterBracketGroup`'s anime-episode branch.
+        let raw = "Enen no Shouboutai - San no Shou Part 2";
+        assert_eq!(
+            find_first_structural_separator(raw),
+            Some(18),
+            "function returns the first \" - \"; AfterBracketGroup must \
+             bypass it on the anime-episode branch (#124 / #127)"
+        );
     }
 
     #[test]

--- a/src/properties/title/secondary.rs
+++ b/src/properties/title/secondary.rs
@@ -1,7 +1,7 @@
 //! Secondary title extractors — episode title, film title, alternative title.
 
 use super::clean::{clean_episode_title, clean_title};
-use super::find_title_boundary;
+use super::find_first_structural_separator;
 use crate::matcher::span::{MatchSpan, Property};
 use crate::tokenizer::TokenStream;
 
@@ -277,7 +277,7 @@ pub fn extract_film_title(
         return None;
     }
 
-    let title_end = find_title_boundary(&title_cleaned)
+    let title_end = find_first_structural_separator(&title_cleaned)
         .map(|offset| title_cleaned[..offset].trim().to_string())
         .unwrap_or(title_cleaned);
 
@@ -334,7 +334,7 @@ pub fn extract_alternative_titles(
     }
 
     let raw_title = &input[filename_start..title_end_abs];
-    let boundary_offset = match find_title_boundary(raw_title) {
+    let boundary_offset = match find_first_structural_separator(raw_title) {
         Some(offset) => offset,
         None => return Vec::new(),
     };

--- a/src/properties/title/strategies/after_bracket_group.rs
+++ b/src/properties/title/strategies/after_bracket_group.rs
@@ -9,7 +9,7 @@ use crate::FILENAME_SEPS as SEPS;
 use crate::matcher::span::{MatchSpan, Property};
 
 use super::super::clean::{clean_title, clean_title_preserve_dashes};
-use super::super::find_title_boundary;
+use super::super::find_first_structural_separator;
 use super::{StrategyContext, TitleStrategy};
 
 pub(crate) struct AfterBracketGroup;
@@ -85,7 +85,7 @@ impl TitleStrategy for AfterBracketGroup {
 
         // When the next match is the Episode (anime `Title - Ep` pattern),
         // the structural boundary is the " - " right before the episode number.
-        // Trim trailing separators rather than letting find_title_boundary chop at
+        // Trim trailing separators rather than letting find_first_structural_separator chop at
         // the *first* in-title " - " — that would lose multi-segment titles like
         // "Enen no Shouboutai - San no Shou Part 2".
         let is_anime_episode_boundary = next_match.map(|m| m.property) == Some(Property::Episode);
@@ -93,7 +93,7 @@ impl TitleStrategy for AfterBracketGroup {
             let trimmed = raw.trim_end_matches([' ', '.', '_', '-']);
             title_start_abs + trimmed.len()
         } else {
-            find_title_boundary(raw)
+            find_first_structural_separator(raw)
                 .map(|offset| title_start_abs + offset)
                 .unwrap_or(title_end_abs)
         };


### PR DESCRIPTION
Implements **Debt #5** from #128 — the last item. Pure refactor, behavior-neutral.

## Verdict

You asked me to peek and decide whether splitting `pipeline/mod.rs` was worth it or pure cosmetic shuffling. **It's worth it.** The 967-line file mixed three concerns:

1. ~40 lines of compile-time TOML `LazyLock<RuleSet>` statics
2. A **190-line** verbose registration table (one 6-line tuple per entry × 21 entries)
3. Pipeline orchestration (`run` / `pass1` / `pass2` / `match_all`)

Concerns 1 and 2 are pure data; concern 3 is logic. They now live in separate files with clear responsibilities.

## What moved

New `src/pipeline/rule_registry.rs` (240 lines, ~50 of which are docs + tests) owns:

- All 21 `LazyLock<RuleSet>` statics for embedded TOML files
- The `SegmentScope` enum + `LegacyMatcherFn` type alias
- A new named **`TomlRule`** struct (replaces the opaque `(rules, property, priority, scope)` 4-tuple)
- `build_toml_rules()` and `build_legacy_matchers()` registration tables
- The smoke test (renamed `toml_rule_sets_parse_and_have_entries`) plus a new `registry_tables_are_populated` guard

## What changed in mod.rs

- **967 → 711 lines** (−256, all pure config)
- `Pipeline::new()` body shrinks from ~190 lines to **6**:

  ```rust
  pub fn new() -> Self {
      Self {
          toml_rules: rule_registry::build_toml_rules(),
          legacy_matchers: rule_registry::build_legacy_matchers(),
      }
  }
  ```

- `match_all` destructuring switches from positional tuple to named fields:

  ```diff
  - for (rule_set, property, priority, scope) in &self.toml_rules {
  + for rule in &self.toml_rules {
       …
  -     if is_dir && *scope == SegmentScope::FilenameOnly { continue; }
  +     if is_dir && rule.scope == SegmentScope::FilenameOnly { continue; }
  ```

## The registration table is now READABLE

**Before** (one entry took 6 lines):

```rust
(
    &VIDEO_CODEC_RULES,
    Property::VideoCodec,
    priority::DEFAULT,
    SegmentScope::AllSegments,
),
```

**After** (one entry per line, columns aligned via `#[rustfmt::skip]`):

```rust
r(&VIDEO_CODEC_RULES,       VideoCodec,       DEFAULT,    AllSegments),
r(&COLOR_DEPTH_RULES,       ColorDepth,       DEFAULT,    AllSegments),
r(&AUDIO_CODEC_RULES,       AudioCodec,       DEFAULT,    AllSegments),
…
```

21 rules now fit in **25 visual lines** instead of 190. Comparing two rules visually is trivial; before, it was a scroll-and-pattern-match exercise.

## Why this isn't split-for-split's-sake

The system prompt says *"don't split purely to hit a line count if it hurts cohesion."* This split **improves** cohesion, not just line counts:

- Pipeline orchestration doesn't change when a TOML rule is added
- Rule registration doesn't depend on any orchestration internals
- The files are now grep-friendly: *"where do I add a rule?"* → `rule_registry.rs`; *"how does the pipeline run?"* → `mod.rs`

## Behavior

**Strictly neutral.** Verified by:

- **271** lib unit tests (270 → 271, +1 new registry sanity test) all pass
- All integration tests pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- All 21 `TomlRule` entries **hand-verified** tuple-for-tuple against the original (`Property`, `priority`, `scope`)

## Diff summary

| File | Δ |
|---|---|
| `src/pipeline/mod.rs` | **−256** (removed statics + 190-line table; `new()` is now 6 lines) |
| `src/pipeline/rule_registry.rs` | **+240** (new file: statics + types + dense table + tests) |

Net **−16 lines** for the project even after adding a struct, constructor helper, expanded module docs, and a new sanity test — the verbose tuple syntax was that wasteful.

## Closes the architectural review

**All 5 documented debts in #128 are now addressed.**

| Debt | Status |
|---|---|
| #1 — 5 ad-hoc `extract_*` strategies | ✅ #132 |
| #2 — monolithic `clean_title` | ✅ #130 |
| #3 — `absorb_part_into_title` post-hoc corrector | ✅ #131 |
| #4 — `find_title_boundary` implicit semantics | ✅ #133 |
| #5 — split `pipeline/mod.rs` | ✅ this PR |

Closes #128.