### PR TITLE
feat: borrow improvements from go-ptn / parse-torrent-name review

### DIFF
--- a/rules/other.toml
+++ b/rules/other.toml
@@ -24,7 +24,16 @@ ultra       = "Ultra HD"
 pal         = "PAL"
 ntsc        = "NTSC"
 secam       = "SECAM"
+# DVD region codes (R0–R6 are the standard MPAA regions; R7–R9 are reserved
+# and rarely used in real-world filenames, so we omit them to limit false
+# positives on niche release-group/encoding tokens that begin with R).
+r0          = "Region 0"
+r1          = "Region 1"
+r2          = "Region 2"
+r3          = "Region 3"
+r4          = "Region 4"
 r5          = "Region 5"
+r6          = "Region 6"
 screener    = "Screener"
 scr         = "Screener"
 hybrid      = "Hybrid"

--- a/src/hunch_result.rs
+++ b/src/hunch_result.rs
@@ -226,6 +226,32 @@ impl HunchResult {
         }
     }
 
+    /// `true` if the detected media type is [`MediaType::Movie`].
+    ///
+    /// Convenience over `media_type() == Some(MediaType::Movie)` for routing
+    /// downstream lookups (e.g., TMDb movie endpoint vs. TVDb episode endpoint).
+    /// Returns `false` when the media type is unknown — callers that need to
+    /// distinguish "definitely not a movie" from "unknown" should use
+    /// [`media_type`](Self::media_type) directly.
+    pub fn is_movie(&self) -> bool {
+        self.media_type() == Some(MediaType::Movie)
+    }
+
+    /// `true` if the detected media type is [`MediaType::Episode`].
+    ///
+    /// See [`is_movie`](Self::is_movie) for caveats around unknown media type.
+    pub fn is_episode(&self) -> bool {
+        self.media_type() == Some(MediaType::Episode)
+    }
+
+    /// `true` if the detected media type is [`MediaType::Extra`]
+    /// (bonus features, openings, endings, specials, etc.).
+    ///
+    /// See [`is_movie`](Self::is_movie) for caveats around unknown media type.
+    pub fn is_extra(&self) -> bool {
+        self.media_type() == Some(MediaType::Extra)
+    }
+
     /// All "other" flags (e.g., "HDR", "Remux", "Proper").
     pub fn other(&self) -> Vec<&str> {
         self.all(Property::Other)
@@ -349,5 +375,72 @@ impl std::fmt::Display for HunchResult {
             Ok(json) => write!(f, "{json}"),
             Err(e) => write!(f, "<serialization error: {e}>"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for typed-accessor helpers added on top of the [`MediaType`]
+    //! enum. The helpers themselves are pure derived getters — no parsing
+    //! change — so we test them by manually setting the underlying property
+    //! rather than running the full pipeline.
+
+    use super::*;
+    use crate::matcher::span::Property;
+
+    fn empty_result() -> HunchResult {
+        HunchResult {
+            props: BTreeMap::new(),
+            confidence: Confidence::Medium,
+        }
+    }
+
+    #[test]
+    fn is_movie_true_when_media_type_is_movie() {
+        let mut r = empty_result();
+        r.set(Property::MediaType, "movie");
+        assert!(r.is_movie());
+        assert!(!r.is_episode());
+        assert!(!r.is_extra());
+    }
+
+    #[test]
+    fn is_episode_true_when_media_type_is_episode() {
+        let mut r = empty_result();
+        r.set(Property::MediaType, "episode");
+        assert!(r.is_episode());
+        assert!(!r.is_movie());
+        assert!(!r.is_extra());
+    }
+
+    #[test]
+    fn is_extra_true_when_media_type_is_extra() {
+        let mut r = empty_result();
+        r.set(Property::MediaType, "extra");
+        assert!(r.is_extra());
+        assert!(!r.is_movie());
+        assert!(!r.is_episode());
+    }
+
+    #[test]
+    fn all_three_helpers_false_when_media_type_unknown() {
+        // Explicit choice: helpers return `false` when the media type is
+        // unknown, NOT "true for movie because there's no episode marker"
+        // (which is what go-ptn does). Callers that need the trichotomy
+        // (movie / episode / unknown) should use `media_type()` directly.
+        let r = empty_result();
+        assert_eq!(r.media_type(), None);
+        assert!(!r.is_movie());
+        assert!(!r.is_episode());
+        assert!(!r.is_extra());
+    }
+
+    #[test]
+    fn is_movie_case_insensitive_via_media_type() {
+        // media_type() lower-cases internally, so any casing of the stored
+        // value should still produce the right helper answer.
+        let mut r = empty_result();
+        r.set(Property::MediaType, "MOVIE");
+        assert!(r.is_movie());
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -731,3 +731,85 @@ fn issue_124_anime_dash_only_no_part_keyword() {
          trailing \" - 11\" is the episode marker)"
     );
 }
+
+// ── Competitor-borrowed regression pins (April 2026 review of go-ptn / parse-torrent-name) ──
+//
+// These tests pin behaviors discovered during a comparative review against
+// `razsteinmetz/go-ptn` and `divijbindlish/parse-torrent-name`. Two of the
+// behaviors below (SBS/OU stereoscopic detection) were already correctly
+// implemented in hunch but lacked focused tests; the third (R0–R6 DVD region
+// codes) extended coverage from a single value (R5) to the standard set.
+
+#[test]
+fn stereoscopic_half_sbs_emits_3d_other() {
+    // Half-SBS (Side-by-Side) is a 3D delivery format — it implies the
+    // content is stereoscopic 3D even when the literal "3D" token is absent.
+    // hunch's TOML rule (rules/other_positional.toml) maps Half-SBS → "3D",
+    // which is more semantically correct than emitting a separate "SBS" tag
+    // (the approach taken by go-ptn / parse-torrent-name).
+    let r = hunch("TEST.2015.1080p.3D.BluRay.Half-SBS.x264.DTS-HD.MA.7.1-ABC");
+    assert!(
+        r.other().contains(&"3D"),
+        "Half-SBS must contribute a \"3D\" Other value (stereoscopic delivery format)"
+    );
+    assert_eq!(r.title(), Some("TEST"));
+    assert_eq!(r.year(), Some(2015));
+    assert_eq!(r.screen_size(), Some("1080p"));
+    assert_eq!(r.source(), Some("Blu-ray"));
+}
+
+#[test]
+fn stereoscopic_half_ou_emits_3d_other() {
+    // Half-OU (Over-Under) is the vertical-stack stereoscopic counterpart to
+    // Half-SBS. Same semantic mapping: implies 3D delivery.
+    let r = hunch("TEST.2015.1080p.3D.BluRay.Half-OU.x264.DTS-HD.MA.7.1-ABC");
+    assert!(
+        r.other().contains(&"3D"),
+        "Half-OU must contribute a \"3D\" Other value (stereoscopic delivery format)"
+    );
+    assert_eq!(r.source(), Some("Blu-ray"));
+}
+
+#[test]
+fn dvd_region_codes_r0_through_r6() {
+    // DVD region codes R0 (worldwide) through R6 (China) are the standard
+    // MPAA region set. R7–R9 are reserved/non-theatrical and intentionally
+    // omitted to limit false positives on niche release-group tokens.
+    //
+    // Pre-review (April 2026) only R5 was supported. This test pins the
+    // extension to R0–R6 from rules/other.toml.
+    let pairs = [
+        ("R0", "Region 0"),
+        ("R1", "Region 1"),
+        ("R2", "Region 2"),
+        ("R3", "Region 3"),
+        ("R4", "Region 4"),
+        ("R5", "Region 5"),
+        ("R6", "Region 6"),
+    ];
+    for (token, expected) in pairs {
+        let filename = format!("Movie.2024.{token}.DVDRip.x264-GROUP.mkv");
+        let r = hunch(&filename);
+        assert!(
+            r.other().contains(&expected),
+            "{filename} should yield Other = \"{expected}\", got {:?}",
+            r.other()
+        );
+        assert_eq!(r.source(), Some("DVD"), "{filename} source");
+    }
+}
+
+#[test]
+fn dvd_region_r5_does_not_break_classic_brave_fixture() {
+    // Regression: the canonical go-ptn / parse-torrent-name R5 fixture.
+    // Pinning this guards against any future change to the region-code
+    // exact-match table that might over-generalize and corrupt the classic
+    // case both libraries use as their R5 reference example.
+    let r = hunch("Brave.2012.R5.DVDRip.XViD.LiNE-UNiQUE");
+    assert_eq!(r.title(), Some("Brave"));
+    assert_eq!(r.year(), Some(2012));
+    assert_eq!(r.source(), Some("DVD"));
+    assert_eq!(r.video_codec(), Some("Xvid"));
+    assert_eq!(r.release_group(), Some("UNiQUE"));
+    assert!(r.other().contains(&"Region 5"));
+}


### PR DESCRIPTION
## Summary

Distills three improvements from a comparative review of two prior-art torrent-name parsers — `razsteinmetz/go-ptn` (Go) and `divijbindlish/parse-torrent-name` (Python) — into a focused, low-risk PR.

## Changes

### 1. `is_movie()` / `is_episode()` / `is_extra()` helpers on `HunchResult` ✨

```rust
let r = hunch("Breaking.Bad.S05E16.720p.BluRay.x264-DEMAND.mkv");
if r.is_episode() {
    // route to TVDb
}
```

Pure derived getters over the existing `media_type()` typed accessor. Borrowed from go-ptn's `IsMovie` field convention, but **adapted to hunch's `MediaType` trichotomy** (movie / episode / extra) instead of go-ptn's binary movie/not-movie split.

**Critical design choice**: these return `false` when the media type is unknown (rather than defaulting to "movie" as go-ptn does). Callers needing to distinguish "definitely not X" from "unknown" should use `media_type()` directly. Documented inline.

### 2. DVD region codes R0–R6 in `rules/other.toml` 🎯

Pre-review only `R5` was in the exact-match table. Standard MPAA region set is **R0 (worldwide) through R6 (China)**; R7–R9 are reserved/non-theatrical and intentionally omitted to limit false positives on niche release-group tokens that begin with R.

```toml
r0 = "Region 0"
r1 = "Region 1"
# … through r6
```

### 3. Regression pins for stereoscopic Half-SBS / Half-OU → 3D mapping 📌

**No code change** — pure documentation-via-test. Review surfaced that hunch already correctly handles Half-SBS and Half-OU as stereoscopic 3D delivery formats (`rules/other_positional.toml` maps them to `value = "3D"`), which is **more semantically correct** than go-ptn / parse-torrent-name's approach of emitting a separate "SBS" tag.

Pinning the behavior with focused tests guards against any future TOML change accidentally splitting these into separate property values.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all` | ✅ clean |
| `cargo clippy --all-targets --all-features -D warnings` | ✅ clean |
| Lib tests | ✅ **277** pass (was 272; +5 helper tests) |
| Integration tests | ✅ **62** pass (was 58; +4 regression pins) |
| Compatibility report | ✅ **1072/1311 (81.8%)** — unchanged (R0–R6 isn't exercised by guessit corpus) |

## Out of scope (filed as follow-up issues)

- Importing the 76-fixture parse-torrent-name JSON corpus (~1-day triage to cherry-pick novel cases vs duplicates) → see linked issue
- Closing the three **0%-accuracy** properties surfaced by the compatibility report: `mimetype` (0/3), `video_bit_rate` (0/4), `audio_bit_rate` (0/4) → see linked issue

## Provenance

The reviewed competitor projects (**~414 LOC for go-ptn, ~191 LOC for parse-torrent-name**, both 2017-era forks of a 2015 JS library) cover a small fraction of hunch's scope (**~9,400 LOC src + 2,070 LOC TOML rules + 1,311 fixtures**). Genuinely-borrowable insights were small but high-leverage:

- **API ergonomics** → helpers (item 1)
- **Exact-match completeness** → R0–R6 (item 2)
- **Explicit regression pins for behaviors hunch already gets right** → SBS/OU (item 3)

Anti-patterns from those projects (flat regex registries, single-file architecture, no zone disambiguation, no parent-directory context) were **explicitly rejected**.

## API impact

This is a **non-breaking additive change** — three new public methods on `HunchResult`, zero existing methods modified. `cargo-semver-checks` will classify this as a minor-bump-eligible change (no breaking change).
