### PR TITLE
ci: add macOS + Windows to PR-time Check + Test matrix [PR-F]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,15 @@ env:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    # Cross-OS PR-time gate: catches platform-conditional compile errors
+    # (path separators, syscalls, std::os::* gates) before they reach
+    # main. Linux is the canonical fast-feedback target; macOS and
+    # Windows catch surprises that ubuntu can't see.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable (2025-04-17 snapshot)
@@ -35,6 +43,8 @@ jobs:
 
   fmt:
     name: Format
+    # Format / Clippy / Docs / Audit are OS-agnostic — keeping them on
+    # ubuntu only avoids tripling CI time for zero signal.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -56,7 +66,15 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    # Cross-OS test matrix: catches platform-conditional behavior —
+    # \`tests/cli_walk_dir_safety.rs\` has \`cfg(unix)\` symlink tests that
+    # only run on macOS/Linux; Windows path-handling differences
+    # (separators, drive letters, line endings in fixtures) surface here.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable


### PR DESCRIPTION
Adds cross-OS gating to the two CI jobs that have OS-conditional sensitivity (`Check` and `Test`). Format / Clippy / Docs / Audit remain Linux-only — they're OS-agnostic and tripling their runtime would be pure cost for zero signal.

Addresses **qa-expert finding D-OS** (no cross-OS PR-time CI — only the release workflow ever exercised non-Linux, so platform regressions had to wait until release-time to surface).

This is **PR-F of 7** in the v1.1.8 release-prep cleanup wave.

## Matrix

```yaml
strategy:
  fail-fast: false
  matrix:
    os: [ubuntu-latest, macos-latest, windows-latest]
runs-on: ${{ matrix.os }}
```

`fail-fast: false` so a Windows-only failure doesn't kill macOS mid-flight — we want the full picture per PR.

## ⚠️ Required-status-check rename

The existing `Check` / `Test` required contexts in the repository ruleset will need updating to the matrix-expanded names:

- `Check (ubuntu-latest)` / `Check (macos-latest)` / `Check (windows-latest)`
- `Test (ubuntu-latest)` / `Test (macos-latest)` / `Test (windows-latest)`

I'll update the ruleset right after merge.

## What this catches that ubuntu-only didn't

| Gap | Surfaced by |
|---|---|
| `cfg(unix)` symlink-skip path in `walk_dir` (PR-B) — Windows hits a different code path | `cli_walk_dir_safety` runs on all 3 OSes |
| Path separator handling | `PathBuf` joins / `std::fs` semantics / test assertions on `Path::display()` |
| Line endings in fixtures | CRLF surprises on Windows |
| Toolchain drift | `dtolnay/rust-toolchain@stable` resolving to slightly different versions across OSes |

## Cost

Public repo → all GitHub-hosted runners are free. Wall-clock CI time grows by ~1-2 minutes (matrix runs in parallel; macOS + Windows runners aren't slower than Linux for a small Rust crate).

## Verification

CI-only change — no source / lockfile modifications. **The matrix's correctness is verified by this PR's own CI run** (especially the previously-untested Windows + macOS test runs).

## Wave progress

| PR | Status |
|---|---|
| PR-A doc-drift cleanup | ✅ merged (#136) |
| PR-B walk_dir defense | ✅ merged (#137) |
| PR-C test gap pinning | ✅ merged (#138) |
| PR-D repo governance | ✅ merged (#139) |
| PR-E CI security hardening | ✅ merged (#140) |
| **PR-F cross-OS PR CI** | 🟡 this PR |
| PR-G `cargo-semver-checks` | next |
