### PR TITLE
fix(website): reject ccTLDs inside language abbreviations (#163)

### DIFF
--- a/src/properties/website.rs
+++ b/src/properties/website.rs
@@ -35,9 +35,13 @@ static WEBSITE_FROM: LazyLock<Regex> = LazyLock::new(|| {
 
 /// Unbracketed website in filename: MkvCage.com, www.divx-overnet.com
 /// Excludes common file extensions and requires a boundary before the domain.
+///
+/// The trailing `\b` is critical: without it, `.ru` would false-positive inside
+/// language abbreviations like `.rus` (Russian), producing nonsense like
+/// `website: "s02e20.ru"` for `Community.s02e20.rus.eng.720p...` (issue #163).
 static WEBSITE_INLINE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-    r"(?P<site>(?:www\.)?[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.(?:com|org|net|info|tv|io|ru|cc))"
+    r"(?P<site>(?:www\.)?[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.(?:com|org|net|info|tv|io|ru|cc))\b"
     ).unwrap()
 });
 
@@ -156,5 +160,48 @@ mod tests {
         assert!(has_known_tld("wawa.co.uk"));
         assert!(!has_known_tld("ready.player.one"));
         assert!(!has_known_tld("some.thing.movie"));
+    }
+
+    /// Regression for #163: inline website matcher must not match `.ru` inside
+    /// the Russian language abbreviation `.rus`. Bug surfaced from the
+    /// parse-torrent-name corpus triage in PR #157.
+    #[test]
+    fn test_no_false_positive_on_language_abbrev_rus() {
+        let m = find_matches("Community.s02e20.rus.eng.720p.Kybik.v.Kybe");
+        assert!(
+            m.is_empty(),
+            "`.ru` inside `.rus` (Russian abbrev) must not match as a website, got: {:?}",
+            m.iter().map(|x| &x.value).collect::<Vec<_>>()
+        );
+    }
+
+    /// Genuine `.ru` domains must still be detected — fix shouldn't regress
+    /// real ccTLD matches.
+    #[test]
+    fn test_genuine_ru_domain_still_matches() {
+        let m = find_matches("Movie.tracker.ru.x264.mkv");
+        assert!(
+            m.iter().any(|x| x.value == "tracker.ru"),
+            "genuine `.ru` domain should still match, got: {:?}",
+            m.iter().map(|x| &x.value).collect::<Vec<_>>()
+        );
+    }
+
+    /// Word-boundary guard should also reject other letter-extended TLDs:
+    /// `.com` inside `.community`, `.net` inside `.network`, etc.
+    #[test]
+    fn test_no_false_positive_on_extended_tld_suffixes() {
+        for sample in [
+            "Show.s01e01.community.center.720p",
+            "Show.s01e01.networking.event.720p",
+            "Show.s01e01.organic.farm.720p",
+        ] {
+            let m = find_matches(sample);
+            assert!(
+                m.is_empty(),
+                "TLD-as-prefix-of-word must not match for {sample:?}, got: {:?}",
+                m.iter().map(|x| &x.value).collect::<Vec<_>>()
+            );
+        }
     }
 }

--- a/tests/fixtures/rules/website.yml
+++ b/tests/fixtures/rules/website.yml
@@ -24,3 +24,10 @@
 
 ? www.4MovieRulz.be - Ginny Weds Sunny (2020) 1080p Hindi Proper HDRip x264 DD5.1 - 2.4GB ESub.mkv
 : website: www.4MovieRulz.be
+
+# Regression for #163: language abbreviations like `.rus`, `.deu`, etc. must
+# not be misread as ccTLD websites by the inline matcher.
+? -Community.s02e20.rus.eng.720p.Kybik.v.Kybe
+  -Movie.s01e02.deu.eng.1080p.WEB-GROUP
+  -Show.s03e04.fra.eng.720p.HDTV-GROUP
+: website: s02e20.ru


### PR DESCRIPTION
## Summary

Fixes #163. The inline website matcher's TLD alternation lacked a trailing word boundary, so `.ru` would false-positive inside the Russian-language abbreviation `.rus`, producing nonsense output like:

```console
$ hunch "Community.s02e20.rus.eng.720p.Kybik.v.Kybe"
{
  ...
  "language": ["Russian", "English"],
  "website": "s02e20.ru"   ← bogus
}
```

## Fix

A single-character regex tightening on `WEBSITE_INLINE` (`src/properties/website.rs`): append `\b` after the TLD alternation. The TLD must now end on a word boundary, so `.ru` can no longer match inside `.rus` (or `.com` inside `.community`, etc.).

```diff
- r"(?P<site>(?:www\.)?[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.(?:com|org|net|info|tv|io|ru|cc))"
+ r"(?P<site>(?:www\.)?[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.(?:com|org|net|info|tv|io|ru|cc))\b"
```

### Why not the other paths suggested in the issue?

- **Bracket matcher** (`WEBSITE_BRACKET`) — already protected. Brackets terminate the match, and the existing `has_known_tld` check rejects unknown TLDs like `rus` / `deu` / `fra`.
- **`From`-prefix matcher** (`WEBSITE_FROM`) — already protected by the greedy `[a-zA-Z0-9-]+` segment, which slurps the whole `rus` rather than stopping at `ru`.
- **Zone-aware constraint** — overkill for a one-byte regex bug, and the issue itself rated path 2 (regex tightening) as cheapest.

The `\b` approach also generalises: any future TLD added to the inline list inherits the protection without per-TLD logic. DRY ✅, YAGNI ✅.

## Verification

End-to-end against the bug case:

```console
$ ./target/release/hunch "Community.s02e20.rus.eng.720p.Kybik.v.Kybe"
{
  "episode": 20,
  "language": ["Russian", "English"],
  "release_group": "v.Kybe",
  "screen_size": "720p",
  "season": 2,
  "title": "Community",
  "type": "episode"
}
```

No more `website` field. ✅

Spot-checks of related cases:

| Input | Expected `website` | Actual |
|---|---|---|
| `Community.s02e20.rus.eng.720p.Kybik.v.Kybe` | _(none)_ | _(none)_ ✅ |
| `Movie.[tvu.org.ru].avi` | `tvu.org.ru` | `tvu.org.ru` ✅ |
| `Movie.720p.MkvCage.com.mkv` | `MkvCage.com` | `MkvCage.com` ✅ |
| `Movie.s01e02.deu.eng.1080p.WEB-GROUP` | _(none)_ | _(none)_ ✅ |

## Tests

- **3 new unit tests** in `src/properties/website.rs`:
  - `test_no_false_positive_on_language_abbrev_rus` — pins the original bug
  - `test_genuine_ru_domain_still_matches` — guards against over-correction
  - `test_no_false_positive_on_extended_tld_suffixes` — generalisation across `.com`/`.net`/`.org`
- **Fixture entry** in `tests/fixtures/rules/website.yml` covering the bug case plus `.deu` / `.fra` siblings.
- Full `cargo test` passes (282 unit + all integration suites). `cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

## Acceptance criteria (from #163)

- [x] `Community.s02e20.rus.eng.720p.Kybik.v.Kybe` produces NO `website` field
- [x] Genuine `.ru`-domain websites still detected (covered by `test_genuine_ru_domain_still_matches`)
- [x] Same fix applies to other ccTLDs that are language abbreviation prefixes (the `\b` guard is TLD-agnostic; verified for `.deu` and `.fra` in the new fixture rows)
- [x] Regression test pinning the corrected behaviour
