### PR TITLE
feat(ci): add nightly mutation testing via cargo-mutants (#146)

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,133 @@
+name: Mutation Tests
+
+# Mutation testing complements line/region coverage by checking whether
+# the test suite would actually *catch* a bug — a mutation that changes
+# behavior but doesn't break any test signals a weak assertion.
+#
+# Slow by nature: ~13 seconds per mutant (rebuild + test the whole crate)
+# means a full crate-wide run (~2,876 mutants as of v1.1.8) is ~10 hours.
+# So we DON'T run on every PR. This workflow runs nightly against the
+# two highest-value targets identified in the epic (#146):
+#   - src/pipeline/mod.rs   (~57 mutants, the orchestration core)
+#   - src/properties/title/clean.rs   (~99 mutants, the busiest property)
+#
+# Future PRs in the epic expand scope — see docs/mutation-baseline.md.
+
+on:
+  schedule:
+    # Nightly at 03:14 UTC — well clear of crates.io publish windows
+    # and after the daily Dependabot wave.
+    - cron: "14 3 * * *"
+  workflow_dispatch:
+    # Allows manual trigger from the Actions UI (e.g., to re-run after
+    # a coverage-improving PR lands).
+
+concurrency:
+  # Only one mutation run at a time — they're slow and the artifact
+  # naming would collide.
+  group: mutants
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  mutants:
+    name: cargo-mutants (high-value targets)
+    runs-on: ubuntu-latest
+    # 90 min hard cap. Local single-threaded estimate for the two scoped
+    # files is ~35 min; with --jobs 4 on the GH runner we expect 12–15 min.
+    # The cap exists to fail loud if cargo-mutants regresses or the test
+    # suite gets dramatically slower.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          key: mutants
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a  # v2
+        with:
+          tool: cargo-mutants
+
+      - name: Run cargo-mutants on high-value targets
+        # --no-shuffle: deterministic mutation order makes diffing
+        #               outcomes between runs trivially possible.
+        # --jobs 4:    parallelism cap matches GH ubuntu-latest's
+        #              practical CPU concurrency. Higher values
+        #              start fighting over the test runner.
+        # --in-place:  mutate in the working copy (faster than
+        #              cargo-mutants' default temp-dir-per-mutant).
+        # || true:     surviving mutants must NOT fail the workflow —
+        #              this job is an *advisory* signal that gets
+        #              triaged via docs/mutation-baseline.md, not a
+        #              hard merge gate. Real failures (build errors,
+        #              tool crashes) still surface in the artifact.
+        run: |
+          cargo mutants \
+            --no-shuffle \
+            --jobs 4 \
+            --in-place \
+            --file src/pipeline/mod.rs \
+            --file src/properties/title/clean.rs \
+            || true
+
+      - name: Generate Job Summary
+        if: always()
+        run: |
+          # Pretty-print the per-category counts to the GH Job Summary
+          # so reviewers don't have to download the artifact for a
+          # quick health check. Uses jq (preinstalled on ubuntu-latest)
+          # to keep the YAML free of nested heredoc escaping.
+          {
+            echo "# 🧬 Mutation Test Results"
+            echo ""
+            echo "**Targets**: \`src/pipeline/mod.rs\`, \`src/properties/title/clean.rs\`"
+            echo ""
+            if [ -f mutants.out/outcomes.json ]; then
+              CAUGHT=$(jq -r '.caught // 0' mutants.out/outcomes.json)
+              MISSED=$(jq -r '.missed // 0' mutants.out/outcomes.json)
+              TIMEOUT=$(jq -r '.timeout // 0' mutants.out/outcomes.json)
+              UNVIABLE=$(jq -r '.unviable // 0' mutants.out/outcomes.json)
+              TOTAL=$(jq -r '.total_mutants // 0' mutants.out/outcomes.json)
+              # awk handles the divide-by-zero case + float math without
+              # bringing in python or bc.
+              RATE=$(awk -v c="$CAUGHT" -v t="$TOTAL" 'BEGIN{ if(t==0) print "n/a"; else printf "%.1f", c*100/t }')
+              echo "| Outcome | Count |"
+              echo "|---|---|"
+              echo "| ✅ Caught (test killed mutant) | $CAUGHT |"
+              echo "| ⚠️ Missed (mutant survived) | $MISSED |"
+              echo "| ⏱️ Timeout | $TIMEOUT |"
+              echo "| 🚫 Unviable (didn't compile) | $UNVIABLE |"
+              echo "| **Total** | **$TOTAL** |"
+              echo ""
+              echo "**Kill rate**: ${RATE}% (target: ≥ 80%)"
+              echo ""
+              if [ -s mutants.out/missed.txt ]; then
+                echo "## Surviving mutants (triage these)"
+                echo ""
+                echo '```'
+                cat mutants.out/missed.txt
+                echo '```'
+                echo ""
+                echo "See [docs/mutation-baseline.md](../blob/main/docs/mutation-baseline.md) for triage guidance."
+              else
+                echo "## 🎉 No surviving mutants — every mutation was caught by a test."
+              fi
+            else
+              echo "⚠️ \`mutants.out/outcomes.json\` not found — see job logs."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload mutants.out artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: mutants-out
+          path: mutants.out/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /target/
+# cargo-mutants output (see docs/mutation-baseline.md)
+/mutants.out/
+/mutants.out.old/
 *.db
 *.sqlite
 *.csv

--- a/docs/mutation-baseline.md
+++ b/docs/mutation-baseline.md
@@ -1,0 +1,167 @@
+# Mutation Testing Baseline
+
+Hunch uses [`cargo-mutants`](https://mutants.rs/) to measure **assertion
+quality**, not just code coverage. Mutation testing mutates the source
+(flips `==` to `!=`, replaces `+` with `-`, etc.) and runs the test suite
+against each mutated build. A mutation that **survives** all tests means
+no test would actually catch that bug — the line might be 100% covered
+yet still fail to detect a real regression.
+
+This complements [code coverage (#145)](./coverage.md): coverage tells us
+which lines run; mutation testing tells us which lines have **strong
+assertions**.
+
+## How it runs
+
+A nightly GitHub Actions workflow ([`.github/workflows/mutants.yml`](../.github/workflows/mutants.yml))
+runs `cargo mutants` against the highest-value targets at 03:14 UTC and
+publishes results as a Job Summary + downloadable `mutants-out` artifact.
+
+The job is **advisory** (`|| true` on the run step) — surviving mutants
+do not fail CI. They get triaged here and addressed in follow-up PRs.
+
+You can also trigger it on demand from the Actions UI via
+**Run workflow** → **Mutation Tests**.
+
+## Scope (first slice)
+
+The full crate has ~2,876 mutants and would take ~10 hours single-threaded.
+This first slice scopes the nightly run to two highest-value targets
+identified in the [Mutation testing epic (#146)](https://github.com/lijunzh/hunch/issues/146):
+
+| File | Mutants | Why |
+|---|---|---|
+| `src/pipeline/mod.rs` | ~57 | Orchestration core — every property runs through here |
+| `src/properties/title/clean.rs` | ~99 | Busiest property module; PR-C #138 added kitchen-sink coverage |
+
+Combined run with `--jobs 4` on a GitHub-hosted ubuntu runner: **~12–15 min**.
+
+## Roadmap
+
+Sequenced expansion (each is its own PR within the #146 epic):
+
+1. **Add the `Pipeline` neighbours**: `pipeline/context.rs`, `pipeline/invariance.rs`,
+   `pipeline/mod.rs`'s sibling helpers.
+2. **Add the `properties/title/` strategies**: `secondary.rs`, `mod.rs`,
+   the four `strategies/*.rs` modules.
+3. **Add the matcher core**: `src/matcher/`, `src/zone_map.rs`, `src/tokenizer.rs`.
+4. **Opt-in PR-time check**: a `mutation-test` label triggers a diff-only
+   mutants run on the PR (cheap subset). Requires #146's epic-level decision
+   on labelling.
+5. **Hard kill-rate gate**: fail the nightly if kill rate drops more than
+   N% below baseline. Deferred until baseline has settled across enough
+   nightly runs to characterise noise.
+
+## Local usage
+
+Install once (note: requires `--locked` so the version matches CI):
+
+```bash
+cargo install cargo-mutants --locked
+```
+
+Run against one file (~5 min for a small file):
+
+```bash
+cargo mutants --file src/properties/year.rs --no-shuffle
+```
+
+Run against the same scope CI uses:
+
+```bash
+cargo mutants --no-shuffle --jobs 4 \
+  --file src/pipeline/mod.rs \
+  --file src/properties/title/clean.rs
+```
+
+Outputs land in `./mutants.out/`:
+
+| File | Contents |
+|---|---|
+| `outcomes.json` | Machine-readable per-mutant results + counts |
+| `missed.txt`    | Surviving mutants (the interesting ones) |
+| `caught.txt`    | Killed mutants (good — your tests work) |
+| `timeout.txt`   | Tests that hung — usually infinite-loop mutations |
+| `unviable.txt`  | Mutants that didn't compile (rare, ignorable) |
+
+`mutants.out/` is gitignored.
+
+## Worked example: `src/properties/year.rs`
+
+A pre-PR smoke run on `year.rs` (20 mutants, ~5 min) produced **3 surviving
+mutants** that demonstrate the categories we'll see in nightly results:
+
+### Equivalent mutation (accepted survival)
+
+```text
+src/properties/year.rs:19:15: replace < with <= in find_matches
+```
+
+```rust
+let mut pos = 0;
+while pos < input.len() {       // mutation: pos <= input.len()
+    let Some(m) = YEAR_RE.find_at(input, pos) else {
+        break;
+    };
+```
+
+When `pos == input.len()`, `Regex::find_at` returns `None` and the loop
+exits via the `else` branch on the next line — so `<` and `<=` produce
+identical observable behaviour. **Equivalent mutation; document and
+move on.**
+
+### Real test gaps (backlog — file as follow-up issues)
+
+```text
+src/properties/year.rs:26:22: replace > with < in find_matches
+src/properties/year.rs:29:20: replace < with > in find_matches
+```
+
+```rust
+// Boundary: no digit before or after.
+if m.start() > 0 && bytes[m.start() - 1].is_ascii_digit() {  // L26
+    continue;
+}
+if m.end() < bytes.len() && bytes[m.end()].is_ascii_digit() { // L29
+    continue;
+}
+```
+
+Both mutations bypass the boundary check (the inverted comparison
+short-circuits via `&&` so the check never runs). They survive because
+**no test exercises a year touching the start or end of the input string**.
+Trivial fix: add fixtures like `2020` (year alone), `12020.mkv` (digit
+prefix), `20201.mkv` (digit suffix) and assert the boundary rejection.
+
+These two are not fixed in this PR — that's deliberate. This PR sets up
+the *infrastructure* to find findings; fixing them is the next loop.
+
+## Triage protocol
+
+When the nightly job posts a Job Summary with surviving mutants:
+
+1. **Equivalent mutation?** (the mutation produces identical observable
+   behaviour) → add a one-line entry to the "Accepted equivalents" table
+   below with the mutation string + a one-sentence rationale.
+2. **Real test gap?** → file a `tech-debt` issue with the mutation string
+   in the title, link the surviving-mutants table from the most recent
+   nightly run, and assign to the next coverage-improvement loop.
+3. **Tool bug / unviable mis-classification?** → file upstream at
+   <https://github.com/sourcefrog/cargo-mutants>.
+
+## Accepted equivalents
+
+| Mutation | Why it's equivalent | Accepted on |
+|---|---|---|
+| `src/properties/year.rs:19:15: replace < with <= in find_matches` | `find_at(input, input.len())` returns `None`; `<` and `<=` produce identical loop behaviour. | 2026-04-18 (smoke run) |
+
+(Future entries get appended as they're triaged.)
+
+## References
+
+- [`cargo-mutants` book](https://mutants.rs/)
+- Epic [#146](https://github.com/lijunzh/hunch/issues/146)
+- Sibling: code coverage [#145](https://github.com/lijunzh/hunch/issues/145) /
+  [`docs/coverage.md`](./coverage.md)
+- Industry benchmark: 80% kill rate is the rough north star for parser
+  code (mature mutation-tested Rust crates land 75–90%).


### PR DESCRIPTION
## Summary

First slice of the [Mutation testing epic (#146)](https://github.com/lijunzh/hunch/issues/146). Now unblocked by the coverage-CI epic (#145 / #168). Adds `cargo-mutants` as a **nightly** CI job + triage methodology + worked-example findings.

Mutation testing complements line coverage: coverage tells us which lines run; mutation testing tells us which lines have **strong assertions** (a mutation that survives means no test would actually catch that bug, even though the line is "covered").

## What's in this PR

- **New nightly workflow** `.github/workflows/mutants.yml` — runs at 03:14 UTC + manual `workflow_dispatch`, scoped to `src/pipeline/mod.rs` + `src/properties/title/clean.rs` (~156 mutants combined, ~12–15 min with `--jobs 4` on a GH ubuntu runner). Posts a per-category Job Summary table with kill rate + surviving-mutant list, and uploads the full `mutants.out/` as a 30-day-retention artifact for triage.
- **New `docs/mutation-baseline.md`** — methodology, scope rationale, expansion roadmap, local usage, a full worked example, and a triage protocol contributors follow when nightly findings come in.
- **`/mutants.out/` added to `.gitignore`**.

## Worked-example findings (real data)

Pre-PR smoke run on `src/properties/year.rs` (20 mutants, ~5 min) produced **3 surviving mutants** that demonstrate the categories we'll see in nightly results:

| Mutation | Category | Action |
|---|---|---|
| `year.rs:19:15: replace < with <= in find_matches` | Equivalent (loop bounds; `find_at` returns None at end-of-input) | ✅ Accepted into the equivalent-mutations table |
| `year.rs:26:22: replace > with < in find_matches` | Real test gap (no test exercises a year touching the start of input) | 📋 Backlog |
| `year.rs:29:20: replace < with > in find_matches` | Real test gap (no test exercises a year touching the end of input) | 📋 Backlog |

Both gaps are trivially fixable (~3 fixture rows each), but **deliberately not fixed in this PR** — that's scope creep. This PR sets up the *infrastructure*; fixing findings is the next loop.

## Job Summary preview

The workflow renders something like this on every nightly run (verified locally against a synthetic `outcomes.json`):

> # 🧬 Mutation Test Results
>
> **Targets**: `src/pipeline/mod.rs`, `src/properties/title/clean.rs`
>
> | Outcome | Count |
> |---|---|
> | ✅ Caught | 138 |
> | ⚠️ Missed | 12 |
> | ⏱️ Timeout | 4 |
> | 🚫 Unviable | 2 |
> | **Total** | **156** |
>
> **Kill rate**: 88.5% (target: ≥ 80%)
>
> ## Surviving mutants
> ```
> src/pipeline/mod.rs:42:18: replace == with != in run
> src/properties/title/clean.rs:108:7: replace > with >= in clean_brackets
> ```

## Design choices worth flagging

| Choice | Why |
|---|---|
| **Advisory** (`\|\| true` on the run step) | Surviving mutants are informational, not a hard gate. Hard kill-rate gate explicitly deferred until baseline has settled across enough nightly runs to characterise noise. |
| **Scoped to two files** | Full crate is ~2,876 mutants (~10 hours single-threaded); nightly CI must complete inside reasonable budget. The two scoped files are the issue's own recommended starting points (`pipeline/mod.rs` = orchestration core; `title/clean.rs` = busiest property module). Roadmap in the doc sequences expansion. |
| **`jq` + `awk`** for the Job Summary | Tried embedding a Python heredoc inside the YAML `run:` block first — too fragile (nested heredoc escaping, indent stripping). `jq` + `awk` are preinstalled on `ubuntu-latest`, no pip wheels, no escaping landmines. Verified locally. |
| **`taiki-e/install-action`** for cargo-mutants | Same pattern set by the coverage job (#168) — prebuilt binary in seconds vs ~3 min for `cargo install`. Pinned to a commit SHA per supply-chain hardening convention. |
| **Nightly cron, not per-PR** | `cargo-mutants` is fundamentally slow. Per-PR runs would either (a) require restricting to diff-only mutants — that's the deferred opt-in label workflow — or (b) blow up CI time. Nightly is the natural fit and matches the issue's specification. |

## Explicitly deferred to follow-up PRs in the epic

- **PR-time opt-in `mutation-test` label workflow** — runs cargo-mutants on the diff only when a PR has the label
- **Hard kill-rate regression gate** — fails nightly if kill rate drops more than N% below baseline
- **Expansion to remaining files** — `pipeline/context.rs`, `pipeline/invariance.rs`, the `title/strategies/*` modules, `matcher/`, `tokenizer.rs`, `zone_map.rs`, etc. (sequenced roadmap in the doc)

Each is its own clean PR within the #146 epic.

## Verification

- ✅ `actionlint .github/workflows/mutants.yml` — clean
- ✅ YAML parses cleanly (`PyYAML`)
- ✅ Full `cargo test` suite still green (525+ tests)
- ✅ Job Summary script tested locally against a sample `outcomes.json` — renders **88.5% kill rate** from synthetic `138/156` input correctly (see screenshot in the PR thread once posted)
- ✅ `cargo-mutants` smoke run on `year.rs` confirms tool behaves as documented (3 surviving mutants found, exactly as documented in `docs/mutation-baseline.md`)

## Acceptance criteria from #146

- [x] Nightly CI workflow runs `cargo mutants` on a fresh checkout of main
- [x] Surviving mutants reported as a GitHub Actions Job Summary
- [x] Triage doc (`docs/mutation-baseline.md`) listing accepted survivals with rationale
- [ ] PR-time opt-in label workflow — _deferred to follow-up PR (see "Explicitly deferred")_
- [ ] Baseline target: kill rate ≥ 80% — _will be measured by the first nightly run after merge; threshold gate deferred_

## How to validate after merge

1. Go to **Actions → Mutation Tests → Run workflow** to trigger an out-of-band run on `main`
2. Wait ~12–15 min for the job to complete
3. Open the Job Summary tab to see the rendered kill-rate table
4. Download the `mutants-out` artifact for the full `outcomes.json` + per-category `*.txt` files
5. Triage any surviving mutants per the protocol in `docs/mutation-baseline.md`

Refs #146
