### PR TITLE
feat(cli): bound walk_dir recursion depth and skip symlinks [PR-B]

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -357,6 +357,15 @@ fn list_media_files(dir: &Path) -> Vec<PathBuf> {
     files
 }
 
+/// Maximum recursion depth for [`walk_dir`] / [`dir_contains_media`].
+///
+/// Real-world media libraries are very rarely deeper than 6 levels
+/// (`Movies/Genre/Year/Title/Disc/file.mkv`). 32 leaves a generous safety
+/// margin while bounding worst-case stack usage and preventing
+/// pathological-input DoS (e.g., a directory tree built deliberately
+/// to exhaust stack on traversal).
+const MAX_WALK_DEPTH: usize = 32;
+
 /// List media files in a directory tree (recursive).
 fn list_media_files_recursive(dir: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
@@ -366,22 +375,55 @@ fn list_media_files_recursive(dir: &Path) -> Vec<PathBuf> {
 }
 
 /// Recursively walk a directory tree, collecting media files.
+///
+/// **Defensive guarantees** (added in PR-B of the v1.1.8 release-prep wave):
+///
+/// - **Depth-bounded**: stops recursing past [`MAX_WALK_DEPTH`] (32) to
+///   prevent stack overflow from pathologically deep trees.
+/// - **Symlink-safe**: skips symlinked entries entirely (uses
+///   [`std::fs::DirEntry::file_type`], which does NOT follow symlinks).
+///   This avoids:
+///     - Infinite recursion on symlink loops
+///     - Filesystem-escape via a symlink to `/`, `/home`, etc.
+///     - Surprising double-traversal when a directory is symlinked into
+///       its own descendant.
+///
+///   Trade-off: legitimate symlink farms (e.g., a curated `Movies/` of
+///   symlinks to a NAS share) will be skipped. The CLI does not currently
+///   advertise symlink support, so this is the safer default. If users
+///   request symlink-following, add an opt-in flag with a visited-inode
+///   set rather than removing the guard.
 fn walk_dir(dir: &Path, out: &mut Vec<PathBuf>) {
+    walk_dir_inner(dir, out, 0);
+}
+
+fn walk_dir_inner(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
+    if depth >= MAX_WALK_DEPTH {
+        return;
+    }
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
     let mut dirs = Vec::new();
     for entry in entries.filter_map(|e| e.ok()) {
+        // Use file_type() (does NOT follow symlinks) instead of
+        // path.is_file() / path.is_dir() (which DO follow symlinks).
+        let Ok(ft) = entry.file_type() else {
+            continue;
+        };
+        if ft.is_symlink() {
+            continue;
+        }
         let path = entry.path();
-        if path.is_file() && is_media_extension(&path) {
+        if ft.is_file() && is_media_extension(&path) {
             out.push(path);
-        } else if path.is_dir() {
+        } else if ft.is_dir() {
             dirs.push(path);
         }
     }
     dirs.sort();
     for d in dirs {
-        walk_dir(&d, out);
+        walk_dir_inner(&d, out, depth + 1);
     }
 }
 
@@ -408,7 +450,13 @@ fn warn_if_subdirs_have_media(batch_dir: &Path) {
     };
     let subdirs_with_media: Vec<String> = entries
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().is_dir())
+        .filter(|e| {
+            // Use file_type() (does NOT follow symlinks) to stay
+            // consistent with walk_dir's defensive guarantees.
+            e.file_type()
+                .map(|ft| ft.is_dir() && !ft.is_symlink())
+                .unwrap_or(false)
+        })
         .filter(|e| dir_contains_media(&e.path()))
         .filter_map(|e| e.file_name().to_str().map(String::from))
         .collect();
@@ -430,20 +478,38 @@ fn warn_if_subdirs_have_media(batch_dir: &Path) {
 
 /// Check if a directory (recursively) contains at least one media file.
 /// Short-circuits on the first match for performance.
+///
+/// Same defensive guarantees as [`walk_dir`]: depth-bounded by
+/// [`MAX_WALK_DEPTH`] and skips symlinks.
 fn dir_contains_media(dir: &Path) -> bool {
+    dir_contains_media_inner(dir, 0)
+}
+
+fn dir_contains_media_inner(dir: &Path, depth: usize) -> bool {
+    if depth >= MAX_WALK_DEPTH {
+        return false;
+    }
     let Ok(entries) = std::fs::read_dir(dir) else {
         return false;
     };
     let mut subdirs = Vec::new();
     for entry in entries.filter_map(|e| e.ok()) {
+        let Ok(ft) = entry.file_type() else {
+            continue;
+        };
+        if ft.is_symlink() {
+            continue;
+        }
         let path = entry.path();
-        if path.is_file() && is_media_extension(&path) {
+        if ft.is_file() && is_media_extension(&path) {
             return true;
-        } else if path.is_dir() {
+        } else if ft.is_dir() {
             subdirs.push(path);
         }
     }
-    subdirs.iter().any(|d| dir_contains_media(d))
+    subdirs
+        .iter()
+        .any(|d| dir_contains_media_inner(d, depth + 1))
 }
 
 /// Check whether a directory name indicates sample/preview content.

--- a/tests/cli_walk_dir_safety.rs
+++ b/tests/cli_walk_dir_safety.rs
@@ -1,0 +1,151 @@
+//! CLI safety tests for the recursive directory walker.
+//!
+//! These tests pin the defensive guarantees added in PR-B of the v1.1.8
+//! release-prep wave (security-auditor finding D4):
+//!
+//! 1. **Depth-bounded** — `walk_dir` stops recursing past `MAX_WALK_DEPTH`
+//!    (32) and does not stack-overflow on pathologically deep trees.
+//! 2. **Symlink-safe** — symlinked entries are skipped entirely, so the CLI
+//!    cannot be tricked into a symlink-loop infinite recursion or into
+//!    walking outside the user-supplied root via a symlink to `/`.
+//!
+//! These guards live in `src/main.rs` (private), so we exercise them
+//! through the CLI binary rather than via direct unit tests.
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+/// Build a directory tree N levels deep, with a media file at the bottom
+/// and a "control" media file at depth 1 that should always be reachable.
+///
+/// ```text
+/// root/
+///   control.mkv                             ← always reached
+///   d1/d2/d3/.../dN/deep.mkv                ← reached only if N ≤ MAX
+/// ```
+fn create_deep_tree(depth: usize) -> TempDir {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let root = tmp.path();
+    fs::write(root.join("control.mkv"), b"").unwrap();
+
+    let mut path = root.to_path_buf();
+    for i in 1..=depth {
+        path = path.join(format!("d{i}"));
+    }
+    fs::create_dir_all(&path).unwrap();
+    fs::write(path.join("deep.mkv"), b"").unwrap();
+
+    tmp
+}
+
+#[test]
+fn walk_dir_does_not_crash_on_deep_tree() {
+    // 40 levels deep — past the MAX_WALK_DEPTH=32 guard. Must terminate
+    // successfully without stack overflow or panic. The deep file may or
+    // may not appear in output (it's past the cap), but the control file
+    // at depth 1 must always be processed.
+    let tmp = create_deep_tree(40);
+
+    let assert = Command::cargo_bin("hunch")
+        .unwrap()
+        .args(["--batch", tmp.path().to_str().unwrap(), "-r", "-j"])
+        .timeout(std::time::Duration::from_secs(30))
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    // Control file must be reachable (proves the walker still works at
+    // shallow depths after we added the depth guard).
+    assert!(
+        stdout.contains("control.mkv"),
+        "control.mkv at depth 1 should always be processed; got: {stdout}",
+    );
+}
+
+#[test]
+fn walk_dir_processes_realistic_depth_unaffected() {
+    // 6 levels deep — well within MAX_WALK_DEPTH. Both control and deep
+    // files must appear. This pins that the guard does not regress
+    // realistic media-library traversal.
+    let tmp = create_deep_tree(6);
+
+    let assert = Command::cargo_bin("hunch")
+        .unwrap()
+        .args(["--batch", tmp.path().to_str().unwrap(), "-r", "-j"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(stdout.contains("control.mkv"), "control.mkv missing");
+    assert!(
+        stdout.contains("deep.mkv"),
+        "deep.mkv at depth 6 should be reachable; got: {stdout}",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn walk_dir_skips_symlink_loop() {
+    // Build a symlink loop: root/loop -> root. Without the symlink guard
+    // this would recurse forever and eventually exhaust the depth cap +
+    // produce an unbounded number of (the same) files. With the guard,
+    // the symlink entry is skipped entirely and the walker terminates
+    // quickly.
+    use std::os::unix::fs::symlink;
+
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::write(root.join("real.mkv"), b"").unwrap();
+    symlink(root, root.join("loop")).unwrap();
+
+    let assert = Command::cargo_bin("hunch")
+        .unwrap()
+        .args(["--batch", root.to_str().unwrap(), "-r", "-j"])
+        .timeout(std::time::Duration::from_secs(15))
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    // Exactly one occurrence of real.mkv — proves we did NOT follow the
+    // symlink (which would have produced loop/real.mkv,
+    // loop/loop/real.mkv, etc., up to the depth cap).
+    let count = stdout.matches("real.mkv").count();
+    assert_eq!(
+        count, 1,
+        "expected exactly 1 occurrence of real.mkv (symlink not followed); got {count} in: {stdout}",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn walk_dir_skips_symlinked_media_file() {
+    // A symlink that points to a media file outside the batch root must
+    // not be followed. Defensive: the user said "scan this dir," not "scan
+    // wherever symlinks point."
+    use std::os::unix::fs::symlink;
+
+    let outside = TempDir::new().unwrap();
+    let target = outside.path().join("escaped.mkv");
+    fs::write(&target, b"").unwrap();
+
+    let inside = TempDir::new().unwrap();
+    fs::write(inside.path().join("legit.mkv"), b"").unwrap();
+    symlink(&target, inside.path().join("symlink_to_outside.mkv")).unwrap();
+
+    let assert = Command::cargo_bin("hunch")
+        .unwrap()
+        .args(["--batch", inside.path().to_str().unwrap(), "-r", "-j"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.contains("legit.mkv"),
+        "legit.mkv missing from output: {stdout}",
+    );
+    assert!(
+        !stdout.contains("symlink_to_outside.mkv") && !stdout.contains("escaped.mkv"),
+        "symlinked file should NOT have been processed; got: {stdout}",
+    );
+}


### PR DESCRIPTION
Adds two defensive guarantees to the recursive directory walker used by `hunch --batch -r`, addressing **security-auditor finding D4** from the v1.1.8 pre-release sub-agent review.

This is **PR-B of 7** in the v1.1.8 release-prep cleanup wave.

## Problem

Before this change, `walk_dir` had two attack/misuse vectors:

1. **Symlink loop \u2192 stack overflow.** `--batch` at a directory with a symlink to itself (or any ancestor) recurses forever and crashes with stack-overflow panic.
2. **Pathological depth \u2192 DoS.** A deliberately-constructed deep tree exhausts stack with no recourse.
3. **Symlink escape.** A symlink to `/`, `/home`, or another mount causes the CLI to walk far outside the user-supplied root.

## Fix

Two complementary guards in **both** `walk_dir` and `dir_contains_media`:

### 1. Depth bound: `MAX_WALK_DEPTH = 32`

Real-world media libraries are very rarely deeper than 6 levels (`Movies/Genre/Year/Title/Disc/file.mkv`). 32 leaves a generous safety margin while bounding worst-case stack usage.

### 2. Symlink skip via `DirEntry::file_type()`

Use `file_type()` (does NOT follow symlinks) instead of `Path::is_file()`/`is_dir()` (which DO). Skip any entry where `FileType::is_symlink()` is true.

**Trade-off explicitly documented in module rustdoc**: legitimate symlink farms (e.g., curated `Movies/` of symlinks to a NAS share) will be skipped. The CLI does not currently advertise symlink support, so this is the safer default. If users request symlink-following, add an opt-in flag with a visited-inode set rather than removing the guard.

## Tests (4 new in `tests/cli_walk_dir_safety.rs`)

| Test | Pins |
|---|---|
| `walk_dir_does_not_crash_on_deep_tree` | 40-level tree terminates without stack overflow |
| `walk_dir_processes_realistic_depth_unaffected` | 6-level tree still fully walked (no regression) |
| `walk_dir_skips_symlink_loop` *(cfg unix)* | self-referential symlink doesn't cause recursion |
| `walk_dir_skips_symlinked_media_file` *(cfg unix)* | symlinked media outside root is NOT processed |

Symlink tests gated to `cfg(unix)` because Windows symlink creation requires admin privileges (would make CI environment-fragile).

## Verification

- 271 lib unit tests pass
- **252 integration tests pass** (was 248; +4 from this PR)
- All doc tests pass
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- `cargo build --no-default-features` builds (lib-only consumers unaffected)

## Out of scope (intentional)

- **Non-recursive `list_media_files`**: deliberately unchanged. No DoS or infinite-recursion risk since it doesn't recurse; following symlinks for a single-dir listing is normal Unix behavior.
- **Hallucinated finding #10** (code-reviewer flagged a PUA sentinel `debug_assert` in `clean.rs`): the sentinel was already killed in #130 (`grep -rn 'F8FF' src/` returns empty). Removed from the deferred list.

## Wave progress

| PR | Status |
|---|---|
| PR-A doc-drift cleanup | \u2705 merged (#136) |
| **PR-B walk_dir defense** | \ud83d\udfe1 this PR |
| PR-C test gap pinning | next |
| PR-D repository governance | queued |
| PR-E CI security hardening | queued |
| PR-F cross-OS PR CI | queued |
| PR-G `cargo-semver-checks` | queued |