### PR TITLE
fix(api): mark public enums #[non_exhaustive] (#144)

### DIFF
--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -111,7 +111,11 @@ PRs:
   the property modules) en masse.
 - **`#[non_exhaustive]`** on the public enums (`Confidence`,
   `HunchResult` field types) so future variant additions aren't
-  SemVer-major.
+  SemVer-major. _Partially landed in #172: `Property`, `MediaType`,
+  `Source`, `Separator`, `BracketKind`, `ZoneScope`, `CharClass` now
+  bear the attribute. `Confidence` and `SegmentKind` deliberately
+  excluded — they're conceptually saturated (Low/Med/High and
+  Directory/Filename respectively)._
 - **Promote the CI job from advisory → blocking** once the surface has
   stabilised post-audit.
 

--- a/docs/public-api.txt
+++ b/docs/public-api.txt
@@ -3,7 +3,7 @@ pub mod hunch::matcher
 pub mod hunch::matcher::engine
 pub fn hunch::matcher::engine::resolve_conflicts(matches: &mut alloc::vec::Vec<hunch::matcher::span::MatchSpan>)
 pub mod hunch::matcher::regex_utils
-pub enum hunch::matcher::regex_utils::CharClass
+#[non_exhaustive] pub enum hunch::matcher::regex_utils::CharClass
 pub hunch::matcher::regex_utils::CharClass::Alpha
 pub hunch::matcher::regex_utils::CharClass::AlphaDigit
 pub hunch::matcher::regex_utils::CharClass::Custom(alloc::vec::Vec<(u8, u8)>)
@@ -51,7 +51,7 @@ impl core::panic::unwind_safe::UnwindSafe for hunch::matcher::regex_utils::Bound
 pub fn hunch::matcher::regex_utils::captures_iter_bounded<'a>(re: &'a regex::regex::string::Regex, input: &'a str, boundary: &hunch::matcher::regex_utils::BoundarySpec) -> alloc::vec::Vec<regex::regex::string::Captures<'a>>
 pub fn hunch::matcher::regex_utils::check_boundary(input: &[u8], start: usize, end: usize, spec: &hunch::matcher::regex_utils::BoundarySpec) -> bool
 pub mod hunch::matcher::rule_loader
-pub enum hunch::matcher::rule_loader::ZoneScope
+#[non_exhaustive] pub enum hunch::matcher::rule_loader::ZoneScope
 pub hunch::matcher::rule_loader::ZoneScope::AfterAnchor
 pub hunch::matcher::rule_loader::ZoneScope::TechOnly
 pub hunch::matcher::rule_loader::ZoneScope::Unrestricted
@@ -132,7 +132,7 @@ impl<'a> core::marker::UnsafeUnpin for hunch::matcher::rule_loader::TokenMatch<'
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for hunch::matcher::rule_loader::TokenMatch<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for hunch::matcher::rule_loader::TokenMatch<'a>
 pub mod hunch::matcher::span
-pub enum hunch::matcher::span::Property
+#[non_exhaustive] pub enum hunch::matcher::span::Property
 pub hunch::matcher::span::Property::AbsoluteEpisode
 pub hunch::matcher::span::Property::AlternativeTitle
 pub hunch::matcher::span::Property::AspectRatio
@@ -212,7 +212,7 @@ impl core::marker::Unpin for hunch::matcher::span::Property
 impl core::marker::UnsafeUnpin for hunch::matcher::span::Property
 impl core::panic::unwind_safe::RefUnwindSafe for hunch::matcher::span::Property
 impl core::panic::unwind_safe::UnwindSafe for hunch::matcher::span::Property
-pub enum hunch::matcher::span::Source
+#[non_exhaustive] pub enum hunch::matcher::span::Source
 pub hunch::matcher::span::Source::Context
 pub hunch::matcher::span::Source::Heuristic
 pub hunch::matcher::span::Source::Structural
@@ -269,7 +269,7 @@ impl core::marker::Unpin for hunch::matcher::span::MatchSpan
 impl core::marker::UnsafeUnpin for hunch::matcher::span::MatchSpan
 impl core::panic::unwind_safe::RefUnwindSafe for hunch::matcher::span::MatchSpan
 impl core::panic::unwind_safe::UnwindSafe for hunch::matcher::span::MatchSpan
-pub enum hunch::matcher::Property
+#[non_exhaustive] pub enum hunch::matcher::Property
 pub hunch::matcher::Property::AbsoluteEpisode
 pub hunch::matcher::Property::AlternativeTitle
 pub hunch::matcher::Property::AspectRatio
@@ -436,7 +436,7 @@ pub fn hunch::properties::website::find_matches(input: &str) -> alloc::vec::Vec<
 pub mod hunch::properties::year
 pub fn hunch::properties::year::find_matches(input: &str) -> alloc::vec::Vec<hunch::matcher::span::MatchSpan>
 pub mod hunch::tokenizer
