### PR TITLE
test: pin three latent regression scenarios [PR-C]

### DIFF
--- a/src/properties/title/clean.rs
+++ b/src/properties/title/clean.rs
@@ -628,6 +628,54 @@ mod tests {
     }
 
     #[test]
+    fn preserve_dashes_kitchen_sink_composition() {
+        // Kitchen-sink test: locks in the *composition order* of every
+        // transform inside `clean_title_preserve_dashes` simultaneously.
+        //
+        // Pre-PR-C this composition was only exercised piecewise (one
+        // transform per test). When the pipeline was decomposed in #130,
+        // the per-transform tests caught regressions inside each step,
+        // but no single test caught "Step 2 strips the year that Step 4
+        // expected to see, leaving Step 4 a no-op". This test pins the
+        // full chain end-to-end so any future re-decomposition of
+        // `clean.rs` (and there will be one — see DESIGN D10) cannot
+        // silently change interaction order.
+        //
+        // Composition under exercise (left to right, all in one input):
+        //   1. strip_leading_brackets:   `[Group] ` → ""
+        //   2. strip_paren_year:         ` (2014)` at end → ""
+        //                                (only fires at end-of-string)
+        //   3. strip_paren_groups:       `(Director's Cut)` mid-string → " "
+        //   4. normalize_separators(PreserveStructuralDash):
+        //        - dot-acronyms preserved
+        //        - `_-_` and `.-.` and ` - ` → ` - `
+        //        - other separators → single space
+        //   5. trim_trailing_punct:      strip trailing `:-,;`
+        //
+        // Note: the trailing-keyword strip (Step 6) is intentionally NOT
+        // applied by `clean_title_preserve_dashes` — "Part N" is genuine
+        // title content for this code path.
+        let input =
+            "[Group].Show_-_Sub.-.Detail.(Director's.Cut).Part.2.S.H.I.E.L.D._-_End.(2014).";
+        // Note: the dot-acronym detector greedily extends "S.H.I.E.L.D."
+        // backwards to include the preceding `2.` (since `2` is also
+        // alphanumeric, the run `2.S.H.I.E.L.D.` matches the
+        // `[A-Za-z0-9](\.[A-Za-z0-9]){2,}\.?` pattern in one shot). The
+        // trailing dot of the acronym also survives. This is the
+        // documented (and tested below in `step_normalize_preserves_dot_acronyms`)
+        // behavior; pinning it explicitly here so any change shows up
+        // as a clear cross-step regression rather than as a mysterious
+        // failure in a single sub-step test.
+        let expected = "Show - Sub - Detail Part 2.S.H.I.E.L.D. - End";
+        assert_eq!(
+            clean_title_preserve_dashes(input),
+            expected,
+            "composition order regression: each step must run on the \
+             output of the previous one in the documented sequence"
+        );
+    }
+
+    #[test]
     fn step_normalize_preserves_dot_acronyms() {
         let out = normalize_separators("Agents.of.S.H.I.E.L.D.S01", DashPolicy::WordDashOnly);
         assert!(out.contains("S.H.I.E.L.D"), "got: {out}");

--- a/tests/fixtures/movies.yml
+++ b/tests/fixtures/movies.yml
@@ -620,6 +620,18 @@
   year: 2004
   edition: Special
 
+# PR-C regression pin: "Title.YEAR.Special.Edition.ext" must NOT be
+# misclassified as an episode by the type-vote (the `Edition: Special`
+# match used to bleed into the episode-marker tally pre-31d6970). Locked
+# in by `tests/wrong_type.rs::special_edition_after_year_stays_movie`;
+# this fixture entry pins the cross-property invariance through the
+# YAML harness as well.
+? A.Common.Title.2014.Special.Edition.avi
+: title: A Common Title
+  year: 2014
+  edition: Special
+  container: avi
+
 ? Dr.LiNE.The.Lorax.2012.DVDRip.LiNE.XviD.AC3.HQ.Hive-CM8.mp4
 : video_codec: Xvid
   title: Dr LiNE The Lorax

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -674,3 +674,60 @@ fn issue_35_western_srt_no_video_props() {
     assert_eq!(r.audio_codec(), None);
     assert_eq!(r.source(), None);
 }
+
+// ── Issue #124 regression: anime multi-segment title with " - " and "Part N" ──
+//
+// The bug (pre-#127): "[Group] Show - Sub Part 2 - 13 [tags].mkv" had its
+// title truncated at the first " - ", losing the "Sub Part 2" segment
+// (the title became "Show" instead of "Show - Sub Part 2").
+//
+// The fix is in `clean_title_preserve_dashes` (src/properties/title/clean.rs)
+// + the anime-bracket title-boundary detector. This integration test
+// pins the *cross-module contract* end-to-end — the unit tests in
+// `clean.rs` only exercise the cleaner in isolation, and the YAML
+// fixture in `tests/fixtures/episodes.yml` is the catch-all harness.
+// A focused integration test makes the regression discoverable when
+// anyone changes either the cleaner OR the title-boundary detector,
+// and prints a sharper diagnostic than the harness does.
+
+#[test]
+fn issue_124_anime_multi_segment_title_preserved() {
+    let r = hunch(
+        "[Erai-raws] Enen no Shouboutai - San no Shou Part 2 - 13 \
+         [1080p CR WEB-DL AVC AAC][MultiSub][7FF9B816].mkv",
+    );
+    assert_eq!(
+        r.title(),
+        Some("Enen no Shouboutai - San no Shou Part 2"),
+        "the multi-segment title with embedded \" - \" and \"Part 2\" \
+         must be preserved verbatim (not truncated at the first dash)"
+    );
+    assert_eq!(r.episode(), Some(13));
+    assert_eq!(r.release_group(), Some("Erai-raws"));
+    assert_eq!(r.screen_size(), Some("1080p"));
+    assert_eq!(r.container(), Some("mkv"));
+}
+
+#[test]
+fn issue_124_anime_dash_only_no_part_keyword() {
+    // Sibling case without "Part N": still must keep the second segment
+    // as part of the title (the boundary detector should treat the
+    // trailing " - 11" as the episode marker, not the inner " - ").
+    //
+    // Note: the YAML fixture in tests/fixtures/episodes.yml asserts
+    // `title: "Show Name"` + `alternative_title: "Still Name"` — that's
+    // the *guessit-compat aspirational* target (the compatibility report
+    // tracks how close we are). Current behavior keeps both segments in
+    // the title; this test pins that behavior so we don't accidentally
+    // change it via an unrelated cleaner refactor.
+    let r = hunch("[SuperGroup].Show.Name.-.Still.Name.-.11.[1080p].mkv");
+    assert_eq!(r.release_group(), Some("SuperGroup"));
+    assert_eq!(r.episode(), Some(11));
+    assert_eq!(r.screen_size(), Some("1080p"));
+    assert_eq!(
+        r.title(),
+        Some("Show Name - Still Name"),
+        "the inner \" - \" must be preserved as part of the title (the \
+         trailing \" - 11\" is the episode marker)"
+    );
+}


### PR DESCRIPTION
Adds focused regression coverage for three scenarios that, despite working correctly in v1.1.7, had no dedicated test pinning their behavior. A future refactor could silently break any of them and the existing per-step / per-property tests would not catch it.

This is **PR-C of 7** in the v1.1.8 release-prep cleanup wave, addressing **qa-expert finding D7** (special-edition golden fixture) plus code-reviewer findings #11 (DashPolicy kitchen-sink) and #23 (anime multi-segment integration test).

## Changes (3 files, +117 / -0)

### 1. `src/properties/title/clean.rs`: kitchen-sink composition test

New unit test `preserve_dashes_kitchen_sink_composition` exercises the **entire** `clean_title_preserve_dashes` pipeline in one input \u2014 leading `[Group]`, mid-string `(Director's Cut)`, trailing `(2014)`, `_-_` / `.-.` / ` - ` separators, `Part 2`, dot-acronym, trailing punctuation \u2014 all in a single assertion.

**Why**: pre-PR-C the composition was only exercised piecewise (one transform per test). When the pipeline was decomposed in #130, per-transform tests caught regressions inside each step, but no single test would catch "Step 2 strips the year that Step 4 expected to see, leaving Step 4 a no-op". This kitchen-sink test pins the full chain end-to-end so any future re-decomposition of `clean.rs` cannot silently change interaction order.

The expected output also explicitly documents the dot-acronym detector's greedy backward extension (`2.S.H.I.E.L.D.` matches in one shot since `2` is alphanumeric) \u2014 so any future tweak to that regex surfaces here as a clear cross-step regression rather than mysteriously breaking only one of the per-step tests.

### 2. `tests/fixtures/movies.yml`: special-edition golden fixture

New entry pinning the `Title.YEAR.Special.Edition.ext` type-vote regression fixed in 31d6970:

```yaml
? A.Common.Title.2014.Special.Edition.avi
: title: A Common Title
  year: 2014
  edition: Special
  container: avi
```

The unit test `tests/wrong_type.rs::special_edition_after_year_stays_movie` already locks in the type assertion. **This new fixture entry pins the cross-property invariance** (title + year + edition + container all correct simultaneously) through the YAML harness as well \u2014 the mechanism that catches regressions breaking property *interactions* without breaking any single one in isolation.

### 3. `tests/integration.rs`: anime multi-segment integration tests (#124)

Two new tests for the title regression fixed in #127:

| Test | Pins |
|---|---|
| `issue_124_anime_multi_segment_title_preserved` | Original bug filename verbatim. `title="Enen no Shouboutai - San no Shou Part 2"`, `episode=13`, `release_group="Erai-raws"`, screen_size, container |
| `issue_124_anime_dash_only_no_part_keyword` | Sibling case w/o `Part N`: inner ` - ` preserved as title, trailing ` - 11` recognized as episode marker |

The unit tests in `clean.rs` only exercise the cleaner in isolation, and the YAML fixture is the catch-all harness. **Focused integration tests make the regression discoverable when anyone changes either the cleaner OR the title-boundary detector**, and produce sharper diagnostics than the harness does.

> **Note on the dash-only sibling**: the YAML fixture in `episodes.yml` asserts the *guessit-compat aspirational* output (`title: "Show Name"` + `alternative_title`); current behavior keeps both segments in the title. The integration test pins the *current* behavior so an unrelated cleaner refactor won't accidentally change it. When/if hunch closes that compat gap, this test gets updated and the fixture starts passing in the report.

## Verification

- **272 lib unit tests pass** (was 271; +1 kitchen-sink)
- **58 integration tests pass** (was 56; +2 anime)
- All other test files unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## Wave progress

| PR | Status |
|---|---|
| PR-A doc-drift cleanup | \u2705 merged (#136) |
| PR-B walk_dir defense | \u2705 merged (#137) |
| **PR-C test gap pinning** | \ud83d\udfe1 this PR |
| PR-D repository governance | next |
| PR-E CI security hardening | queued |
| PR-F cross-OS PR CI | queued |
| PR-G cargo-semver-checks | queued |