### PR TITLE
perf(bench): drop the `minimal` bench (closes #191)

### DIFF
--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -52,9 +52,12 @@ fn bench_anime(c: &mut Criterion) {
     });
 }
 
-fn bench_minimal(c: &mut Criterion) {
-    c.bench_function("minimal", |b| b.iter(|| hunch(black_box("movie.mkv"))));
-}
+// `bench_minimal` was removed in #191 — it parsed only "movie.mkv" so it
+// primarily measured function-call overhead, not parser logic, and its
+// 16-22 µs baseline made it hyper-sensitive to ubuntu-latest runner-
+// hardware shifts (a flat ~6 µs offset showed up as a 37% ratio —
+// enough to fire the regression gate on innocuous PRs). The other 5
+// benches cover the parse paths that actually matter.
 
 criterion_group!(
     benches,
@@ -63,6 +66,5 @@ criterion_group!(
     bench_episode,
     bench_episode_with_path,
     bench_anime,
-    bench_minimal
 );
 criterion_main!(benches);

--- a/docs/src/reference/benchmarks.md
+++ b/docs/src/reference/benchmarks.md
@@ -21,7 +21,6 @@ Six benchmarks in `benches/parse.rs` cover the main parse paths:
 
 | Bench | Input | What it stresses |
 |---|---|---|
-| `minimal` | `movie.mkv` | The parser fast path; baseline for "do nothing useful" cost |
 | `movie_basic` | `The.Matrix.1999.1080p.BluRay.x264-GROUP.mkv` | Standard movie filename |
 | `movie_complex` | `Blade.Runner.2049.2017.2160p.UHD.BluRay.REMUX.HDR.HEVC.DTS-HD.MA.7.1.Atmos-EPSiLON.mkv` | Loaded movie with many tags (codec, source, audio, HDR, atmos) |
 | `episode_sxxexx` | `The.Walking.Dead.S05E03.720p.BluRay.x264-DEMAND.mkv` | Standard episode with `SxxExx` marker |
@@ -33,10 +32,8 @@ Coverage matches what [PR #138](https://github.com/lijunzh/hunch/pull/138) pinne
 ## Initial baseline (2026-04-18)
 
 Captured on local M-class hardware, criterion default (100 samples, 5s collection):
-
 | Bench | Median time | Iterations to fill 5 s |
 |---|---|---|
-| `minimal` | **11.5 µs** | 444k |
 | `anime_bracket` | **62.5 µs** | 81k |
 | `movie_basic` | **74.8 µs** | 67k |
 | `episode_with_path` | **78.5 µs** | 64k |
@@ -49,7 +46,6 @@ GitHub-hosted ubuntu-latest runners are **~2-3× slower** with significantly noi
 
 | Bench | CI estimate (rough) |
 |---|---|
-| `minimal` | 25-40 µs |
 | `movie_complex` | 400-600 µs |
 | Others | 150-250 µs |
 
@@ -129,7 +125,7 @@ cargo bench --bench parse
 Run just one bench:
 
 ```bash
-cargo bench --bench parse -- minimal
+cargo bench --bench parse -- movie_basic
 ```
 
 Use criterion's baseline-comparison mode to detect regressions across two commits:


### PR DESCRIPTION
## Summary

Closes [#191](https://github.com/lijunzh/hunch/issues/191). Removes the `minimal` bench surfaced as a noise generator by [PR #190](https://github.com/lijunzh/hunch/pull/190) (the gate fired on a docs-only change).

## Diagnosis (full write-up in #191)

| | Baseline (#189) | This PR ancestor (#190 run) | Ratio |
|---|---|---|---|
| `movie_basic` | 99 µs | 105 µs | 1.07 ✅ |
| `movie_complex` | 232 µs | 240 µs | 1.03 ✅ |
| `episode_sxxexx` | 107 µs | 112 µs | 1.04 ✅ |
| `episode_with_path` | 103 µs | 108 µs | 1.05 ✅ |
| `anime_bracket` | 85 µs | 91 µs | 1.08 ✅ |
| **`minimal`** | **17 µs** | **23 µs** | **1.37** ❌ |

A flat ~6µs runner-hardware delta hits every bench, but only blows up the smallest one. `minimal` parses just `"movie.mkv"` — primarily measures function-call overhead, not parser logic. Not a useful perf signal.

## Changes

- **`benches/parse.rs`**: drop `bench_minimal` + remove from `criterion_group!`. Inline comment explains why.
- **`docs/src/reference/benchmarks.md`**: drop the `minimal` row from three tables; update "run just one bench" example.

## Verification

- `cargo bench --bench parse --no-run`: clean ✅
- `mdbook build docs`: clean ✅  
- `cargo test --lib`: 339 passed ✅
- This PR is the live test: it should pass the gate where #190 didn't (because the now-removed flake bench can't fail).

## Effect on dashboard

The gh-pages history retains `minimal` data points. After merge, future pushes record entries without it — the dashboard chart for `minimal` becomes a line that ends. Acceptable archaeology.
