### PR TITLE
feat(ci): wire up bench regression gate + PR comments (#178)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,49 +2,47 @@ name: Benchmarks
 
 # Performance regression tracking via criterion (the existing benches/ harness).
 #
-# First slice of the perf regression CI epic (#148). Honest scope:
+# Second slice of the perf regression CI epic (#148, after #176 + #177):
 #
-#   - Runs `cargo bench` on weekly schedule + manual dispatch
-#   - Captures bencher-format output as an artifact (90-day retention)
-#   - **Advisory only** — does NOT compare against a baseline yet,
-#     does NOT comment on PRs, does NOT fail on regression
+#   - Runs `cargo bench` on weekly schedule, push-to-main, AND pull_request
+#   - On PRs: comments delta table, FAILS if any bench >120% of main baseline
+#   - On main pushes: appends to gh-pages history (per #177 storage decision)
+#   - On schedule/manual: still produces an artifact (legacy; useful belt)
 #
-# Why this minimal first slice (vs the full epic DoD):
+# Threshold rationale (from #178):
+#   - alert-threshold: 120% → fail when any bench is >20% slower than baseline
+#   - Deliberately permissive to filter the 5-10% noise floor on shared runners
+#   - Tighten once we have ~4 weeks of data to characterize real variance
 #
-#   - GitHub-hosted runners are *noisy* (shared CPU). Naive PR-vs-main
-#     comparisons produce false positives that train people to ignore
-#     the signal entirely. Statistical-rigorous comparison needs care.
-#   - Setting up bencher.dev (the cloud option) requires picking a
-#     vendor, creating an account, configuring an API token. That's a
-#     repo-owner decision, not something to slip in via PR.
-#   - benchmark-action/github-action-benchmark needs a gh-pages branch
-#     for trend storage. That's a workspace structural change.
-#   - For now, accumulating a *history* of artifact runs lets us
-#     observe the noise floor and inform the comparison-strategy
-#     decision in the next slice. Honest first slice > flaky gate.
+# Storage strategy (per #177): github-action-benchmark commits results to
+# the `gh-pages` branch under `dev/bench/`. The action's stock Chart.js
+# dashboard lives at `dev/bench/index.html` for now; the future mdbook
+# refactor (separate issue) will own the chrome via Pattern B and let
+# the action keep ownership of `data.js` only.
 #
-# Roadmap (deferred to follow-up PRs within #148):
-#   - PR-time job that runs benches on PR + main + posts a delta table
-#   - Hard-fail at >20% slower with p<0.01 (per epic DoD)
-#   - Per-release baseline snapshots committed to the repo
-#   - Decision on bencher.dev vs self-hosted noise filtering
-#
-# See docs/benchmarks.md for methodology + baseline numbers + roadmap.
+# See docs/benchmarks.md for methodology + baseline numbers + threshold tuning.
 
 on:
   schedule:
-    # Weekly Sunday 05:14 UTC. Weekly (not nightly) because:
-    #   - Benches are stable; running daily creates noise without signal
-    #   - Stagger position: 05:14 = 2 hours after fuzz nightly (03:14)
-    #     and 1 hour after mutation nightly (04:14). No runner contention.
+    # Weekly Sunday 05:14 UTC. Stagger position: 05:14 = 2 hours after
+    # fuzz nightly (03:14) and 1 hour after mutation nightly (04:14).
     - cron: "14 5 * * 0"
   workflow_dispatch:
     # Manual trigger for ad-hoc baselines (e.g., before/after a perf PR).
   push:
     branches: [main]
-    # Run on every push to main so we accumulate a baseline history.
-    # Path filter: skip docs-only and CI-only changes that can't move
-    # parser perf.
+    # Run on every push to main so we accumulate baseline history on
+    # gh-pages. Path filter: skip docs-only and CI-only changes that
+    # can't move parser perf.
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'benches/**'
+      - '.github/workflows/benchmark.yml'
+  pull_request:
+    # Run on PRs to compare against the latest main baseline and gate.
+    # Same path filter — docs/CI-only PRs skip the bench cycle entirely.
     paths:
       - 'src/**'
       - 'Cargo.toml'
@@ -53,14 +51,15 @@ on:
       - '.github/workflows/benchmark.yml'
 
 concurrency:
-  # Only one bench run at a time — multiple runs would fight for the
-  # runner's already-noisy CPU and produce garbage numbers. Don't
-  # cancel in-progress runs; we want every triggered run to complete
-  # so the history is contiguous.
-  group: benchmark
-  cancel-in-progress: false
+  # Only one bench run per ref at a time — multiple PR pushes shouldn't
+  # fight for the runner's already-noisy CPU. Don't cancel in-progress
+  # runs on main pushes (we want every triggered run to complete so
+  # gh-pages history is contiguous); DO cancel for PRs (latest commit wins).
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
+  # Default to read; bumped to write only for the comment + gh-pages push.
   contents: read
 
 env:
@@ -68,12 +67,18 @@ env:
 
 jobs:
   bench:
-    name: cargo bench (advisory)
+    name: cargo bench (with regression gate)
     runs-on: ubuntu-latest
     # 30 min cap. Local M-class hardware completes in ~70s; ubuntu-latest
-    # is ~2-3× slower so estimate 3-4 min. The cap exists to fail loud
-    # if the bench harness regresses badly or hangs.
+    # is ~2-3× slower so estimate 3-4 min. Cap exists to fail loud if the
+    # bench harness regresses badly or hangs.
     timeout-minutes: 30
+    permissions:
+      # Per-job overrides:
+      #   - contents: write — needed to push results to gh-pages on main
+      #   - pull-requests: write — needed to comment delta table on PRs
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
@@ -85,9 +90,7 @@ jobs:
 
       - name: Run benches (bencher output format)
         # --output-format bencher: machine-parseable line-oriented format,
-        #   compatible with most third-party comparison tools (handy for
-        #   future slices that wire up bencher.dev / github-action-benchmark
-        #   without re-running the benches).
+        #   directly consumed by github-action-benchmark with `tool: cargo`.
         # --noplot: skip gnuplot/HTML report generation; we don't have
         #   gnuplot installed and HTML is heavy for an artifact.
         # 2>&1 + tee: capture both criterion's progress on stderr and
@@ -102,10 +105,10 @@ jobs:
           echo "=== Summary ==="
           cat bench-output/parse-summary.txt
 
-      - name: Upload bench results
+      - name: Upload bench results (artifact)
         # Always upload — even on cancellation we want partial data.
         # 90-day retention so we have a multi-month rolling history
-        # when the next slice lands.
+        # backstop independent of gh-pages.
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
@@ -113,3 +116,40 @@ jobs:
           path: bench-output/
           if-no-files-found: error
           retention-days: 90
+
+      - name: Compare vs baseline + gate (github-action-benchmark)
+        # Per #178:
+        #   - On PR runs: comment the delta table, FAIL if any bench >120%
+        #     of the latest main baseline (= >20% slower).
+        #   - On main pushes: append to the gh-pages history under
+        #     dev/bench/, no comment, no fail (history accumulation only).
+        #   - On schedule/dispatch: skip entirely (no PR to comment on,
+        #     no main push to record).
+        #
+        # The action consumes bench-output/parse.txt directly via tool: cargo
+        # (cargo bench's bencher format is one of its native input modes).
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372  # v1.22.0
+        with:
+          name: hunch criterion benches
+          tool: cargo
+          output-file-path: bench-output/parse.txt
+          # Per #177: gh-pages branch, dev/bench subdir (mdbook-friendly).
+          gh-repository: github.com/${{ github.repository }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Push to gh-pages ONLY on main (not on PRs).
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          # Always comment on PRs so dev sees the delta inline.
+          comment-always: ${{ github.event_name == 'pull_request' }}
+          # Threshold: 120% = fail when any bench is >20% slower than baseline.
+          # Permissive on purpose; tighten after noise-floor data accumulates.
+          alert-threshold: '120%'
+          # Fail the job on regression (PRs only). Main pushes record
+          # history but never fail — a regression that lands shouldn't
+          # block subsequent main commits.
+          fail-on-alert: ${{ github.event_name == 'pull_request' }}
+          # Belt-and-suspenders: also @-mention on alert (CC the PR author).
+          comment-on-alert: ${{ github.event_name == 'pull_request' }}
+          alert-comment-cc-users: '@lijunzh'

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -59,15 +59,27 @@ These ranges will tighten once we have a multi-month CI history to characterize 
 
 [`.github/workflows/benchmark.yml`](../.github/workflows/benchmark.yml) — triggered on:
 
-| Trigger | Why |
+| Trigger | Behavior |
 |---|---|
-| Weekly Sunday 05:14 UTC | Track long-term perf trajectory without daily noise |
-| Push to `main` (source/bench/Cargo paths only) | Catch the SHA where any regression entered |
-| Manual dispatch | Ad-hoc baselines (e.g., before/after a perf-targeted PR) |
+| Pull request (paths: `src/`, `benches/`, `Cargo.*`, workflow file) | Compare vs latest `main` baseline; **comment delta table** on PR; **fail if any bench >120% of baseline** |
+| Push to `main` (same paths) | Append results to `gh-pages/dev/bench/data.js`; no comment, no fail |
+| Weekly Sunday 05:14 UTC | Produce artifact only (legacy belt) |
+| Manual dispatch | Produce artifact only |
 
-Output: `bench-output/parse.txt` (full criterion log) + `bench-output/parse-summary.txt` (one bencher-format line per bench), uploaded as the `bench-results-<sha>` artifact with **90-day retention**.
+Output on every run: `bench-output/parse.txt` (full criterion log) + `bench-output/parse-summary.txt` (one bencher-format line per bench), uploaded as the `bench-results-<sha>` artifact with **90-day retention** — independent backstop in case the gh-pages history gets corrupted.
 
-**Currently advisory only**: no PR-time comparison, no comment, no fail. See "Roadmap" below for why.
+### Threshold rationale
+
+- **`alert-threshold: '120%'`** — fail when any bench is **>20% slower** than the latest main baseline.
+- Deliberately permissive to filter the typical 5–10% noise floor on shared GitHub-hosted runners. A tighter threshold without statistical-significance handling would flake constantly.
+- Tighten once we have ~4 weeks of weekly-run data to characterize real variance — tracked in [#178](https://github.com/lijunzh/hunch/issues/178)'s comments.
+
+### Triage when the gate fires
+
+1. **Don't immediately revert.** Confirm by re-running the bench job (CPU jitter on shared runners is real). If the second run still flags it, you have a real signal.
+2. Pull the bench artifact from both the PR run and the most recent `main` run; eyeball the absolute numbers (the action's comment shows %-delta, but absolute µs tells you whether it's a hot-path concern or a 100ns blip on a 10µs bench).
+3. If real, profile locally with `cargo bench --bench parse -- --profile-time 10` (criterion's built-in flamegraph mode) or `samply` for deeper drill-down.
+4. **Override path**: if the regression is intentional (perf traded for correctness or feature), document the rationale in `CHANGELOG.md` and use the `[skip-bench-gate]` label (TODO once we hit the first justified override) — for now, accept the failure and discuss in PR review.
 
 ## History storage — decision (#177)
 
@@ -137,17 +149,15 @@ Criterion will print "Performance has improved" / "Performance has regressed" wi
 This first slice intentionally does **not** implement the full epic [DoD](https://github.com/lijunzh/hunch/issues/148). Why each piece is deferred:
 
 - [x] **Decision: bencher.dev (cloud) vs github-action-benchmark (gh-pages) vs self-hosted runner** — resolved in [#177](https://github.com/lijunzh/hunch/issues/177). See "History storage — decision" above.
-- [ ] **PR-time comparison + comment** ([#178](https://github.com/lijunzh/hunch/issues/178)): wire up `github-action-benchmark`'s comparison mode. Now unblocked by the storage decision; needs a noise-floor characterization first to pick a sensible alert-threshold (default 200% is too permissive; <120% would flake on shared-runner CPU jitter).
-- [ ] **Hard-fail at >20% slower with p<0.01**: per the epic DoD, but only meaningful once we have a baseline that establishes the noise floor. Adding a gate before knowing real variance = guaranteed flake. Tracked under [#178](https://github.com/lijunzh/hunch/issues/178).
-- [ ] **Per-release baseline snapshot committed to the repo** ([#179](https://github.com/lijunzh/hunch/issues/179)): useful for showing perf trajectory in `CHANGELOG.md` per release. Trivial follow-up once the storage substrate exists.
+- [x] **PR-time comparison + comment + regression gate** — resolved in [#178](https://github.com/lijunzh/hunch/issues/178). See "How it runs in CI" above.
+- [ ] **Tighten alert threshold from 120% to something stricter** — needs ~4 weeks of post-#178 data to characterize the noise floor on shared runners. Tracked in #178's comments.
+- [ ] **Per-release baseline snapshot committed to the repo** ([#179](https://github.com/lijunzh/hunch/issues/179)): useful for showing perf trajectory in `CHANGELOG.md` per release. Trivial follow-up now that the storage substrate exists.
 - [ ] **Differential vs guessit**: out of epic scope per #148 ("interesting but apples-to-oranges").
 - [ ] **Memory profiling**: out of epic scope per #148 (criterion is wall-clock).
 
-## Triage protocol — when CI shows a regression
+## Triage protocol — manual deep-dive when the gate fires
 
-Until PR-time comparison lands, regression detection is **manual**: review the artifact from the latest `main` push and eyeball it against the previous one (or local baseline).
-
-If you spot a > 20% slowdown:
+The automated triage steps live in "Triage when the gate fires" above. This section covers the deeper-dive workflow once you've decided a regression is real.
 
 1. **Reproduce locally** with `cargo bench --bench parse` — confirm it's not just CI noise (re-run the workflow if numbers look wild).
 2. **Bisect** with `cargo bench --bench parse -- --save-baseline X` at suspect commits, then `--baseline X` at the next one to find the introducing SHA.


### PR DESCRIPTION
## Summary

Second slice of the perf regression CI epic ([#148](https://github.com/lijunzh/hunch/issues/148)) — wires up the actual gate on top of [#176](https://github.com/lijunzh/hunch/pull/176)'s baseline workflow and the just-merged [#186](https://github.com/lijunzh/hunch/pull/186)'s storage strategy.

> 📌 **Replaces [PR #187](https://github.com/lijunzh/hunch/pull/187)** — that PR was auto-closed when its base branch (`docs/177-bench-storage-decision`) got deleted on #186's merge. Same commit, rebased onto fresh main; full CI now fires.

## What changes in `benchmark.yml`

| # | Change | Why |
|---|---|---|
| 1 | Add `pull_request` trigger (same path filter as push) | Without it, the gate has no PRs to gate |
| 2 | Per-job `permissions:` override → `contents: write` + `pull-requests: write` | Push to gh-pages on main; comment on PRs |
| 3 | Tighten `concurrency.group` to `benchmark-${{ github.ref }}`; `cancel-in-progress: true` for PRs only | Latest PR commit wins; main pushes always run to keep history contiguous |
| 4 | Add new step using `benchmark-action/github-action-benchmark@v1.22.0` (SHA-pinned) | The actual gate |

## How the gate behaves per trigger

| Trigger | Comment | Push to gh-pages | Fail on >120% |
|---|---|---|---|
| **Pull request** | ✅ delta table | ❌ | ✅ |
| **Push to `main`** | ❌ | ✅ append to `dev/bench/data.js` | ❌ (regression that lands shouldn't block subsequent commits) |
| **Schedule / dispatch** | ❌ | ❌ | ❌ (artifact-only fallback) |

## Threshold rationale

- `alert-threshold: 120%` → fail at **>20% slower**.
- Deliberately permissive to filter the 5–10% noise floor on shared GitHub-hosted runners.
- A tighter threshold without statistical-significance handling would flake constantly.
- **Tighten once we have ~4 weeks of post-merge data** to characterize real variance. Tracked as a Roadmap follow-up in `docs/benchmarks.md`.

## `docs/benchmarks.md` updates

- ✅ Removes the *"Currently advisory only"* caveat — the workflow now has teeth.
- 🆕 New per-trigger behavior table in "How it runs in CI"
- 🆕 New subsections "Threshold rationale" + "Triage when the gate fires"
- ✅ Roadmap: marks #178 as done; adds "tighten threshold" follow-up

## Verification done locally

- `cargo bench --bench parse --no-run`: compiles cleanly ✅
- `cargo test --lib`: 339 passed (no source changes; sanity check) ✅
- YAML validated with `pyyaml` — triggers/permissions/steps shape correct ✅
- SHA for `benchmark-action/github-action-benchmark@v1.22.0` confirmed via GitHub API: `a60cea5bc7b49e15c1f58f411161f99e0df48372`

## Verification on previous PR (#187, same commit)

The bench job already ran successfully on the now-closed #187 (1m22s wall-clock, well within the <5min DoD). Action gracefully handled "no baseline yet" — recorded the PR's results as the inaugural data point, no comment, no failure. Once this lands on main, subsequent PRs will see real comparisons.

## Verification deferred to first real run

The DoD-required scenarios from the issue have a chicken-and-egg with this PR. Suggested followup checklist for the next perf-adjacent PR after this lands:

- [ ] Open a deliberately-regressing test PR (e.g., add `std::thread::sleep(Duration::from_micros(500))` to a hot path) and confirm the gate fires.
- [ ] Open a no-op PR and confirm no false-positive failure.
- [ ] Open a perf-improving PR and confirm the comment shows the win.

## Cross-cutting note: future mdbook compatibility

Per recent design discussion ([Issue #188](https://github.com/lijunzh/hunch/issues/188)): the bench data lives at `gh-pages/dev/bench/data.js`. When the planned mdbook refactor lands (Pattern B), the mdbook deploy can co-exist by using `keep_files: true` to preserve `/dev/bench/`. No future-mdbook concerns require changes to this PR.

Closes #178
Refs #148
Refs #177