-pub enum hunch::tokenizer::BracketKind
+#[non_exhaustive] pub enum hunch::tokenizer::BracketKind
 pub hunch::tokenizer::BracketKind::Curly
 pub hunch::tokenizer::BracketKind::Round
 pub hunch::tokenizer::BracketKind::Square
@@ -475,7 +475,7 @@ impl core::marker::Unpin for hunch::tokenizer::SegmentKind
 impl core::marker::UnsafeUnpin for hunch::tokenizer::SegmentKind
 impl core::panic::unwind_safe::RefUnwindSafe for hunch::tokenizer::SegmentKind
 impl core::panic::unwind_safe::UnwindSafe for hunch::tokenizer::SegmentKind
-pub enum hunch::tokenizer::Separator
+#[non_exhaustive] pub enum hunch::tokenizer::Separator
 pub hunch::tokenizer::Separator::Dash
 pub hunch::tokenizer::Separator::Dot
 pub hunch::tokenizer::Separator::None
@@ -676,7 +676,7 @@ impl core::marker::Unpin for hunch::Confidence
 impl core::marker::UnsafeUnpin for hunch::Confidence
 impl core::panic::unwind_safe::RefUnwindSafe for hunch::Confidence
 impl core::panic::unwind_safe::UnwindSafe for hunch::Confidence
-pub enum hunch::MediaType
+#[non_exhaustive] pub enum hunch::MediaType
 pub hunch::MediaType::Episode
 pub hunch::MediaType::Extra
 pub hunch::MediaType::Movie
@@ -698,7 +698,7 @@ impl core::marker::Unpin for hunch::MediaType
 impl core::marker::UnsafeUnpin for hunch::MediaType
 impl core::panic::unwind_safe::RefUnwindSafe for hunch::MediaType
 impl core::panic::unwind_safe::UnwindSafe for hunch::MediaType
-pub enum hunch::Property
+#[non_exhaustive] pub enum hunch::Property
 pub hunch::Property::AbsoluteEpisode
 pub hunch::Property::AlternativeTitle
 pub hunch::Property::AspectRatio

--- a/src/hunch_result.rs
+++ b/src/hunch_result.rs
@@ -34,8 +34,13 @@ pub enum Confidence {
 }
 
 /// The type of media detected.
+///
+/// `#[non_exhaustive]` so future variants (e.g. `Music`, `TVMovie`) can be
+/// added in minor releases without a SemVer break. Downstream `match`es must
+/// include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum MediaType {
     /// A standalone movie / film.
     Movie,

--- a/src/matcher/regex_utils.rs
+++ b/src/matcher/regex_utils.rs
@@ -15,7 +15,12 @@ pub struct BoundarySpec {
 }
 
 /// A character class for boundary checking.
+///
+/// `#[non_exhaustive]` so future built-in classes can be added in minor
+/// releases without a SemVer break. The escape hatch `Custom(Vec<(u8, u8)>)`
+/// already exists for arbitrary byte-range predicates.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum CharClass {
     /// `[a-z]`
     Lower,

