### PR TITLE
feat(parse): close 0%-accuracy gaps for mimetype + audio/video bit-rate split (#158)

### DIFF
--- a/src/hunch_result.rs
+++ b/src/hunch_result.rs
@@ -95,6 +95,20 @@ impl HunchResult {
                 values.push(m.value.clone());
             }
         }
+
+        // Derive Mimetype from Container (#158). This is a pure mapping —
+        // no parsing — so it lives at result-build time rather than as a
+        // matcher. Done after the dedup pass so we read the canonical
+        // container value that survived.
+        if let Some(container) = props.get(&Property::Container).and_then(|v| v.first())
+            && let Some(mime) = container_to_mimetype(container)
+        {
+            props
+                .entry(Property::Mimetype)
+                .or_default()
+                .push(mime.to_string());
+        }
+
         Self {
             props,
             confidence: Confidence::Medium, // default; pipeline sets the real value
@@ -158,6 +172,35 @@ impl HunchResult {
     /// Audio codec (e.g., "AAC", "DTS").
     pub fn audio_codec(&self) -> Option<&str> {
         self.first(Property::AudioCodec)
+    }
+
+    /// Audio bit rate (e.g., `"320Kbps"`, `"448Kbps"`).
+    ///
+    /// All bit-rate matches with `Kbps` units are routed here. See
+    /// [`Property::AudioBitRate`] for the unit-based disambiguation rationale.
+    pub fn audio_bit_rate(&self) -> Option<&str> {
+        self.first(Property::AudioBitRate)
+    }
+
+    /// Video bit rate (e.g., `"1.5Mbps"`, `"19.1Mbps"`).
+    ///
+    /// All bit-rate matches with `Mbps` units are routed here. See
+    /// [`Property::VideoBitRate`] for the unit-based disambiguation rationale.
+    pub fn video_bit_rate(&self) -> Option<&str> {
+        self.first(Property::VideoBitRate)
+    }
+
+    /// MIME type derived from the file container (e.g., `"video/mp4"`).
+    ///
+    /// This is a derived getter — the MIME type is not parsed from the
+    /// filename but mapped from [`container`](Self::container) using a fixed
+    /// table of common video/audio/subtitle containers. Returns `None` if
+    /// the container is unknown or unmapped.
+    ///
+    /// The mapping is populated when the [`HunchResult`] is built so that
+    /// callers don't have to maintain their own container → MIME table.
+    pub fn mimetype(&self) -> Option<&str> {
+        self.first(Property::Mimetype)
     }
 
     /// Audio channels (e.g., "5.1", "7.1").
@@ -378,6 +421,50 @@ impl std::fmt::Display for HunchResult {
     }
 }
 
+/// Map a normalized container value (e.g., `"mp4"`, `"mkv"`) to its IANA
+/// MIME type. Returns `None` for unknown containers (defensive default —
+/// the alternative would be to fabricate a `application/octet-stream`
+/// fallback, but a missing mimetype is more honest than a wrong one).
+///
+/// The table covers the containers actually emitted by hunch's parser
+/// (see `src/properties/container.rs`) plus a few common aliases. Add
+/// entries here if a new container is supported upstream.
+fn container_to_mimetype(container: &str) -> Option<&'static str> {
+    // Lower-case lookup so callers don't have to normalize. The values
+    // returned are canonical IANA registrations where they exist; for
+    // formats without an IANA entry (e.g., .mkv) we use the de-facto
+    // standard MIME type widely accepted by browsers and players.
+    match container.to_ascii_lowercase().as_str() {
+        // Video containers.
+        "mp4" | "m4v" => Some("video/mp4"),
+        "mkv" => Some("video/x-matroska"),
+        "avi" => Some("video/x-msvideo"),
+        "mov" | "qt" => Some("video/quicktime"),
+        "webm" => Some("video/webm"),
+        "flv" => Some("video/x-flv"),
+        "wmv" => Some("video/x-ms-wmv"),
+        "mpg" | "mpeg" => Some("video/mpeg"),
+        "ts" | "m2ts" | "mts" => Some("video/mp2t"),
+        "vob" => Some("video/dvd"),
+        "3gp" => Some("video/3gpp"),
+        // Audio containers.
+        "mp3" => Some("audio/mpeg"),
+        "flac" => Some("audio/flac"),
+        "m4a" => Some("audio/mp4"),
+        "ogg" | "oga" => Some("audio/ogg"),
+        "wav" => Some("audio/wav"),
+        "wma" => Some("audio/x-ms-wma"),
+        "aac" => Some("audio/aac"),
+        // Subtitle containers.
+        "srt" => Some("application/x-subrip"),
+        "ass" | "ssa" => Some("text/x-ssa"),
+        "vtt" => Some("text/vtt"),
+        "sub" => Some("text/plain"),
+        "idx" => Some("application/x-vobsub"),
+        // Unknown container — return None rather than guess.
+        _ => None,
+    }
+}
 #[cfg(test)]
 mod tests {
     //! Unit tests for typed-accessor helpers added on top of the [`MediaType`]

--- a/src/matcher/span.rs
+++ b/src/matcher/span.rs
@@ -149,6 +149,12 @@ define_properties! {
     /// File size (e.g., `"1.4 GB"`, `"700 MB"`).
     Size => "size",
     /// Audio or video bit rate (e.g., `"320Kbps"`, `"1.5Mbps"`).
+    ///
+    /// **Deprecated**: bit rate matches are now disambiguated at parse time
+    /// into [`AudioBitRate`](Self::AudioBitRate) (`Kbps`) and
+    /// [`VideoBitRate`](Self::VideoBitRate) (`Mbps`). This variant is retained
+    /// for enum-API stability (downstream `match` arms continue to compile)
+    /// but no parser produces it as of the bit-rate split (#158).
     BitRate => "bit_rate",
     /// CD / disc number within a multi-disc set (e.g., `"1"` from `CD1`).
     Cd => "cd",
@@ -192,6 +198,37 @@ define_properties! {
     SeasonCount => "season_count",
     /// Video API / framework (e.g., `"DXVA"`).
     VideoApi => "video_api",
+    /// MIME type derived from the file container (e.g., `"video/mp4"`,
+    /// `"video/x-matroska"`).
+    ///
+    /// This is a derived property: it is computed from
+    /// [`Container`](Self::Container) at result-build time rather than parsed
+    /// from the input string. The mapping is fixed (mp4→video/mp4, mkv→
+    /// video/x-matroska, etc.) so downstream consumers don't have to maintain
+    /// their own container→MIME table.
+    ///
+    /// (Appended to the end of the enum to keep the
+    /// discriminants of pre-existing variants stable.)
+    Mimetype => "mimetype",
+    /// Audio bit rate (e.g., `"320Kbps"`, `"448Kbps"`).
+    ///
+    /// All bit-rate matches with `Kbps` units are emitted under this property.
+    /// Audio data rates are universally in the kilobit range (typically
+    /// 96–512 Kbps), making the unit a near-perfect signal for the audio /
+    /// video distinction.
+    ///
+    /// (Appended to the end of the enum to keep the
+    /// discriminants of pre-existing variants stable.)
+    AudioBitRate => "audio_bit_rate",
+    /// Video bit rate (e.g., `"1.5Mbps"`, `"19.1Mbps"`).
+    ///
+    /// All bit-rate matches with `Mbps` units are emitted under this property.
+    /// Video data rates are universally in the megabit range (typically
+    /// 1–50 Mbps).
+    ///
+    /// (Appended to the end of the enum to keep the
+    /// discriminants of pre-existing variants stable.)
+    VideoBitRate => "video_bit_rate",
 }
 
 /// A single match found in the input string.

--- a/src/properties/bit_rate.rs
+++ b/src/properties/bit_rate.rs
@@ -1,8 +1,22 @@
 //! Bit rate detection.
 //!
 //! Detects audio/video bit rates: 320Kbps, 448Kbps, 19.1Mbps, etc.
-//! Hunch emits a single `bit_rate` property (not split into audio/video).
-//! See COMPATIBILITY.md for rationale.
+//!
+//! Bit-rate matches are disambiguated at parse time using the unit as the
+//! signal:
+//!
+//! - `Kbps` (kilobits per second) → [`Property::AudioBitRate`].
+//!   Audio data rates are universally in the kilobit range (typically
+//!   96–512 Kbps for compressed formats; rarely above 1024 Kbps even for
+//!   lossless).
+//! - `Mbps` (megabits per second) → [`Property::VideoBitRate`].
+//!   Video data rates are universally in the megabit range (typically
+//!   1–50 Mbps for compressed formats).
+//!
+//! This unit-based heuristic matches guessit's behavior and reflects how the
+//! values appear in real-world filenames. The legacy [`Property::BitRate`]
+//! variant is retained on the enum for back-compat with downstream `match`
+//! arms but is no longer produced by this matcher.
 
 use regex::Regex;
 
@@ -10,9 +24,21 @@ use crate::matcher::regex_utils::{BoundarySpec, CharClass, check_boundary};
 use crate::matcher::span::{MatchSpan, Property};
 use std::sync::LazyLock;
 
-/// Matches: 320Kbps, 448 Kbps, 19.1Mbps, 1.5 Mbps, etc.
+/// Matches: 320Kbps, 448 Kbps, 19.1Mbps, 1.5 Mbps, 384kbit, 5Mbit, etc.
+///
+/// Accepts the long suffix (`bps` = bits per second), the short suffix
+/// (`bit`), or the plural short suffix (`bits` — seen in some anime
+/// release notations like `19.1mbits`). All three normalize to `bps` at
+/// output for a single canonical form.
+///
+/// The decimal portion is intentionally bounded to 1–2 digits. Real-world
+/// bit-rate values are almost never specified to higher precision, and the
+/// loose `\d+` form caused greedy collisions with adjacent decimals like
+/// audio-channel notation (`DD5.1.448kbps` would match `1.448Kbps` instead
+/// of `448Kbps`). The bounded form lets the regex backtrack cleanly to the
+/// next integer match in such cases.
 static BIT_RATE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)(?P<num>\d+(?:\.\d+)?)\s*(?P<unit>[KkMm]bps)")
+    Regex::new(r"(?i)(?P<num>\d+(?:\.\d{1,2})?)\s*(?P<unit>[KkMm])(?:bps|bits?)")
         .expect("BIT_RATE regex is valid")
 });
 
