### PR TITLE
ci: add cargo-semver-checks PR-time gate [PR-G]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,23 @@ jobs:
         # shouldn't block PRs. Use --deny yanked here only if you
         # want to enforce zero-yanks; we tolerate dev-dep yanks today.
         run: cargo audit
+
+  semver:
+    name: Semver Checks
+    # Detects accidental SemVer-incompatible changes to the public Rust
+    # API (anything `pub use`d from src/lib.rs). Catches the easy-to-miss
+    # cases that CONTRIBUTING.md's API Stability Policy enumerates:
+    # removed/renamed pub items, signature changes, new non-defaulted
+    # variants on pub enums, tightened trait bounds, etc.
+    #
+    # Compares the PR head's public API against the latest release on
+    # crates.io. Hard-fails on any breaking change — if the change is
+    # intentional and warrants a major-version bump, the PR author
+    # bumps Cargo.toml `version` to N+1.0.0 and this job becomes a
+    # no-op (semver-checks only flags breakage WITHIN a major).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      - uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae  # v2.8


### PR DESCRIPTION
Adds a new `Semver Checks` CI job that detects accidental SemVer-incompatible changes to the public Rust API. Catches the easy-to-miss cases enumerated in CONTRIBUTING.md's [API Stability Policy](../blob/main/CONTRIBUTING.md#api-stability-policy) (added in PR-D #139): removed/renamed `pub` items, signature changes, new non-defaulted variants on `pub` enums, tightened trait bounds, etc.

This is **PR-G of 7 — the FINAL PR** — in the v1.1.8 release-prep cleanup wave, addressing **code-reviewer finding #20** and **qa-expert finding D-API**.

## How it works

`obi1kenobi/cargo-semver-checks-action` compares the PR head's public API against the latest release on crates.io. **Hard-fails on any breaking change.**

If a change is intentional and warrants a major-version bump, the PR author bumps `Cargo.toml` `version` to N+1.0.0 and this job becomes a no-op (cargo-semver-checks only flags breakage *within* a major).

## Why this matters

The CONTRIBUTING.md "API Stability Policy" added in PR-D documented hunch's hard vs soft API contract. **But documentation alone doesn't prevent accidental breakage** — the next contributor who renames a `pub` enum variant or adds a non-defaulted field gets a green PR if all they had to do was satisfy the type checker.

`cargo-semver-checks` is the automated enforcement that turns the written policy into a tested invariant. It's the standard recommendation for any crate that publishes to crates.io.

## SHA pinning

`obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae` (v2.8 — latest stable as of 2026-04-17), consistent with the SHA-pinning policy established in PR-E.

## Required-status-check addition

The new "Semver Checks" context will be added to the repository ruleset alongside the existing required checks. I'll update the ruleset right after merge.

## Verification

CI-only change — no source / lockfile modifications. The new job's correctness is verified by this PR's own CI run. Since this PR makes **zero public-API changes**, the semver-checks job should pass trivially.

## Wave context — COMPLETE 🎉

PR-G is the **final** PR in the v1.1.8 release-prep cleanup wave:

| PR | Status |
|---|---|
| PR-A doc-drift cleanup | ✅ #136 |
| PR-B walk_dir defense | ✅ #137 |
| PR-C test gap pinning | ✅ #138 |
| PR-D repo governance | ✅ #139 |
| PR-E CI security hardening | ✅ #140 |
| PR-F cross-OS PR CI | ✅ #141 |
| **PR-G cargo-semver-checks** | 🟡 this PR |

After this lands, the 6 deferred epic items (TOML migration of legacy matchers, visibility audit, coverage CI, mutation testing, fuzzing, perf regression CI) become the next wave of work — to be filed as tracking issues.
