### PR TITLE
ci: make Semver Checks an advisory (non-blocking) check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,18 +119,23 @@ jobs:
 
   semver:
     name: Semver Checks
-    # Detects accidental SemVer-incompatible changes to the public Rust
-    # API (anything `pub use`d from src/lib.rs). Catches the easy-to-miss
+    # Detects SemVer-incompatible changes to the public Rust API
+    # (anything `pub use`d from src/lib.rs). Catches the easy-to-miss
     # cases that CONTRIBUTING.md's API Stability Policy enumerates:
     # removed/renamed pub items, signature changes, new non-defaulted
     # variants on pub enums, tightened trait bounds, etc.
     #
     # Compares the PR head's public API against the latest release on
-    # crates.io. Hard-fails on any breaking change — if the change is
-    # intentional and warrants a major-version bump, the PR author
-    # bumps Cargo.toml `version` to N+1.0.0 and this job becomes a
-    # no-op (semver-checks only flags breakage WITHIN a major).
+    # crates.io.
+    #
+    # ADVISORY (continue-on-error): pre-1.0-stability semantics for
+    # hunch — there are no external users on the 1.1.x line yet, so
+    # breaking-API PRs are landed on `main` with the version bump
+    # deferred to release-prep time. Failure here is informational,
+    # not a merge gate. Release-prep PRs MUST verify this job is
+    # green (or accept the bump it implies).
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable


### PR DESCRIPTION
Pre-1.0-stability for hunch: no external users on 1.1.x yet, so breaking-API PRs land on `main` with the version bump deferred to release-prep time.

## Two-layer change

1. **Workflow**: `continue-on-error: true` on the `semver` job \u2014 job still runs, output still visible, but a failure no longer fails the overall workflow.
2. **Ruleset**: removed 'Semver Checks' from `Main Branch` ruleset's required-status-checks list (already applied via `gh api PUT`).

## Release-prep contract

Release PRs MUST verify Semver Checks is green (or accept the major bump it implies). Job comment updated to spell this out.