### PR TITLE
chore: release v1.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,114 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.8] - 2026-04-17
+
+### Changed
+
+- **`--batch -r` now bounds recursion depth and skips symlinks.** Recursive
+  directory walks (`hunch --batch <dir> -r`) cap at 32 levels deep and
+  silently skip symbolic links — both regular files and directories.
+  Defends against denial-of-service via deeply nested trees (stack
+  overflow) and symlink loops (infinite recursion). Users with curated
+  libraries that rely on symlinks (e.g., a `Movies/` directory built from
+  NAS symlinks) will see fewer or zero results in v1.1.8 — either follow
+  the symlinks before invoking hunch, or run hunch on the original
+  directory tree. (#137)
+
 ### Fixed
 
 - **Anime titles containing `" - "` and `"Part N"`** — in `[Group] Show - Sub
   Part 2 - 13 [tags]` style filenames, the title is now extracted as the full
   `Show - Sub Part 2`. Previously the parser truncated at the first `" - "`
-  and incorrectly extracted `Part 2` as a standalone `part` property. (#124)
+  and incorrectly extracted `Part 2` as a standalone `part` property.
+  (#124, #127)
+
+### Refactored
+
+- **Pipeline `rule_registry` extracted** from `pipeline/mod.rs` into its own
+  module. Centralizes the legacy / TOML rule registration so the pipeline
+  orchestration stays at the orchestration layer of abstraction. (#134)
+- **Title `find_title_boundary` renamed** for clarity, with documented
+  semantics and a pinned caveat preventing accidental re-introduction of the
+  pre-rename behavior. (#128 Debt #4, #133)
+- **Title fallback extractors unified** behind a new `TitleStrategy` trait.
+  The 5–6 ad-hoc extractor functions are now first-class strategy types in
+  `properties/title/strategies/`, registered in a single ordered fallback
+  list. (#128 Debt #1, #132)
+- **Part reclaimable when Episode present.** `Part N` matches in the same
+  set as an `Episode` match are now marked reclaimable so the existing
+  title-absorption step can fold them into the title uniformly. Replaces
+  the bespoke `absorb_part_into_title` post-hoc corrector (in line with the
+  D10 "no post-hoc correctors" tripwire). (#128 Debt #3, #131)
+- **`clean_title` decomposed** into composable transforms (`strip_*`,
+  `normalize_separators`, `trim_trailing_punct`, `strip_trailing_keywords`,
+  `clean_title_preserve_dashes`, `DashPolicy`). Each transform is
+  individually testable and composable; `clean_title` becomes a thin
+  orchestrator. (#128 Debt #2, #130)
+- **`mark_reclaimable_when_episode_present` visibility tightened** from
+  `pub` to `pub(crate)`. Internal-only helper; never intended as part of
+  the public API surface. (release-prep)
+
+### Tests
+
+- **Three regression scenarios pinned** as named tests in dedicated files:
+  flat-batch warning hint, parent-context propagation, and wrong-type path
+  inference. Prevents silent regression of behaviors that previously had
+  only ad-hoc coverage. (#138)
+- **`tests/cli_walk_dir_safety.rs`** added alongside #137 with four
+  scenarios: deep-tree depth bound (40 levels, control file at depth 1);
+  realistic-depth happy path (depth 6); `cfg(unix)` symlink-loop containment
+  (counts occurrences to prove non-following); outside-root symlink-escape
+  rejection. (#137)
+
+### Docs
+
+- **`SECURITY.md` added** at repo root with threat model, vulnerability
+  reporting procedure (private GitHub Security Advisories), and explicit
+  in-scope / out-of-scope categorization. (#139)
+- **API Stability Policy** added to `CONTRIBUTING.md` documenting the hard
+  vs. soft public-API contract: `hunch::Pipeline`, `HunchResult`, `MediaType`,
+  `Confidence`, `Property`, and the top-level `hunch()` / `hunch_with_context()`
+  functions are SemVer-stable; `properties::*` submodules are explicitly
+  unstable. (#139)
+- **`DESIGN.md` promoted** to a root-level document (was `docs/design.md`).
+  Adds D10 "Refactor before accreting" with three concrete tripwire rules:
+  no post-hoc correctors, no parallel matchers, no growing dispatchers.
+  (#129, #135)
+- **`docs/user_manual.md`** updated to document `-r` recursion behavior:
+  symlinks are skipped (loop-safe), traversal stops at 32 levels deep.
+  (release-prep, paired with #137)
+- **Doc drift cleanup** — README, CONTRIBUTING, user_manual, and
+  compatibility cross-references audited and refreshed against current
+  source state. (#136)
+- **Compatibility report** refreshed: 1072 / 1311 fixtures pass (81.8%),
+  up from 1071 / 1309 in v1.1.7 (two fixtures added, one new pass).
+  (release-prep)
+
+### CI
+
+- **`cargo-semver-checks` PR-time gate** added. Detects accidental
+  SemVer-incompatible changes to the public Rust API by comparing PR head
+  against the latest crates.io release. Blocks breaking changes within a
+  major version line. (#142)
+- **Cross-OS PR matrix** — `Check` and `Test` jobs now run on
+  ubuntu-latest, macos-latest, and windows-latest. Catches
+  platform-conditional compile errors and path-handling differences before
+  release time. (#141)
+- **Security hardening of CI workflows.** All third-party actions SHA-pinned
+  with version comments (defends against tag-republishing supply-chain
+  attacks). `cargo audit` now hard-fails on RUSTSEC vulnerabilities (was
+  silenced by `|| true`). Dependabot auto-merge metadata-gated to
+  patches-only and dev/CI-tooling minor bumps; major bumps and runtime-dep
+  minor bumps now require manual review. Two yanked transitive dev-deps
+  refreshed (`js-sys 0.3.88` → `0.3.95`, `wasm-bindgen 0.2.111` →
+  `0.2.118`). Default `permissions: contents: read` on `ci.yml`. (#140)
+
+### Repository governance
+
+- **`.gitignore` hardened** with broad patterns for accidental secret /
+  credential commits (`.env*`, `*.pem`, `*.key`, `id_rsa*`, `secrets*`,
+  `credentials.json`, `service-account*.json`). (#139)
 
 ## [1.1.7] - 2026-03-23
 
@@ -691,6 +793,7 @@ source, audio_codec, screen_size, audio_channels, date.
 
 color_depth, streaming_service, bonus, episode_details, film.
 
+[1.1.8]: https://github.com/lijunzh/hunch/releases/tag/v1.1.8
 [1.1.7]: https://github.com/lijunzh/hunch/releases/tag/v1.1.7
 [1.1.6]: https://github.com/lijunzh/hunch/releases/tag/v1.1.6
 [1.1.5]: https://github.com/lijunzh/hunch/releases/tag/v1.1.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hunch"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hunch"
-version = "1.1.7"
+version = "1.1.8"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Lijun Zhu"]

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ All 49 guessit properties implemented. Validated against guessit's
 
 | Metric | Value |
 |---|---|
-| Pass rate | **81.8%** (1,071 / 1,309) |
+| Pass rate | **81.8%** (1,072 / 1,311) |
 | Properties at 95%+ | 22 |
 | Properties at 100% | 16 |
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -8,7 +8,7 @@ But guessit compatibility is no longer the primary optimization target.
 Hunch is tuned first for **real-world media-library accuracy**, with guessit
 compatibility used as a reference point rather than a product goal.
 
-> **Last updated:** 2026-04-17 (`main` after #135, pre-v1.1.8 release prep)
+> **Last updated:** 2026-04-17 (v1.1.8 release)
 
 ---
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -94,7 +94,7 @@ hunch --batch /path/to/movies/ -r -j
 |---|---|
 | `--context <DIR>` | Use sibling files for better title detection |
 | `--batch <DIR>` | Parse all media files in a directory |
-| `-r`, `--recursive` | Recurse into subdirectories (with `--batch`) |
+| `-r`, `--recursive` | Recurse into subdirectories (with `--batch`). Symlinks are skipped (loop-safe, sandbox-safe), and traversal stops at 32 levels deep. |
 | `-j`, `--json` | Compact JSON output (default is pretty-printed) |
 | `-v`, `--verbose` | Enable debug logging |
 

--- a/src/properties/part.rs
+++ b/src/properties/part.rs
@@ -190,7 +190,7 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
 ///
 /// For movie-style files (`Movie.Part.3.mkv`) there is no Episode match,
 /// so Part stays confident and remains the title boundary.
-pub fn mark_reclaimable_when_episode_present(matches: &mut [MatchSpan]) {
+pub(crate) fn mark_reclaimable_when_episode_present(matches: &mut [MatchSpan]) {
     let has_episode = matches.iter().any(|m| m.property == Property::Episode);
     if !has_episode {
         return;


### PR DESCRIPTION
## v1.1.7 → **v1.1.8** (patch bump)

Promotes the v1.1.8 release-prep wave (PRs #127, #129–#142) into a tagged release. Pure patch — bug fixes / refactors / docs / CI hardening; **no new public API, no breaking changes.** Public API surface (`src/lib.rs`) is byte-identical vs v1.1.7.

After this PR merges, `v1.1.8` will be tagged on `main` HEAD and pushed, triggering the automated [release.yml](../blob/main/.github/workflows/release.yml) workflow (5-platform binary build, crates.io publish, GitHub Release, Homebrew tap update).

## Changelog highlights

### Changed (user-visible)
- **`--batch -r` now bounds recursion + skips symlinks** (#137). Caps at 32 levels deep, silently skips symbolic links. Defends against DoS via deeply nested trees + symlink loops. **Users with symlink-based `Movies/` libraries will see fewer/zero results in v1.1.8** — see CHANGELOG for migration notes.

### Refactored
- Title fallback extractors unified behind `TitleStrategy` trait (#132)
- `clean_title` decomposed into composable transforms (#130)
- `Part` reclaimable when `Episode` present, retiring `absorb_part_into_title` (#131)
- `find_title_boundary` renamed with documented semantics (#133)
- `rule_registry` extracted from `pipeline/mod.rs` (#134)
- `mark_reclaimable_when_episode_present` visibility tightened to `pub(crate)` (release-prep)

### Fixed
- Anime titles with `" - "` and `"Part N"` no longer truncated at the first dash (#124, #127)

### Tests
- Three regression scenarios pinned (flat-batch warning, parent-context, wrong-type) (#138)
- New `cli_walk_dir_safety.rs` with depth + symlink + escape coverage (#137)

### Docs
- `SECURITY.md` added with threat model + reporting procedure (#139)
- API Stability Policy added to CONTRIBUTING.md (#139)
- `DESIGN.md` promoted to root with new D10 "Refactor before accreting" + tripwire rules (#129, #135)
- Doc-drift cleanup across README, CONTRIBUTING, user_manual, compatibility (#136)
- Compatibility report refreshed: 1072/1311 (81.8%)

### CI
- `cargo-semver-checks` PR-time gate (#142) — public-API breakage now blocked automatically
- Cross-OS PR matrix: ubuntu + macOS + Windows for `Check` + `Test` (#141)
- All third-party actions SHA-pinned, `cargo audit` hard-fails, Dependabot auto-merge metadata-gated, yanked dev-deps refreshed, `permissions: contents: read` default (#140)

### Repository governance
- `.gitignore` hardened against accidental secret commits (#139)

## Sub-agent pre-release validation

All four mandated sub-agents reviewed `release/v1.1.8` against `v1.1.7`:

| Agent | Verdict | Key findings |
|---|---|---|
| **code-reviewer** 🛡️ | 🟢 (after fixes applied) | Caught accidental `pub fn mark_reclaimable_when_episode_present` → fixed in this PR. DESIGN.md drift: zero — wave explicitly enforces D10 tripwires. |
| **rust-programmer** 🦀 | ✅ | fmt/clippy/test/doc/library-only-build all green. Crates.io metadata complete. |
| **security-auditor** 🛡️ | ✅ | `cargo audit` clean (127 deps, 0 findings). Zero new `unsafe`. No fancy_regex. SECURITY block in dependabot-auto-merge.yml verified accurate. |
| **qa-expert** 🐾 | ✅ | 525 tests pass. Compat 1072/1311 (81.8%). Manual CLI spot-checks (deep tree, symlink loop) all green. |

## Verification checklist

- [x] `Cargo.toml` bumped to 1.1.8
- [x] `Cargo.lock` regenerated
- [x] CHANGELOG `[Unreleased]` promoted to `[1.1.8]` with link reference
- [x] Public API surface byte-stable vs v1.1.7 (`git diff v1.1.7..HEAD -- src/lib.rs` empty)
- [x] All required CI checks green (Check×3 + Test×3 + Format + Clippy + Docs + Security Audit + Semver Checks)
- [x] Compatibility report verified locally: 1072/1311 (81.8%)
- [x] No new `unsafe` blocks (`rg unsafe src/` returns one doc-comment hit only)
- [x] `cargo build --no-default-features` clean (library-only consumers OK)

### Deferred items (tracked)

Will be appended after issues are filed.

| # | Issue | Source | Severity |
|---|---|---|---|
| #150 | CI: extend PR-time CI trigger to `release/**` branches | qa-expert F-4 | P2 |
| #151 | CI: tighten release.yml workflow-wide permissions | security-auditor P3 | P3 |
| #152 | CI: reconsider `continue-on-error` on cargo publish | security-auditor O2 | P3 |
| #153 | Tests: extend `cli_walk_dir_safety` with boundary + EACCES + Windows | qa-expert F-3 | P2 |
| #154 | Tests: pin TitleStrategy fallback ordering | code-reviewer P2 #8 | P2 |
| #155 | Cleanup: stale version-tagged TODOs in tests/integration.rs | code-reviewer P1 #6 | P2 |

These items were intentionally **deferred to post-release** because none block tagging or shipping v1.1.8. They'll be picked up alongside the broader epic backlog (#143–#148).