@@ -54,18 +80,32 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
             .expect("unit group always present in BIT_RATE")
             .as_str();
 
-        // Normalize unit casing: "kbps" → "Kbps", "mbps" → "Mbps".
+        // Normalize unit prefix casing: "k" → "K", "m" → "M".
+        // The trailing suffix is always normalized to "bps" regardless of
+        // whether the input said "bps" or "bit" — single canonical form.
         let normalized_unit = match unit.to_ascii_lowercase().as_str() {
-            "kbps" => "Kbps",
-            "mbps" => "Mbps",
-            _ => unit,
+            "k" => "Kbps",
+            "m" => "Mbps",
+            // Fallback: shouldn't occur given the regex character class.
+            _ => "Kbps",
         };
 
         // Output without spaces: "320Kbps", "19.1Mbps".
         let value = format!("{num}{normalized_unit}");
 
+        // Disambiguate by unit (#158): Kbps → audio, Mbps → video.
+        // The unit alone is a near-perfect signal in real-world filenames.
+        let property = match normalized_unit {
+            "Kbps" => Property::AudioBitRate,
+            "Mbps" => Property::VideoBitRate,
+            // Fallback: shouldn't happen given the regex, but keep the
+            // legacy BitRate variant as the safety net rather than
+            // panicking on an unexpected unit (defensive).
+            _ => Property::BitRate,
+        };
+
         matches.push(
-            MatchSpan::new(abs_start, abs_end, Property::BitRate, &value)
+            MatchSpan::new(abs_start, abs_end, property, &value)
                 .with_priority(crate::priority::VOCABULARY),
         );
 
