### PR TITLE
chore: repository governance (gitignore + SECURITY.md + API policy) [PR-D]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,37 @@ venv
 .venv
 __pycache__/
 *.pyc
+
+# ── Secrets ───────────────────────────────────────────────────────────
+# Defense-in-depth: prevent accidental commit of credentials. These
+# patterns are intentionally aggressive — a false-positive ignore is
+# always recoverable; a leaked credential isn't.
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.pfx
+id_rsa
+id_rsa.*
+id_dsa
+id_dsa.*
+id_ecdsa
+id_ecdsa.*
+id_ed25519
+id_ed25519.*
+*.crt.key
+secrets/
+secrets.*
+credentials.json
+service-account*.json
+
+# ── Editor / OS noise ────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.swp
+*.swo
+*~

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,60 @@ otherwise every subsequent release will reuse the same stale notes.
 `RELEASE_NOTES.md` is intentionally **not** in `.gitignore` because the
 release workflow needs to read it from a clean checkout.
 
+## API Stability Policy
+
+`hunch` follows [Semantic Versioning](https://semver.org/) on its
+**Rust public API** — anything reachable from `pub use` in `src/lib.rs`.
+Within the `1.x` line, breaking changes to that surface require a
+major-version bump.
+
+What counts as a breaking change to the **Rust API**:
+
+- Removing or renaming a `pub` item (function, type, variant, field)
+- Changing the signature of a `pub` function (parameter / return types)
+- Adding a non-defaulted variant to a `pub` enum or a non-defaulted
+  field to a `pub` struct (callers' exhaustive matches break)
+- Tightening a trait bound on a `pub` item
+- Changing a public re-export's source path in a way that breaks
+  downstream `use` statements
+
+What does **not** count ("soft API" — free to change in a minor):
+
+- The exact **parsed output** for a given filename. Property extractors
+  (title cleaner, type voter, edition detector, etc.) improve over
+  time. We may produce a different `title` / `episode_title` / `type`
+  for the same input across minor versions — that's a feature, not a
+  contract.
+- Confidence scores. The numeric values are heuristic and subject to
+  re-tuning. Consumers should treat them as ordinal, not absolute.
+- The set of properties returned for a given filename (we may newly
+  detect a property we previously missed).
+- Internal module structure (`src/properties/`, `src/pipeline/`, etc.).
+  Anything not re-exported from `src/lib.rs` is implementation detail.
+- CLI human-readable output formatting (column widths, wording of
+  hints, color choices).
+- The contents of `tests/fixtures/*.yml` and the
+  `docs/compatibility.md` numbers — these are diagnostic, not API.
+
+What is **soft-but-still-careful**:
+
+- The **JSON output schema** of `hunch -j` is a documented integration
+  point. Field renames or removals will be called out in the changelog
+  under a "CLI output" heading and rolled with care, but they do not
+  by themselves trigger a major-version bump.
+- New JSON fields may appear in any minor release; consumers should
+  ignore unknown fields.
+
+When in doubt, file an issue describing your use case before relying
+on a behavior that isn't on the Rust API surface — we'll either
+promote it to a stable contract or document it as soft.
+
+## Reporting Security Issues
+
+See [SECURITY.md](SECURITY.md) for the private reporting channel and
+response timeline. Please **do not** file security vulnerabilities as
+public GitHub issues.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,85 @@
+# Security Policy
+
+## Threat Model
+
+`hunch` is a **filename parser**. It reads filename strings (and optional
+parent-directory path context) and produces structured metadata. It does
+**not**:
+
+- Open, read, or write the contents of any media file
+- Make network requests
+- Execute external programs
+- Persist any state to disk (the library is pure; the CLI only writes
+  structured output to stdout)
+
+The CLI does perform **directory traversal** (`hunch --batch -r`),
+which is explicitly hardened: depth-bounded (`MAX_WALK_DEPTH = 32`)
+and symlink-skipping. See the rustdoc on
+[`walk_dir`](src/main.rs) for the full threat-model rationale.
+
+## Supported Versions
+
+Security fixes are applied to the **latest minor release** on the
+`1.x` line. Older minor releases are not patched — please upgrade.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.1.x   | :white_check_mark: |
+| < 1.1   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub
+issues.**
+
+Instead, use one of these private channels:
+
+1. **GitHub private vulnerability reporting** (preferred):
+   <https://github.com/lijunzh/hunch/security/advisories/new>
+2. **Email**: open an issue tagged `security` requesting a private
+   contact, and a maintainer will reach out.
+
+Please include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce (a minimal filename / directory layout is ideal)
+- The version of `hunch` affected (`hunch --version`)
+- Your assessment of severity, if you have one
+
+## Response Timeline
+
+As an open-source project maintained by volunteers:
+
+- **Initial acknowledgment**: within 7 days
+- **Triage / severity assessment**: within 14 days
+- **Fix or mitigation plan**: communicated within 30 days for
+  high-severity issues; longer for low-severity / hardening items
+
+We will credit reporters in the changelog unless they prefer to remain
+anonymous.
+
+## Scope
+
+In-scope vulnerabilities include (but are not limited to):
+
+- **Denial of service** via crafted filenames or directory layouts
+  (panics, stack overflows, unbounded resource consumption, regex
+  catastrophic backtracking)
+- **Path traversal / sandbox escape** in the CLI's `--batch -r` mode
+- **Vulnerabilities in dependencies** that are exploitable through
+  `hunch`'s public API
+
+Out-of-scope:
+
+- Vulnerabilities requiring the attacker to already have write access
+  to the parsed filenames AND to a directory the user explicitly chose
+  to scan (this is a trust boundary, not a vulnerability)
+- Issues in `dev-dependencies` not reachable from the published crate
+- Style / hardening preferences without a concrete exploit scenario
+  (please file these as regular issues)
+
+## Security Hardening (non-CVE)
+
+For non-CVE security hardening (e.g., adding a defense-in-depth check,
+upgrading a yanked dev-dep), please open a regular GitHub issue. These
+do not need the private reporting channel.


### PR DESCRIPTION
Three repository-governance improvements bringing hunch in line with common open-source-project hygiene. **Pure documentation / configuration \u2014 no code changes, no behavioral impact.**

This is **PR-D of 7** in the v1.1.8 release-prep cleanup wave, addressing **security-auditor findings D5, D6, D9**.

## Changes (3 files, +173 / -0)

### 1. `.gitignore`: defense-in-depth secret patterns (+34 lines)

Aggressive ignore patterns for common credential-file naming conventions. *A false-positive ignore is always recoverable; a leaked credential isn't.*

| Category | Patterns |
|---|---|
| Env files | `.env`, `.env.*` *(with `!.env.example` carve-out)* |
| TLS / PGP | `*.pem`, `*.key`, `*.p12`, `*.pfx` |
| SSH keys | `id_rsa`/`id_dsa`/`id_ecdsa`/`id_ed25519` + `.*` variants |
| Cloud / app | `secrets/`, `secrets.*`, `credentials.json`, `service-account*.json` |
| Editor / OS noise | `.DS_Store`, `Thumbs.db`, `.idea/`, `.vscode/`, swap files |

Verified `git ls-files | grep -E '<patterns>'` returns nothing \u2014 no existing tracked file becomes ignored as a side effect.

### 2. `SECURITY.md` (new file, 85 lines)

Standard GitHub-recognized security-policy file. Sections:

- **Threat model** \u2014 hunch is a filename parser; documents what it does NOT do (no file-content reads, no network, no exec, no disk writes), points at `walk_dir`'s rustdoc for the one filesystem-traversal bit (now hardened by PR-B).
- **Supported versions** \u2014 latest 1.x minor only.
- **Reporting channel** \u2014 GitHub private vulnerability reporting preferred; `security`-tagged issue requesting private contact as fallback.
- **Response timeline** \u2014 7d ack / 14d triage / 30d fix-or-plan for high-severity. Honest about volunteer-maintained.
- **Scope** \u2014 in-scope (DoS via crafted inputs, path traversal in --batch -r, exploitable dep vulns) vs out-of-scope (attacker needing pre-existing write access; dev-deps; style preferences).

This **unlocks GitHub's "Security policy" tab**, which adds a "Report a vulnerability" button to the Security advisories page \u2014 critical for responsible disclosure to actually happen.

### 3. `CONTRIBUTING.md`: API stability policy section (+54 lines)

New **"API Stability Policy"** section explicitly documents what hunch considers a breaking change vs a soft-API change.

**Hard API (semver-bound)**: anything `pub use`d from `src/lib.rs` \u2014 function signatures, type shapes, exhaustive enums/structs.

**Soft API (free to change in minor)**:
- Parsed-output values for a given filename (extractors improve over time \u2014 same input may produce different `title` / `episode_title` / `type` across minors, by design)
- Confidence scores (heuristic, ordinal not absolute)
- The set of detected properties
- Internal module structure
- CLI human-readable output formatting
- Fixture YAMLs and compatibility-report numbers

**Soft-but-careful**: JSON output schema of `hunch -j`. Documented integration point \u2014 rename/remove gets called out in changelog under "CLI output" but doesn't trigger major bump on its own. New JSON fields may appear in any minor; consumers should ignore unknown fields.

Plus a short **"Reporting Security Issues"** section pointing at `SECURITY.md` so contributors landing in CONTRIBUTING.md first don't miss the private-disclosure channel.

## Verification

- 272 lib unit tests pass (unchanged \u2014 no code changes)
- `cargo build` clean
- `git ls-files` confirms no existing tracked file matches the new ignore patterns
- `SECURITY.md` renders correctly in GitHub Markdown

## Wave progress

| PR | Status |
|---|---|
| PR-A doc-drift cleanup | \u2705 merged (#136) |
| PR-B walk_dir defense | \u2705 merged (#137) |
| PR-C test gap pinning | \u2705 merged (#138) |
| **PR-D repo governance** | \ud83d\udfe1 this PR |
| PR-E CI security hardening | next |
| PR-F cross-OS PR CI | queued |
| PR-G `cargo-semver-checks` | queued |