### PR TITLE
fix(ci/mutants): drop --in-place, harden exit-code handling

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -60,21 +60,39 @@ jobs:
         # --jobs 4:    parallelism cap matches GH ubuntu-latest's
         #              practical CPU concurrency. Higher values
         #              start fighting over the test runner.
-        # --in-place:  mutate in the working copy (faster than
-        #              cargo-mutants' default temp-dir-per-mutant).
-        # || true:     surviving mutants must NOT fail the workflow —
-        #              this job is an *advisory* signal that gets
-        #              triaged via docs/mutation-baseline.md, not a
-        #              hard merge gate. Real failures (build errors,
-        #              tool crashes) still surface in the artifact.
+        #              (Mutually exclusive with --in-place since
+        #              parallel workers would conflict on shared
+        #              source files; cargo-mutants instead copies
+        #              the source to per-worker scratch dirs.)
+        #
+        # Exit-code handling: cargo-mutants returns
+        #   0 = all mutants caught (great)
+        #   1 = some mutants survived (interesting; expected; not a build failure)
+        #   2 = mutants timed out (also not a build failure)
+        #   3 = unviable mutations (rare; not a build failure)
+        #   other = real error (usage error, build broke, tool crashed)
+        # We only swallow 0–3. A usage error must still fail the job
+        # so we don't repeat the silent-no-op problem from the first
+        # run after #169 (the original `|| true` masked an --in-place
+        # / --jobs incompatibility for the entire run).
         run: |
+          set +e
           cargo mutants \
             --no-shuffle \
             --jobs 4 \
-            --in-place \
             --file src/pipeline/mod.rs \
-            --file src/properties/title/clean.rs \
-            || true
+            --file src/properties/title/clean.rs
+          status=$?
+          set -e
+          case "$status" in
+            0|1|2|3)
+              echo "cargo-mutants completed (exit $status — mutants survived/timed-out is expected)"
+              ;;
+            *)
+              echo "::error::cargo-mutants failed with unexpected exit $status (likely a usage error or tool crash)"
+              exit $status
+              ;;
+          esac
 
       - name: Generate Job Summary
         if: always()


### PR DESCRIPTION
## Summary

Hot-fix for #169. The first manual dispatch of the nightly mutation workflow ([run 24614353621](https://github.com/lijunzh/hunch/actions/runs/24614353621)) silently no-op'd: completed in ~25 seconds with `conclusion: success` and no artifacts. The job log told the real story:

```
error: the argument '--jobs <JOBS>' cannot be used with '--in-place'
```

`cargo-mutants v27` makes `--in-place` and `--jobs > 1` mutually exclusive (parallel workers would conflict on shared source files). The original `|| true` swallowed the usage-error exit code, so the workflow showed green while having done literally nothing useful.

## Fix

Three small changes to `.github/workflows/mutants.yml`:

1. **Drop `--in-place`.** Parallelism (`--jobs 4`) saves far more wall-clock than the in-place skip-the-copy optimisation costs. cargo-mutants's default (copy source to per-worker scratch dirs) is the only mode compatible with concurrent workers.

2. **Replace blanket `|| true` with explicit exit-code handling:**
   ```bash
   set +e
   cargo mutants ...
   status=$?
   set -e
   case "$status" in
     0|1|2|3) echo "completed" ;;       # expected outcomes
     *) echo "::error::..."; exit $status ;;  # real failure
   esac
   ```
   Same pattern as the cargo-publish guard in `release.yml` — swallow only the known-benign cases (some mutants survived, some timed out, some were unviable), fail loudly on everything else (usage error, tool crash, build broken).

3. **Update the inline comments** to document the `--in-place` / `--jobs` incompatibility so future-us doesn't re-introduce the bug.

## Why blanket `|| true` was the real bug

The flag mistake itself was a five-second fix. The architectural lesson is that `|| true` makes a workflow incapable of distinguishing "did the job and the answer is interesting" from "didn't do the job at all." That's a worse outcome than failing loudly. The new exit-code allowlist preserves the original "advisory" semantics (surviving mutants don't fail CI) while restoring the ability to detect genuine breakage.

## Verification

- ✅ `actionlint .github/workflows/mutants.yml` — clean
- ✅ YAML parses cleanly (PyYAML)
- ⏳ A manual dispatch on this PR branch (or after merge) should now actually run cargo-mutants for ~12–15 min and produce real `mutants-out` artifacts. Because the workflow only fires on `schedule` and `workflow_dispatch`, no checks will appear on this PR itself — same as #169.

## How to validate after merge

1. **Actions → Mutation Tests → Run workflow → main** to trigger
2. Watch for ~12–15 min runtime (vs ~25s before this fix)
3. Confirm `mutants-out` artifact is downloadable and contains real `outcomes.json` + `missed.txt`
4. Confirm the Job Summary tab renders the kill-rate table with non-zero counts

If a future tool upgrade re-introduces a usage incompatibility, the workflow will now surface it as a `::error::` annotation + non-success conclusion instead of pretending everything is fine.

Refs #146
