### PR TITLE
test(title): kill 5 surviving strip_extension mutants (#146)

### DIFF
--- a/src/properties/title/clean.rs
+++ b/src/properties/title/clean.rs
@@ -923,4 +923,98 @@ mod tests {
         // Identical inputs: trivially tie → left.
         assert_eq!(pick_better_casing("Same", "Same"), "Same");
     }
+
+    // ── strip_extension boundary tests ────────────────────────
+    //
+    // Five mutants survived in strip_extension as of the 2026-04-19
+    // nightly (#146). Each test below is named for the specific
+    // mutation it kills. The function is small (8 lines) but
+    // semantically dense — every operator and condition matters.
+
+    #[test]
+    fn strip_extension_no_dot_returns_input_unchanged() {
+        // Pins the function-stub mutant `replace strip_extension -> &str
+        // with ""`. With the mutation, this would return "" instead of
+        // "NoExtensionHere", which is plainly wrong.
+        assert_eq!(strip_extension("NoExtensionHere"), "NoExtensionHere");
+    }
+
+    #[test]
+    fn strip_extension_known_extension_strips_dot_and_ext() {
+        // Pins the function-stub mutant for the happy path — confirms
+        // the function returns the actual prefix, not "".
+        assert_eq!(strip_extension("The.Matrix.mkv"), "The.Matrix");
+        assert_eq!(strip_extension("movie.mp4"), "movie");
+    }
+
+    #[test]
+    fn strip_extension_dot_plus_one_indexing_is_correct() {
+        // Pins `+ -> -` and `+ -> *` in `dot + 1..`.
+        //
+        // For "foo.mkv" (dot at index 3):
+        //   - dot + 1 = 4 → ext = "mkv" (correct, is_likely_extension=true)
+        //   - dot - 1 = 2 → ext = "o.mkv" (5 chars, but not a known
+        //     extension → returns whole input unchanged)
+        //   - dot * 1 = 3 → ext = ".mkv" (4 chars, not a known extension
+        //     because of the leading dot → returns whole input unchanged)
+        //
+        // Either mutation produces "foo.mkv" instead of "foo".
+        assert_eq!(strip_extension("foo.mkv"), "foo");
+    }
+
+    #[test]
+    fn strip_extension_unknown_short_extension_keeps_input() {
+        // Pins `&& -> ||` in `ext.len() <= 5 && is_likely_extension(...)`.
+        //
+        // "foo.xyzab" has a 5-char extension that satisfies len <= 5
+        // but is_likely_extension("xyzab") returns false.
+        //   - With `&&`: false → return whole input "foo.xyzab"
+        //   - With `||`: true (length OK) → strip → "foo"  (BUG)
+        //
+        // Asserting the input survives kills the `||` mutation.
+        assert_eq!(strip_extension("foo.xyzab"), "foo.xyzab");
+    }
+
+    #[test]
+    fn strip_extension_long_known_lookalike_keeps_input() {
+        // Belt-and-suspenders for `<= -> >`. While none of our recognized
+        // extensions happen to be exactly 5 chars, this test pins the
+        // length gate against "too long to be plausible":
+        //
+        // "sample.notarealextension" — ext is 17 chars.
+        //   - With `<=`: 17 <= 5 false → return whole input (correct)
+        //   - With `>`:  17 > 5 true → fall to is_likely_extension
+        //     (returns false for "notarealextension") → still returns
+        //     whole input. Equivalent for this case alone.
+        //
+        // The kill for `<= -> >` actually comes from the test below.
+        assert_eq!(
+            strip_extension("sample.notarealextension"),
+            "sample.notarealextension"
+        );
+    }
+
+    #[test]
+    fn strip_extension_known_three_char_extension_pins_le_boundary() {
+        // Pins `<= -> >` in `ext.len() <= 5`.
+        //
+        // "clip.mkv" — ext is 3 chars, is_likely_extension("mkv")=true.
+        //   - With `<=`: 3 <= 5 true → AND with is_likely=true → strip → "clip"
+        //   - With `>`:  3 > 5 false → return whole input "clip.mkv" (BUG)
+        //
+        // Asserting the strip happens kills `<= -> >` (and reinforces
+        // the function-stub mutant kill from above).
+        assert_eq!(strip_extension("clip.mkv"), "clip");
+        // Also exercise a 4-char known extension ("webm"):
+        assert_eq!(strip_extension("video.webm"), "video");
+    }
+
+    #[test]
+    fn strip_extension_case_insensitive_match() {
+        // Documented behaviour: extension matching uses to_lowercase.
+        // Belt for the `is_likely_extension(&ext_lower)` call site —
+        // confirms the lowercasing is in the loop, not skipped.
+        assert_eq!(strip_extension("Movie.MKV"), "Movie");
+        assert_eq!(strip_extension("Trailer.Mp4"), "Trailer");
+    }
 }


