### PR TITLE
feat(ci): add advisory benchmark workflow with criterion (#148)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,115 @@
+name: Benchmarks
+
+# Performance regression tracking via criterion (the existing benches/ harness).
+#
+# First slice of the perf regression CI epic (#148). Honest scope:
+#
+#   - Runs `cargo bench` on weekly schedule + manual dispatch
+#   - Captures bencher-format output as an artifact (90-day retention)
+#   - **Advisory only** — does NOT compare against a baseline yet,
+#     does NOT comment on PRs, does NOT fail on regression
+#
+# Why this minimal first slice (vs the full epic DoD):
+#
+#   - GitHub-hosted runners are *noisy* (shared CPU). Naive PR-vs-main
+#     comparisons produce false positives that train people to ignore
+#     the signal entirely. Statistical-rigorous comparison needs care.
+#   - Setting up bencher.dev (the cloud option) requires picking a
+#     vendor, creating an account, configuring an API token. That's a
+#     repo-owner decision, not something to slip in via PR.
+#   - benchmark-action/github-action-benchmark needs a gh-pages branch
+#     for trend storage. That's a workspace structural change.
+#   - For now, accumulating a *history* of artifact runs lets us
+#     observe the noise floor and inform the comparison-strategy
+#     decision in the next slice. Honest first slice > flaky gate.
+#
+# Roadmap (deferred to follow-up PRs within #148):
+#   - PR-time job that runs benches on PR + main + posts a delta table
+#   - Hard-fail at >20% slower with p<0.01 (per epic DoD)
+#   - Per-release baseline snapshots committed to the repo
+#   - Decision on bencher.dev vs self-hosted noise filtering
+#
+# See docs/benchmarks.md for methodology + baseline numbers + roadmap.
+
+on:
+  schedule:
+    # Weekly Sunday 05:14 UTC. Weekly (not nightly) because:
+    #   - Benches are stable; running daily creates noise without signal
+    #   - Stagger position: 05:14 = 2 hours after fuzz nightly (03:14)
+    #     and 1 hour after mutation nightly (04:14). No runner contention.
+    - cron: "14 5 * * 0"
+  workflow_dispatch:
+    # Manual trigger for ad-hoc baselines (e.g., before/after a perf PR).
+  push:
+    branches: [main]
+    # Run on every push to main so we accumulate a baseline history.
+    # Path filter: skip docs-only and CI-only changes that can't move
+    # parser perf.
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'benches/**'
+      - '.github/workflows/benchmark.yml'
+
+concurrency:
+  # Only one bench run at a time — multiple runs would fight for the
+  # runner's already-noisy CPU and produce garbage numbers. Don't
+  # cancel in-progress runs; we want every triggered run to complete
+  # so the history is contiguous.
+  group: benchmark
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bench:
+    name: cargo bench (advisory)
+    runs-on: ubuntu-latest
+    # 30 min cap. Local M-class hardware completes in ~70s; ubuntu-latest
+    # is ~2-3× slower so estimate 3-4 min. The cap exists to fail loud
+    # if the bench harness regresses badly or hangs.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          # Separate cache key — benches use --release which produces
+          # different artifacts than the default dev profile cache.
+          key: bench
+
+      - name: Run benches (bencher output format)
+        # --output-format bencher: machine-parseable line-oriented format,
+        #   compatible with most third-party comparison tools (handy for
+        #   future slices that wire up bencher.dev / github-action-benchmark
+        #   without re-running the benches).
+        # --noplot: skip gnuplot/HTML report generation; we don't have
+        #   gnuplot installed and HTML is heavy for an artifact.
+        # 2>&1 + tee: capture both criterion's progress on stderr and
+        #   the result lines on stdout into one file.
+        run: |
+          mkdir -p bench-output
+          cargo bench --bench parse -- --output-format bencher --noplot \
+            2>&1 | tee bench-output/parse.txt
+          # Extract just the bencher-format result lines for easy diffing.
+          grep '^test ' bench-output/parse.txt > bench-output/parse-summary.txt || true
+          echo ""
+          echo "=== Summary ==="
+          cat bench-output/parse-summary.txt
+
+      - name: Upload bench results
+        # Always upload — even on cancellation we want partial data.
+        # 90-day retention so we have a multi-month rolling history
+        # when the next slice lands.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: bench-results-${{ github.sha }}
+          path: bench-output/
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,132 @@
+# Benchmarks
+
+Hunch uses [criterion](https://bheisler.github.io/criterion.rs/book/)
+to track parsing performance via `benches/parse.rs`. The
+[Benchmarks workflow](../.github/workflows/benchmark.yml) runs them
+weekly + on every push to `main` to accumulate a performance history.
+
+## How this fits in the quality stack
+
+| Layer | Catches | Where |
+|---|---|---|
+| **Coverage** (#168) | Which lines are exercised at all | [`coverage.md`](./coverage.md) |
+| **Mutation testing** (#146) | Whether tests actually catch bugs | [`mutation-baseline.md`](./mutation-baseline.md) |
+| **Fuzzing** (#147) | Crash-shape bugs on adversarial inputs | [`fuzzing.md`](./fuzzing.md) |
+| **Public API surface** (#145) | SemVer-relevant public-surface drift | [`public-api.md`](./public-api.md) |
+| **Performance** (this doc, #148) | Parse-time regressions | `benches/` + this doc |
+
+## Bench coverage
+
+Six benchmarks in `benches/parse.rs` cover the main parse paths:
+
+| Bench | Input | What it stresses |
+|---|---|---|
+| `minimal` | `movie.mkv` | The parser fast path; baseline for "do nothing useful" cost |
+| `movie_basic` | `The.Matrix.1999.1080p.BluRay.x264-GROUP.mkv` | Standard movie filename |
+| `movie_complex` | `Blade.Runner.2049.2017.2160p.UHD.BluRay.REMUX.HDR.HEVC.DTS-HD.MA.7.1.Atmos-EPSiLON.mkv` | Loaded movie with many tags (codec, source, audio, HDR, atmos) |
+| `episode_sxxexx` | `The.Walking.Dead.S05E03.720p.BluRay.x264-DEMAND.mkv` | Standard episode with `SxxExx` marker |
+| `episode_with_path` | `Series/Californication/Season 2/Californication.2x05.Vaginatown.HDTV.XviD-0TV.avi` | Multi-segment path with directory context |
+| `anime_bracket` | `[SubGroup] Anime Title - 01 [720p] [ABCD1234].mkv` | Anime-style brackets + CRC32 checksum |
+
+Coverage matches what [PR #138](https://github.com/lijunzh/hunch/pull/138) pinned for correctness — the same shapes get exercised for both correctness and perf.
+
+## Initial baseline (2026-04-18)
+
+Captured on local M-class hardware, criterion default (100 samples, 5s collection):
+
+| Bench | Median time | Iterations to fill 5 s |
+|---|---|---|
+| `minimal` | **11.5 µs** | 444k |
+| `anime_bracket` | **62.5 µs** | 81k |
+| `movie_basic` | **74.8 µs** | 67k |
+| `episode_with_path` | **78.5 µs** | 64k |
+| `episode_sxxexx` | **83.4 µs** | 60k |
+| `movie_complex` | **183 µs** | 27k |
+
+Total cargo-bench wall clock: ~70 s on local hardware.
+
+GitHub-hosted ubuntu-latest runners are **~2-3× slower** with significantly noisier per-iteration variance. Expect CI numbers to be roughly:
+
+| Bench | CI estimate (rough) |
+|---|---|
+| `minimal` | 25-40 µs |
+| `movie_complex` | 400-600 µs |
+| Others | 150-250 µs |
+
+These ranges will tighten once we have a multi-month CI history to characterize the noise floor.
+
+## How it runs in CI
+
+[`.github/workflows/benchmark.yml`](../.github/workflows/benchmark.yml) — triggered on:
+
+| Trigger | Why |
+|---|---|
+| Weekly Sunday 05:14 UTC | Track long-term perf trajectory without daily noise |
+| Push to `main` (source/bench/Cargo paths only) | Catch the SHA where any regression entered |
+| Manual dispatch | Ad-hoc baselines (e.g., before/after a perf-targeted PR) |
+
+Output: `bench-output/parse.txt` (full criterion log) + `bench-output/parse-summary.txt` (one bencher-format line per bench), uploaded as the `bench-results-<sha>` artifact with **90-day retention**.
+
+**Currently advisory only**: no PR-time comparison, no comment, no fail. See "Roadmap" below for why.
+
+## Local usage
+
+Run the full bench suite:
+
+```bash
+cargo bench --bench parse
+```
+
+(Takes ~70 s on M-class hardware; longer on CI.)
+
+Run just one bench:
+
+```bash
+cargo bench --bench parse -- minimal
+```
+
+Use criterion's baseline-comparison mode to detect regressions across two commits:
+
+```bash
+# Save numbers from the current state as 'before'
+cargo bench --bench parse -- --save-baseline before
+
+# Make your change, then compare
+cargo bench --bench parse -- --baseline before
+```
+
+Criterion will print "Performance has improved" / "Performance has regressed" with confidence intervals. Anything with `p < 0.05` is statistically significant; anything > 5% delta is usually visible above the local-hardware noise floor.
+
+## Roadmap (deferred to follow-up PRs within #148)
+
+This first slice intentionally does **not** implement the full epic [DoD](https://github.com/lijunzh/hunch/issues/148). Why each piece is deferred:
+
+- [ ] **PR-time comparison + comment**: needs a comparison strategy that handles GitHub-hosted runner noise. Naive PR-vs-main comparisons produce false positives (5-10% noise floor on shared CPU). Without statistical rigor, devs would learn to ignore the comment, killing the signal. Better to gather baseline history first.
+- [ ] **Hard-fail at >20% slower with p<0.01**: per the epic DoD, but only meaningful once we have a baseline that establishes the noise floor. Adding a gate before knowing real variance = guaranteed flake.
+- [ ] **Per-release baseline snapshot committed to the repo**: useful for showing perf trajectory in `CHANGELOG.md` per release. Trivial follow-up once we pick a comparison tool.
+- [ ] **Decision: bencher.dev (cloud) vs github-action-benchmark (gh-pages) vs self-hosted runner**: this is a stewardship/vendor decision the repo owner should make, not something to slip into a tooling PR. Each option has tradeoffs:
+  - **bencher.dev**: best UX, free for OSS, requires API token + account
+  - **github-action-benchmark**: in-repo (gh-pages branch), simpler trust model, less polished UI
+  - **Self-hosted runner**: lowest noise (dedicated CPU), highest maintenance cost
+- [ ] **Differential vs guessit**: out of epic scope per #148 ("interesting but apples-to-oranges").
+- [ ] **Memory profiling**: out of epic scope per #148 (criterion is wall-clock).
+
+## Triage protocol — when CI shows a regression
+
+Until PR-time comparison lands, regression detection is **manual**: review the artifact from the latest `main` push and eyeball it against the previous one (or local baseline).
+
+If you spot a > 20% slowdown:
+
+1. **Reproduce locally** with `cargo bench --bench parse` — confirm it's not just CI noise (re-run the workflow if numbers look wild).
+2. **Bisect** with `cargo bench --bench parse -- --save-baseline X` at suspect commits, then `--baseline X` at the next one to find the introducing SHA.
+3. **Profile** with `cargo bench --bench parse -- --profile-time 10` (criterion's built-in flag) or `samply` / `flamegraph` for deeper drill-down.
+4. **Fix or revert**: if the regression is acceptable (e.g., new feature traded perf for correctness), document it in `CHANGELOG.md`. Otherwise, fix or revert.
+
+## References
+
+- [criterion.rs book](https://bheisler.github.io/criterion.rs/book/) — methodology, statistical model
+- [`benches/parse.rs`](../benches/parse.rs) — the bench harness itself
+- Sibling docs: [`coverage.md`](./coverage.md), [`mutation-baseline.md`](./mutation-baseline.md), [`fuzzing.md`](./fuzzing.md), [`public-api.md`](./public-api.md)
+- [#148](https://github.com/lijunzh/hunch/issues/148) — the parent epic
+- [#138](https://github.com/lijunzh/hunch/pull/138) — established the property-extractor coverage shape this doc mirrors
+- [#140](https://github.com/lijunzh/hunch/pull/140) — refreshed criterion's transitive dev-deps


### PR DESCRIPTION
## Summary

First slice of the [perf regression CI epic (#148)](https://github.com/lijunzh/hunch/issues/148) — completing **"every next-wave epic now has a first slice"** alongside #168 (coverage), #169 (mutants), #171 (public-api), #172 (non-exhaustive enums), and #174 (fuzz).

Honest minimal scope: runs the existing criterion benches in CI, captures output as artifact. Does **not** attempt regression detection yet.

## What's in this PR

### CI

- **`.github/workflows/benchmark.yml`** — runs `cargo bench --bench parse` on:
  - **Weekly Sunday 05:14 UTC** — staggered after fuzz (03:14) + mutants (04:14) so the three slow nightlies don't fight for runner concurrency
  - **Push to `main`** with src/Cargo/bench path filters — catches the SHA where any regression entered
  - **Manual `workflow_dispatch`** — ad-hoc baselines (e.g., before/after a perf-targeted PR)

  Output: `bench-output/parse.txt` (full criterion log) + `bench-output/parse-summary.txt` (one bencher-format line per bench), uploaded as the `bench-results-<sha>` artifact with **90-day retention**.

### Docs

- **`docs/benchmarks.md`** — methodology, bench coverage table, initial baseline numbers, local-usage cookbook, deferred-roadmap with rationale, triage protocol.

## Initial baseline (local M-class hardware)

| Bench | Median time | What it stresses |
|---|---|---|
| `minimal` | **11.5 µs** | Parser fast path |
| `anime_bracket` | **62.5 µs** | `[Group]` + CRC32 brackets |
| `movie_basic` | **74.8 µs** | Standard movie filename |
| `episode_with_path` | **78.5 µs** | Multi-segment path |
| `episode_sxxexx` | **83.4 µs** | Standard episode |
| `movie_complex` | **183 µs** | Loaded movie (HDR, atmos, REMUX) |

Wall clock: ~70 s locally; ~3-4 min estimated on ubuntu-latest (slower CPU, more variance).

## Why this minimal first slice (vs the full epic DoD)

GitHub-hosted runners are notoriously noisy (5-10% per-iter variance on shared CPU). Naive PR-vs-main comparisons produce false positives that train developers to ignore the signal entirely. Setting up:

- A statistically rigorous comparison
- A vendor decision: **bencher.dev** (cloud, free OSS, needs API token) vs **github-action-benchmark** (in-repo gh-pages) vs **self-hosted runner** (lowest noise, highest maintenance)
- A noise-floor characterization to set the >20% threshold honestly

…all need a baseline of historical CI data first. **This slice accumulates that data without pretending to gate on it.** The roadmap section in `docs/benchmarks.md` explains each deferral.

## Verification

- ✅ `actionlint` clean
- ✅ YAML parses cleanly (PyYAML)
- ✅ Bencher output format verified locally:
  ```
  $ cargo bench --bench parse -- --output-format bencher --noplot minimal
  test minimal ... bench:      11,286 ns/iter (+/- 63)
  ```
  This is the standard go-bench format that almost every comparison tool can parse, so the next slice (PR-time comparison) won't need to re-run the benches.
- ✅ Local baseline cross-checked against two independent runs (numbers above are medians, both runs within ±3%)

## Explicitly deferred (within #148)

Each gets its own follow-up PR:

- [ ] **PR-time bench job** that runs benches on PR + main and posts a delta-table comment
- [ ] **Hard-fail at >20% slower with p<0.01** (per epic DoD)
- [ ] **Per-release baseline snapshots** committed to the repo for `CHANGELOG.md` perf-trajectory storytelling
- [ ] **Vendor decision**: bencher.dev vs github-action-benchmark vs self-hosted

## Strategic context — completes the tooling-baseline trifecta

With this PR, **every one of the 6 next-wave epics has a first slice**:

| Epic | Status | First slice |
|---|---|---|
| #143 TOML matcher migration | ⏳ no slice yet (out of "tooling baseline" theme) | — |
| #144 Public-API audit | ✅ #171 + #172 | tripwire + non-exhaustive enums |
| #145 Coverage CI | ✅ #168 + #172 (docs) | working CI + public surface doc |
| #146 Mutation testing | ✅ #169 + #170 + #173 + #175 | nightly + baseline + first kill |
| #147 Fuzzing | ✅ #174 | 2 targets + nightly + triage doc |
| #148 Perf regression CI | ✅ **this PR** | weekly bench + methodology doc |

That's 5 of 6 epics with foundational tooling in place. #143 (TOML matcher migration) is a different shape (architectural, not tooling) and is the natural focus for a future wave.

Refs #148