--- a/src/matcher/rule_loader.rs
+++ b/src/matcher/rule_loader.rs
@@ -91,7 +91,11 @@ struct PatternRule {
 ///
 /// Controls whether matches are suppressed based on their position
 /// relative to the title zone boundary. See DESIGN.md D4.
+///
+/// `#[non_exhaustive]` so future scope policies can be added in minor
+/// releases without a SemVer break.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum ZoneScope {
     /// Match in all zones (default, backwards-compatible).
     /// Use for unambiguous tech tokens: codecs, suffixed resolutions.

--- a/src/matcher/span.rs
+++ b/src/matcher/span.rs
@@ -13,7 +13,11 @@ use std::fmt;
 /// This tag is purely informational: it feeds logging (`[CONTEXT]`,
 /// `[HEURISTIC]` prefixes) and confidence scoring. It does **not** affect
 /// conflict resolution — priority is still the authority there.
+///
+/// `#[non_exhaustive]` so future provenance categories (e.g. ML-derived) can
+/// be added in minor releases without a SemVer break.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
 pub enum Source {
     /// Matched by a deterministic structural rule (SxxExx, parenthesized year,
     /// codec keyword, etc.). This is the default and "happy path".
@@ -56,7 +60,12 @@ macro_rules! define_properties {
         /// Each variant corresponds to one metadata field in the final
         /// [`HunchResult`](crate::HunchResult). Use [`Property::from_name`] to parse
         /// from a string, or [`fmt::Display`] to convert back.
+        ///
+        /// `#[non_exhaustive]` so new property kinds (e.g. `Mimetype`,
+        /// `AudioBitRate`) can be added in minor releases without a SemVer
+        /// break. Downstream `match`es must include a wildcard arm.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        #[non_exhaustive]
         pub enum Property {
             $( $(#[$meta])* $variant ),*
         }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -67,7 +67,11 @@ impl Token {
 }
 
 /// The separator that preceded a token.
+///
+/// `#[non_exhaustive]` so future separator kinds (e.g. `Comma`, `Tab`) can
+/// be added in minor releases without a SemVer break.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Separator {
     /// No separator (start of input, or inside a compound token).
     None,
@@ -138,7 +142,11 @@ impl BracketGroup {
 }
 
 /// The type of bracket delimiter.
+///
+/// `#[non_exhaustive]` so future bracket kinds (e.g. `Angle` `<...>`) can
+/// be added in minor releases without a SemVer break.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BracketKind {
     /// `[...]`
     Square,


### PR DESCRIPTION
## Summary

Closes the SemVer-major leak that the api-surface tripwire (#171) and `semver-checks` together exposed: `Property` had picked up three new variants (`Mimetype`, `AudioBitRate`, `VideoBitRate`) since v1.1.8 without being marked `#[non_exhaustive]`, turning every minor-version variant addition into a SemVer-major break.

This is the first **action** PR off the audit epic (#144) — previous PRs in the chain were instrumentation; this one actually changes API behaviour.

## What changed

Added `#[non_exhaustive]` to **seven** public enums where future variant additions are realistic:

| Enum | Why it gets the attribute |
|---|---|
| `Property` | Already broke SemVer adding 3 variants — the immediate trigger |
| `MediaType` | Domain likely to grow (`Music`, `TVMovie`, etc.) |
| `Source` | Could add ML/LLM-derived provenance |
| `Separator` | Could add `Comma`, `Tab`, etc. |
| `BracketKind` | Could add `Angle` `<…>` |
| `ZoneScope` | Domain enum; new policies are plausible |
| `CharClass` | Has `Custom(...)` escape hatch — clearly extension-prone |

Deliberately **NOT** marked (the explicit-no-future-variants list):

| Enum | Why excluded |
|---|---|
| `Confidence` (Low/Med/High) | Conceptually saturated; no obvious 4th level |
| `SegmentKind` (Directory/Filename) | Genuinely binary by definition |

The "deliberately excluded" callout is in `docs/public-api.md` so future maintainers don't reflexively add `#[non_exhaustive]` to those two without thinking through the conceptual model first.

## Why pre-1.0 is the right time

Adding `#[non_exhaustive]` to an existing public enum is **itself** a SemVer-major change (downstream `match`-without-wildcard breaks). At 1.1.x with no external users on the line yet, this is free; at 2.0 it would require a major-version bump just for the attribute.

Internal matches are unaffected — `#[non_exhaustive]` only triggers the "missing wildcard arm" lint for downstream crates, not the defining crate. (Confirmed by the green test suite below.)

## Verification

- ✅ `cargo build`: clean
- ✅ `cargo test`: 282 lib tests + 13 integration tests + 0 ignored, all pass
- ✅ `cargo doctest`: all pass (no public match patterns in the docs broke)
- ✅ `docs/public-api.txt` regenerated: clean 9-line diff, all 7 enums correctly show `#[non_exhaustive]` in the snapshot:
  ```diff
  -pub enum hunch::matcher::regex_utils::CharClass
  +#[non_exhaustive] pub enum hunch::matcher::regex_utils::CharClass
  -pub enum hunch::matcher::rule_loader::ZoneScope
  +#[non_exhaustive] pub enum hunch::matcher::rule_loader::ZoneScope
  -pub enum hunch::matcher::span::Property
  +#[non_exhaustive] pub enum hunch::matcher::span::Property
  -pub enum hunch::matcher::span::Source
  +#[non_exhaustive] pub enum hunch::matcher::span::Source
  ... (and 5 more)
  ```
- ✅ `docs/public-api.md` audit-roadmap entry updated to reflect partial landing

## Expected CI impact

This PR is itself a clean test of the new infrastructure landed in the previous PRs:

| Job | Expected outcome |
|---|---|
| `Semver Checks` | **🟢 green** — the `enum_variant_added` failure was the only finding on #171; this PR fixes it |
| `Public API Surface` | **🟡 advisory yellow** — will report "9 additions, 9 removals" (the `#[non_exhaustive]` annotations rewriting each enum line). The diff in the Job Summary is exactly the intended change. The committed `docs/public-api.txt` matches, so the diff against the new baseline is empty — the job should actually be 🟢 green here |

Watching CI on this PR will be the first end-to-end validation that the tripwire + the regenerate-the-baseline workflow actually work together as documented.

Refs #144