### PR DESCRIPTION
## Summary

Third execution of [#173](https://github.com/lijunzh/hunch/issues/173)'s triage roadmap (after [#175](https://github.com/lijunzh/hunch/pull/175) + [#180](https://github.com/lijunzh/hunch/pull/180)). The **2026-04-19 nightly mutation run** ([validation run we triggered post-#180](https://github.com/lijunzh/hunch/actions/runs/24619804158)) confirmed combined kill rate already jumped to **88.3%** (from 73.7% baseline) and surfaced `strip_extension` as the **largest single-function cluster of survivors**: 5 mutants in 8 lines.

The function was already `pub(super)` so **no refactor was needed** — just surgical unit tests pinning each mutation. Each test is named for the specific mutant it kills.

## New tests (7 total)

| Test | Kills |
|---|---|
| `strip_extension_no_dot_returns_input_unchanged` | Function-stub mutant (`replace -> &str with ""`) |
| `strip_extension_known_extension_strips_dot_and_ext` | Belt-and-suspenders for the function-stub on the happy path |
| `strip_extension_dot_plus_one_indexing_is_correct` | `+ -> -` and `+ -> *` in `dot + 1..` |
| `strip_extension_unknown_short_extension_keeps_input` | `&& -> ‖` using `"foo.xyzab"` (5-char unknown ext) |
| `strip_extension_long_known_lookalike_keeps_input` | Belt for length-gate; documents the equivalent-mutant edge |
| `strip_extension_known_three_char_extension_pins_le_boundary` | `<= -> >` using `"clip.mkv"` |
| `strip_extension_case_insensitive_match` | Pins the `to_lowercase()` call site |

The detailed inline comments serve as **documentation of WHY the operators are the way they are** — useful for future readers debugging extension-detection regressions.

## Verification — 100% kill rate on targeted code

| Check | Result |
|---|---|
| `cargo test --lib` | **307 passed** (300 baseline + 7 new) |
| `cargo fmt --check` | ✅ clean |
| `cargo clippy --all-targets -- -D warnings` | ✅ clean |
| `cargo mutants --file src/properties/title/clean.rs --re strip_extension` | **6 found, 6 caught (100%)** |

🎯 All 5 originally-surviving mutants killed + 1 new mutation location surfaced (and also killed) by the new tests.

## Expected impact on next nightly

Cumulative effect of #175 + #180 + this PR (relative to original 73.7% baseline from #173):

| Metric | Before #175 | After #175+#180 (current nightly) | After this PR (predicted) |
|---|---|---|---|
| `title/clean.rs` kill rate | 83.7% | ~89% | **~93%** |
| `pipeline/mod.rs` kill rate | 66.7% | 85.1% | 85.1% (unchanged here) |
| **Overall (scoped) kill rate** | **73.7%** | **88.3%** | **~91%** |

## File-size note

`title/clean.rs` is now 1020 lines (was 926; +94 for tests). The file already exceeded the 600-line guideline before this PR; **splitting into a sibling module would be a sensible follow-up**, tracked separately as a refactor concern. Adding tests doesn't make it worse — but the next mutation slice on this file should consider extracting tests to a sibling `tests.rs` first.

## Remaining survivors (deferred to future slices of #146)

12 mutants still survive across the two scoped files:
- 4 `pipeline/mod.rs` pass2 boundaries (lines 454, 515, 534, 550)
- 3 `pipeline/mod.rs` `match_all` mutants (lines 587, 597)
- 3 `title/clean.rs` `normalize_separators` (lines 154, 164)
- 1 `title/clean.rs` `classify_dash` (line 225)
- 1 `title/clean.rs` `is_generic_dir` (line 516)

## Pattern continuity (the playbook is now refined)

Three PRs in, this is the proven loop:

1. ✅ Identify highest-cluster hot spot from latest nightly's `missed.txt`
2. ✅ If the function is nested → hoist to `pub(super) fn` (#175, #180)
3. ✅ If already `pub(super)` → skip the refactor (this PR)
4. ✅ Add named tests pinning each surviving mutant (~7 tests per ~5 mutants)
5. ✅ Verify locally with `cargo mutants --re <name>` → 100% on targeted surface
6. ✅ Single-file diff, easy to review

Three identical playbook executions, three measurable wins. The mutation feedback loop is now provably **boring and reliable** — the highest compliment for tooling.

Refs #146