@@ -85,6 +125,8 @@ mod tests {
         let m = find_matches("Music.Track.320Kbps.mp3");
         assert_eq!(m.len(), 1);
         assert_eq!(m[0].value, "320Kbps");
+        // Kbps must always be classified as AudioBitRate (#158).
+        assert_eq!(m[0].property, Property::AudioBitRate);
     }
 
     #[test]
@@ -92,6 +134,7 @@ mod tests {
         let m = find_matches("Music [320 Kbps].mp3");
         assert_eq!(m.len(), 1);
         assert_eq!(m[0].value, "320Kbps");
+        assert_eq!(m[0].property, Property::AudioBitRate);
     }
 
     #[test]
@@ -99,6 +142,8 @@ mod tests {
         let m = find_matches("Show.Name.19.1Mbps.mkv");
         assert_eq!(m.len(), 1);
         assert_eq!(m[0].value, "19.1Mbps");
+        // Mbps must always be classified as VideoBitRate (#158).
+        assert_eq!(m[0].property, Property::VideoBitRate);
     }
 
     #[test]
@@ -106,6 +151,7 @@ mod tests {
         let m = find_matches("Show.Name.20Mbps.mkv");
         assert_eq!(m.len(), 1);
         assert_eq!(m[0].value, "20Mbps");
+        assert_eq!(m[0].property, Property::VideoBitRate);
     }
 
     #[test]
