### PR TITLE
ci: harden CI security (SHA-pin actions, hard-fail audit, gate auto-merge) [PR-E]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,26 +9,36 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Least-privilege default: jobs only need to read the repo. Override per-job
+# if a future job actually needs to write something (e.g., upload artifacts).
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
+
+# All third-party actions are pinned to a full commit SHA (not a moving tag)
+# to defend against tag-republishing supply-chain attacks. The trailing
+# `# vN` comment records the human-readable version for auditability;
+# Dependabot's github-actions ecosystem keeps these SHAs current.
 
 jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable (2025-04-17 snapshot)
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo check --all-targets
 
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt
       - run: cargo fmt --check
@@ -37,29 +47,29 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo clippy --all-targets -- -D warnings
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo test
 
   doc:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo doc --no-deps
         env:
           RUSTDOCFLAGS: -Dwarnings
@@ -68,10 +78,17 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run audit
-        run: cargo audit || true  # Advisory-only, don't fail CI
+        # `cargo audit` exits non-zero on any RUSTSEC vulnerability by
+        # default (the previous \`|| true\` was masking this gate — a
+        # real CVE could have shipped). Yanks / unmaintained warnings
+        # remain informational (exit 0) since they happen routinely
+        # in the dev-dep tree (criterion → plotters → web-sys) and
+        # shouldn't block PRs. Use --deny yanked here only if you
+        # want to enforce zero-yanks; we tolerate dev-dep yanks today.
+        run: cargo audit

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,6 +3,12 @@ name: Dependabot Auto-Merge
 # pull_request_target runs in the base-branch context and grants write
 # permissions to the GITHUB_TOKEN — required for Dependabot PRs, which
 # receive a read-only token under the plain `pull_request` trigger.
+#
+# SECURITY: pull_request_target with elevated permissions is dangerous
+# if combined with `actions/checkout` of the PR head SHA — that would
+# execute attacker-controlled code with write tokens. We deliberately
+# do NOT check out the PR; we only call `gh pr merge --auto`, which
+# runs entirely against the GitHub API.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -16,7 +22,28 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      # Fetch Dependabot's own classification of the PR (update type,
+      # dependency type, semver impact). We gate auto-merge on this so
+      # major version bumps and runtime-dep minor bumps still require
+      # manual review — auto-merge is reserved for the safest changes.
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a  # v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Auto-merge only if ALL of:
+      #   - Update type is patch OR minor (NEVER auto-merge major bumps)
+      #   - For minor bumps: dep is direct:development (dev-dep / build-dep)
+      #     OR ecosystem is github-actions (CI tooling, no runtime impact)
+      # Patch bumps auto-merge regardless of dep type — by semver
+      # contract they fix bugs without behavior change.
       - name: Enable auto-merge (squash — linear history)
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
+           (steps.meta.outputs.dependency-type == 'direct:development' ||
+            steps.meta.outputs.package-ecosystem == 'github_actions'))
         # --auto merges once all required status checks pass — CI is the gate.
         run: gh pr merge --auto --squash "$PR_URL"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Verify Version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Check tag matches Cargo.toml version
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
@@ -36,9 +36,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo test
 
   build:
@@ -60,11 +60,11 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           key: release-${{ matrix.target }}
 
@@ -88,7 +88,7 @@ jobs:
           cp README.md LICENSE hunch-${{ matrix.target }}/
           7z a hunch-${{ matrix.target }}.zip hunch-${{ matrix.target }}/
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: hunch-${{ matrix.target }}
           path: |
@@ -103,8 +103,8 @@ jobs:
     environment: crates-io
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -116,9 +116,9 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           path: artifacts
           merge-multiple: true
@@ -140,7 +140,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3.0.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           generate_release_notes: ${{ steps.notes.outputs.generate == 'true' }}
           body_path: ${{ steps.notes.outputs.generate != 'true' && 'release_notes.md' || '' }}
@@ -153,7 +153,7 @@ jobs:
     needs: github-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           path: artifacts
           merge-multiple: true