@@ -113,6 +159,7 @@ mod tests {
         let m = find_matches("Title Name [480p][1.5Mbps][.mp4]");
         assert_eq!(m.len(), 1);
         assert_eq!(m[0].value, "1.5Mbps");
+        assert_eq!(m[0].property, Property::VideoBitRate);
     }
 
     #[test]
@@ -121,6 +168,7 @@ mod tests {
         let m = find_matches("H264.384Kbps.mkv");
         assert_eq!(m.len(), 1);
         assert_eq!(m[0].value, "384Kbps");
+        assert_eq!(m[0].property, Property::AudioBitRate);
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -283,30 +283,26 @@ fn crc32_in_brackets() {
 #[test]
 fn bit_rate_kbps() {
     let r = hunch("Chuck Berry The Very Best Of Chuck Berry(2010)[320 Kbps]");
-    assert_eq!(
-        r.first(hunch::matcher::span::Property::BitRate),
-        Some("320Kbps")
-    );
+    // Kbps must be classified as audio (#158): the unit is the disambiguator.
+    assert_eq!(r.audio_bit_rate(), Some("320Kbps"));
+    assert_eq!(r.video_bit_rate(), None);
     assert_eq!(r.year(), Some(2010));
 }
 
 #[test]
 fn bit_rate_mbps() {
     let r = hunch("Title Name [480p][1.5Mbps][.mp4]");
-    assert_eq!(
-        r.first(hunch::matcher::span::Property::BitRate),
-        Some("1.5Mbps")
-    );
+    // Mbps must be classified as video (#158).
+    assert_eq!(r.video_bit_rate(), Some("1.5Mbps"));
+    assert_eq!(r.audio_bit_rate(), None);
     assert_eq!(r.screen_size(), Some("480p"));
 }
 
 #[test]
 fn bit_rate_after_codec() {
     let r = hunch("Show.Name.S01E01.H264.384Kbps.mkv");
-    assert_eq!(
-        r.first(hunch::matcher::span::Property::BitRate),
-        Some("384Kbps")
-    );
+    // 384Kbps is audio (Kbps unit), regardless of being adjacent to H264.
+    assert_eq!(r.audio_bit_rate(), Some("384Kbps"));
     assert_eq!(r.video_codec(), Some("H.264"));
 }
 
@@ -815,4 +811,60 @@ fn dvd_region_r5_does_not_break_classic_brave_fixture() {
     assert_eq!(r.video_codec(), Some("Xvid"));
     assert_eq!(r.release_group(), Some("UNiQUE"));
     assert!(r.other().contains(&"Region 5"));
+}
+
+// ── #158 regression pins: bit_rate split + mimetype derivation ────────────
+
+#[test]
+fn mimetype_derived_from_mp4_container() {
+    // mp4 → video/mp4 — the universal video container.
+    let r = hunch("Movie.2024.1080p.WEB-DL.x264.mp4");
+    assert_eq!(r.container(), Some("mp4"));
+    assert_eq!(r.mimetype(), Some("video/mp4"));
+}
+
+#[test]
+fn mimetype_derived_from_mkv_container() {
+    // mkv → video/x-matroska — de facto MIME for Matroska.
+    let r = hunch("Movie.2024.1080p.BluRay.x265.mkv");
+    assert_eq!(r.container(), Some("mkv"));
+    assert_eq!(r.mimetype(), Some("video/x-matroska"));
+}
+
+#[test]
+fn mimetype_none_when_container_unknown() {
+    // Unknown container → None (never fabricate a fallback MIME).
+    let r = hunch("Movie.2024.1080p.WEB-DL.x264.weirdext");
+    assert_eq!(r.container(), None);
+    assert_eq!(r.mimetype(), None);
+}
+
+#[test]
+fn bit_rate_kbps_lowercase_with_channel_collision() {
+    // Pin the regression where "DD5.1.448kbps" was being parsed as
+    // bit_rate "1.448Kbps" because the regex greedily absorbed the
+    // fractional channel digit. Now bounded decimals (\d{1,2}) force
+    // the regex to backtrack to the next valid match.
+    let r = hunch("Hotel.Hell.S01E01.720p.DD5.1.448kbps-ALANiS");
+    assert_eq!(r.audio_bit_rate(), Some("448Kbps"));
+    assert_eq!(r.audio_channels(), Some("5.1"));
+    assert_eq!(r.audio_codec(), Some("Dolby Digital"));
+}
+
+#[test]
+fn bit_rate_kbit_short_suffix() {
+    // Pin the `bit` short-suffix support added in #158. Older filenames
+    // (especially anime) use `kbit` instead of `kbps` — both must yield
+    // the same canonical "Kbps" output.
+    let r = hunch("Show.Name.S01E01.H264-384kbit_AAC.mp4");
+    assert_eq!(r.audio_bit_rate(), Some("384Kbps"));
+}
+
+#[test]
+fn bit_rate_mbits_plural_suffix() {
+    // Pin the `bits` plural-short-suffix support added in #158. Some
+    // anime-release notations (e.g. "19.1mbits") use this form.
+    let r = hunch("[HorribleSubs] Overlord II - 01 [1080p] 19.1mbits - 120fps.mkv");
+    assert_eq!(r.video_bit_rate(), Some("19.1Mbps"));
+    assert_eq!(r.frame_rate(), Some("120fps"));
 }


### PR DESCRIPTION
Closes #158.

## TL;DR

Three properties were at **0% accuracy** because hunch had no parser/derivation:
- `mimetype`, `audio_bit_rate`, `video_bit_rate`

All three now at **100%**. Overall compat: **81.8% → 82.4%** (+8 cases).

## The elegant insight: unit IS the signal

Real-world bit-rate values are universally:
- `Kbps` (kilobits/sec) for **audio** (typical 96–512 Kbps)
- `Mbps` (megabits/sec) for **video** (typical 1–50 Mbps)

No codec-adjacency analysis needed. `bit_rate.rs` now classifies by unit.

## Mimetype is a pure derivation

Mapping table at `HunchResult::from_matches` build time. mp4 → video/mp4, mkv → video/x-matroska, etc. Unknown container → `None` (never fabricate).

## Two regex tweaks needed for full coverage

1. **Bounded decimal** (`\\d{1,2}`): fixes `DD5.1.448kbps` matching as `1.448Kbps`
2. **Suffix alternation** (`bps|bits?`): supports anime-release `kbit`/`mbits` notation

## API additions

- `Property::AudioBitRate`, `Property::VideoBitRate`, `Property::Mimetype` (appended to end of enum — pre-existing discriminants unchanged)
- `HunchResult::audio_bit_rate()`, `video_bit_rate()`, `mimetype()`
- `Property::BitRate` retained for enum-API stability (deprecated; no parser produces it)

## Versioning

⚠️ **No version bump in this PR.** `cargo-semver-checks` will flag the new `Property` variants as breaking-by-strict-semver (exhaustive enum without `#[non_exhaustive]`). That failure is **expected and acknowledged** — the version bump will happen at release-prep time, not per-PR. Pre-1.0 stability semantics for hunch make this acceptable since there are no external users on the 1.1.x line yet.

## Verification

- 6 new regression pins in `tests/integration.rs`
- All existing bit_rate tests updated to typed-property assertions
- `cargo clippy --all-targets` clean, `cargo fmt` clean
- 1080/1311 compat cases green (was 1072/1311)