@@ -169,7 +169,7 @@ jobs:
           echo "x86_64_linux=$(sha256sum artifacts/hunch-x86_64-unknown-linux-gnu.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
 
       - name: Checkout Homebrew tap
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           repository: lijunzh/homebrew-hunch
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -931,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -941,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -954,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",


### PR DESCRIPTION
Four CI security improvements addressing **security-auditor findings D1, D2, D3** + bonus dev-dep hygiene. Pure CI / lockfile work \u2014 zero source-code changes.

This is **PR-E of 7** in the v1.1.8 release-prep cleanup wave.

## Changes (4 files, +89 / -45)

### 1. `cargo audit` actually gates now (was no-op)

**Before**: `run: cargo audit || true  # Advisory-only, don't fail CI` \u2014 the `|| true` masked **every** audit failure including actual RUSTSEC vulnerabilities. A real CVE could have landed unnoticed.

**After**: `run: cargo audit` \u2014 exits non-zero on any RUSTSEC vulnerability by default, exits zero on yanks/unmaintained warnings (those happen routinely in the dev-dep tree and shouldn't block PRs).

### 2. SHA-pin all third-party actions (3 workflow files)

Every `uses:` reference replaced with a full commit SHA + version comment. Defends against tag-republishing supply-chain attacks (the vector that hit `tj-actions/changed-files` in March 2025).

| Action | Pinned SHA | Tag |
|---|---|---|
| actions/checkout | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6 |
| Swatinem/rust-cache | `e18b497796c12c097a38f9edb9d0641fb99eee32` | v2 |
| dtolnay/rust-toolchain | `29eef336d9b2848a0b548edc03f92a220660cdb8` | stable |
| dependabot/fetch-metadata | `21025c705c08248db411dc16f3619e6b5f9ea21a` | v2 |
| actions/download-artifact | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | v8 |
| actions/upload-artifact | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7 |
| softprops/action-gh-release | `b4309332981a82ec1c5618f44dd2e27cc8bfbfda` | v3.0.0 |

The existing `github-actions` Dependabot ecosystem entry will keep these SHAs current \u2014 **no maintenance burden added**.

Also tightened ci.yml's default permissions to `contents: read` (least-privilege).

### 3. Dependabot auto-merge: metadata-gated

**Before**: ANY Dependabot PR auto-merged once CI passed \u2014 including runtime-dep major version bumps.

**After**: `dependabot/fetch-metadata` extracts the PR's classification, and auto-merge only fires if **all** of:

- `update-type == semver-patch` (always safe by semver), **OR**
- `update-type == semver-minor` AND
  - `dependency-type == direct:development` (dev-dep / build-dep), OR
  - `package-ecosystem == github_actions` (CI tooling)

**Major bumps and runtime-dep minor bumps now require manual review.** Patches still auto-merge across the board.

Also added a SECURITY comment block warning that `pull_request_target` + write permissions combined with `actions/checkout` of the PR head SHA is dangerous \u2014 documents the existing safe pattern (we never check out the PR; only call `gh pr merge` against the API).

### 4. Refresh yanked dev-deps in `Cargo.lock`

`cargo audit` was warning about two yanked transitive dev-deps:
- `js-sys 0.3.88`
- `wasm-bindgen 0.2.111`

Both pulled in via `criterion \u2192 plotters \u2192 web-sys`. Resolved by `cargo update -p web-sys --precise 0.3.95`. Post-update: **127 deps scanned, 0 warnings, 0 vulnerabilities.**

## Verification

- 272 lib unit tests pass (no source changes)
- `cargo build` clean post-lockfile-update
- `cargo audit` exits 0 with zero warnings (was 2 yank warnings)
- All action SHAs verified via `gh api repos/.../git/refs/tags/...`
- Workflows are valid YAML

## Wave progress

| PR | Status |
|---|---|
| PR-A doc-drift cleanup | \u2705 merged (#136) |
| PR-B walk_dir defense | \u2705 merged (#137) |
| PR-C test gap pinning | \u2705 merged (#138) |
| PR-D repo governance | \u2705 merged (#139) |
| **PR-E CI security hardening** | \ud83d\udfe1 this PR |
| PR-F cross-OS PR CI | next |
| PR-G `cargo-semver-checks` | queued |