### PR TITLE
feat(ci): per-release benchmark snapshots (closes #179)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,6 +40,11 @@ on:
       - 'Cargo.lock'
       - 'benches/**'
       - '.github/workflows/benchmark.yml'
+    # Per #179: ALSO trigger on version-tag push so each release gets
+    # a permanent named snapshot at gh-pages/release-snapshots/<tag>.json.
+    # No path filter on tag push — we always want the snapshot.
+    tags:
+      - 'v*'
   pull_request:
     # Run on PRs to compare against the latest main baseline and gate.
     # Same path filter — docs/CI-only PRs skip the bench cycle entirely.
@@ -153,3 +158,72 @@ jobs:
           # Belt-and-suspenders: also @-mention on alert (CC the PR author).
           comment-on-alert: ${{ github.event_name == 'pull_request' }}
           alert-comment-cc-users: '@lijunzh'
+
+      - name: Build release snapshot JSON (tag push only)
+        # Per #179: on every version-tag push, capture a permanent snapshot
+        # of the bench numbers so they can be referenced from CHANGELOG.md
+        # and the docs/src/reference/release-trajectory.md page.
+        #
+        # Why a separate format from dev/bench/data.js:
+        #   - data.js is the rolling per-commit history (mutable scope ─ may
+        #     drop benches as the suite evolves, see #191's removal of `minimal`)
+        #   - release-snapshots/<tag>.json is the immutable per-release record;
+        #     consumers can diff `v1.1.8.json` vs `v1.2.0.json` without
+        #     worrying about history rewrites
+        #
+        # Format is intentionally simple (no schema versioning yet) so that
+        # the trajectory page's JS reader stays trivial. If this ever needs
+        # to evolve, add a `schema_version` field and ship readers that
+        # handle both.
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          mkdir -p snapshot-output
+          TAG="${GITHUB_REF#refs/tags/}"
+          # Build the JSON via jq from the bencher-format output.
+          # Each `test <name> ... bench: <ns> ns/iter (+/- <variance>)` line
+          # becomes one entry in the `benches` array.
+          jq -n \
+            --arg tag "$TAG" \
+            --arg sha "$GITHUB_SHA" \
+            --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg runner "${RUNNER_OS}-${RUNNER_ARCH}" \
+            --rawfile raw bench-output/parse.txt \
+            '{
+              tag: $tag,
+              sha: $sha,
+              date: $date,
+              runner: $runner,
+              benches: (
+                $raw
+                | split("\n")
+                | map(select(startswith("test ")))
+                | map(
+                    capture("test (?<name>\\S+)\\s+\\.\\.\\. bench:\\s+(?<value>[0-9,]+)\\s+(?<unit>\\S+)\\s+\\(\\+/- (?<variance>[0-9,]+)\\)")
+                    | {
+                        name: .name,
+                        value: (.value | gsub(","; "") | tonumber),
+                        unit: .unit,
+                        variance: (.variance | gsub(","; "") | tonumber)
+                      }
+                  )
+              )
+            }' > "snapshot-output/${TAG}.json"
+          echo "=== Snapshot for ${TAG} ==="
+          cat "snapshot-output/${TAG}.json"
+
+      - name: Push release snapshot to gh-pages (tag push only)
+        # peaceiris with destination_dir + keep_files is the cleanest way
+        # to add ONE file to a subdir without touching anything else on
+        # gh-pages (notably: leaves dev/bench/data.js + the mdbook deploy
+        # alone, per the keep_files lessons learned in #190).
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: snapshot-output
+          destination_dir: release-snapshots
+          keep_files: true
+          commit_message: 'bench: snapshot for ${{ github.ref_name }}'
+          user_name: 'github-actions[bot]'
+          user_email: '41898282+github-actions[bot]@users.noreply.github.com'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+<!--
+Release prep checklist (per #179):
+  1. Bump `version` in Cargo.toml
+  2. Move "[Unreleased]" entries below into a new "[X.Y.Z] - YYYY-MM-DD" section
+  3. Add the new tag to the RELEASE_TAGS array in
+     docs/src/reference/release-trajectory.md (top of list)
+  4. (Optional) Add a "### Performance" subsection to the new release with
+     a one-liner like:
+     - See <https://lijunzh.github.io/hunch/reference/release-trajectory.html>
+       for bench numbers compared to vX.Y.Z-1.
+  5. Tag + push: `git tag vX.Y.Z && git push origin vX.Y.Z`
+  6. The Benchmarks workflow auto-publishes the snapshot to
+     gh-pages/release-snapshots/vX.Y.Z.json (~3 min after the tag push)
+-->
+
 ## [Unreleased]
 
 ## [1.1.8] - 2026-04-17

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,6 +13,7 @@
 
 - [Benchmarks](./reference/benchmarks.md)
 - [Benchmark Dashboard](./reference/benchmark-dashboard.md)
+- [Release Performance Trajectory](./reference/release-trajectory.md)
 - [Public API Surface](./reference/public-api.md)
 
 # Contributor Guide

--- a/docs/src/reference/benchmarks.md
+++ b/docs/src/reference/benchmarks.md
@@ -162,6 +162,8 @@ The automated triage steps live in "Triage when the gate fires" above. This sect
 
 ## References
 
+- [Live Dashboard](./benchmark-dashboard.md) — per-commit history (Pattern B chart)
+- [Release Trajectory](./release-trajectory.md) — per-released-version snapshots
 - [criterion.rs book](https://bheisler.github.io/criterion.rs/book/) — methodology, statistical model
 - [`benches/parse.rs`](https://github.com/lijunzh/hunch/blob/main/benches/parse.rs) — the bench harness itself
 - Sibling docs: [Coverage](../contributor-guide/coverage.md), [Mutation Testing](../contributor-guide/mutation-baseline.md), [Fuzzing](../contributor-guide/fuzzing.md), [Public API](./public-api.md)

--- a/docs/src/reference/release-trajectory.md
+++ b/docs/src/reference/release-trajectory.md
@@ -1,0 +1,122 @@
+# Release Performance Trajectory
+
+How hunch's parser performance has evolved across released versions.
+
+> **Source of truth:** `gh-pages/release-snapshots/<tag>.json` — one
+> immutable file per version tag. Generated automatically by the
+> `Benchmarks` workflow whenever a `v*` tag is pushed (per
+> [#179](https://github.com/lijunzh/hunch/issues/179)). Each snapshot
+> records the bench numbers, git SHA, runner identity, and timestamp.
+>
+> See [Benchmarks](./benchmarks.md) for methodology and the
+> [Live Dashboard](./benchmark-dashboard.md) for per-commit history.
+
+## Snapshots
+
+<div id="trajectory-status">Loading release snapshots…</div>
+<div id="trajectory-content"></div>
+
+<!-- The list of release tags below is the ONLY thing that needs to be
+     updated as part of release prep. Newest tag first. Tags older
+     than the bench harness landing in #176 (= older than v1.1.8) won't
+     have snapshots — they're not in this list.
+
+     Release-prep checklist (per #179):
+       1. Bump version in Cargo.toml
+       2. Update CHANGELOG.md
+       3. Add the new tag to the RELEASE_TAGS array below (top of list)
+       4. Tag + push: `git tag vX.Y.Z && git push origin vX.Y.Z`
+       5. Wait ~3 min for the bench workflow to publish the snapshot
+       6. (optional) Verify at https://lijunzh.github.io/hunch/release-snapshots/<tag>.json -->
+<script>
+const RELEASE_TAGS = [
+  // Newest first. Add new entries to the TOP per the checklist above.
+  // (Empty until the first post-#179 release lands.)
+];
+
+(async function () {
+  const status = document.getElementById('trajectory-status');
+  const content = document.getElementById('trajectory-content');
+
+  if (RELEASE_TAGS.length === 0) {
+    status.innerHTML =
+      '<p><em>No release snapshots yet. The first one will appear after ' +
+      'the next <code>v*</code> tag is pushed (post-#179 merge). ' +
+      'Until then, see the <a href="./benchmark-dashboard.html">' +
+      'live per-commit dashboard</a> for current performance trends.</em></p>';
+    return;
+  }
+
+  // Fetch all snapshots in parallel; tolerate 404s (a tag in the list
+  // without a published snapshot just gets skipped, with a console warning).
+  const fetched = await Promise.all(RELEASE_TAGS.map(async (tag) => {
+    try {
+      const r = await fetch(`../release-snapshots/${tag}.json`);
+      if (!r.ok) {
+        console.warn(`No snapshot for ${tag} (HTTP ${r.status})`);
+        return null;
+      }
+      return await r.json();
+    } catch (e) {
+      console.warn(`Failed to fetch ${tag}:`, e);
+      return null;
+    }
+  }));
+
+  const snapshots = fetched.filter(Boolean);
+  if (snapshots.length === 0) {
+    status.textContent =
+      'Listed releases have no published snapshots yet. ' +
+      'Re-deploying the docs after the next bench workflow run should fix this.';
+    return;
+  }
+
+  // Build a per-bench comparison table: rows = bench names,
+  // columns = release tags (newest first), cells = ns/iter.
+  // Bench names taken from the newest snapshot; older snapshots that
+  // are missing a bench (e.g. `minimal` was dropped in #191) show "—".
+  const newest = snapshots[0];
+  const benchNames = newest.benches.map(b => b.name);
+
+  let html = '<h2>Per-bench comparison</h2><table><thead><tr><th>Bench</th>';
+  for (const s of snapshots) html += `<th>${s.tag}</th>`;
+  html += '</tr></thead><tbody>';
+
+  for (const name of benchNames) {
+    html += `<tr><td><code>${name}</code></td>`;
+    for (const s of snapshots) {
+      const b = s.benches.find(x => x.name === name);
+      html += b
+        ? `<td>${(b.value / 1000).toFixed(1)} \u00b5s</td>`
+        : '<td><em>—</em></td>';
+    }
+    html += '</tr>';
+  }
+  html += '</tbody></table>';
+
+  // Snapshot metadata table.
+  html += '<h2>Snapshot details</h2><table><thead><tr><th>Tag</th><th>Date</th><th>SHA</th><th>Runner</th></tr></thead><tbody>';
+  for (const s of snapshots) {
+    const sha = s.sha.slice(0, 7);
+    const date = s.date.slice(0, 10);
+    html += `<tr><td><strong>${s.tag}</strong></td><td>${date}</td><td><code>${sha}</code></td><td><code>${s.runner}</code></td></tr>`;
+  }
+  html += '</tbody></table>';
+
+  status.remove();
+  content.innerHTML = html;
+})();
+</script>
+
+## Methodology caveat
+
+Numbers are wall-clock parse time on `ubuntu-latest` GitHub-hosted
+runners — useful for **trajectory** (is the parser getting slower or
+faster across releases?) but **not** for absolute comparisons against
+your hardware. Local M-class hardware typically runs ~2–3× faster.
+
+Per-bench variance from runner-hardware shifts has been observed at
+±5–10% on the larger benches and >30% on benches under ~25 µs. The
+[#178](https://github.com/lijunzh/hunch/issues/178) regression gate
+uses a 120% threshold for exactly this reason; small absolute
+swings shouldn't be over-interpreted as real regressions.


### PR DESCRIPTION
## Summary

Closes [#179](https://github.com/lijunzh/hunch/issues/179) and **completes the [#148 perf-regression-CI epic](https://github.com/lijunzh/hunch/issues/148)** 🎉.

Adds per-release performance snapshots that complement the rolling per-commit history from [#178](https://github.com/lijunzh/hunch/issues/178).

## What changes

| File | Change |
|---|---|
| `.github/workflows/benchmark.yml` | Add `tags: [v*]` push trigger + 2 new tag-gated steps (build snapshot JSON via jq + push to `gh-pages/release-snapshots/<tag>.json`) |
| `docs/src/reference/release-trajectory.md` | New mdbook page that fetches snapshot JSONs and renders comparison tables |
| `docs/src/SUMMARY.md` | Add trajectory page to Reference section |
| `docs/src/reference/benchmarks.md` | Cross-link to trajectory + dashboard |
| `CHANGELOG.md` | Add release-prep checklist comment (HTML, invisible in render) |

Net: **+214 lines**, no source changes.

## Snapshot format

```json
{
  "tag": "v1.1.9",
  "sha": "abc123...",
  "date": "2026-04-19T...Z",
  "runner": "Linux-X64",
  "benches": [
    { "name": "movie_basic", "value": 99013, "unit": "ns/iter", "variance": 1877 },
    { "name": "movie_complex", "value": 232042, "unit": "ns/iter", "variance": 914 }
  ]
}
```

Two storage layers, two purposes:
- `dev/bench/data.js` — rolling per-commit history (mutable; benches may come/go like #191's `minimal` removal)
- `release-snapshots/<tag>.json` — immutable per-release record

## Why a manual tag list in the trajectory page?

GitHub Pages can't list directories. Two alternatives I considered:

| Option | Verdict |
|---|---|
| Workflow-maintained `manifest.json` | ❌ Race condition with bench workflow's own pushes |
| Hardcoded list in JS | ✅ One-line edit during release prep, no race risk |

The release-prep checklist is now spelled out in two places:
- `CHANGELOG.md` (as an HTML comment at the top)
- `release-trajectory.md` (as an inline comment above the array)

## Verification

- ✅ jq snippet tested locally with sample bencher-format input — correct JSON shape
- ✅ `mdbook build docs`: clean, no warnings, trajectory page renders the empty-state message
- ✅ `cargo fmt --check` + `cargo clippy --all-targets`: clean
- ✅ YAML validated — 8 steps, last 2 gated on `startsWith(github.ref, 'refs/tags/v')`

## Verification deferred to first real release

The tag-push code path can't be exercised until a `v*` tag is pushed. Suggested smoke test on the next release:

- [ ] Push tag (e.g. `v1.1.9`)
- [ ] Wait ~3 min for bench workflow
- [ ] Confirm `https://lijunzh.github.io/hunch/release-snapshots/v1.1.9.json` returns 200
- [ ] Add `'v1.1.9'` to `RELEASE_TAGS` in `release-trajectory.md`
 ] Confirm trajectory page renders the comparison table

The snapshot generation is fully gated to tag push, so if it breaks it can't affect normal PR/main bench runs.

## Closes

- Closes #179
- Closes the entire #148 epic 🏁

Refs #148 (epic), #178ate substrate), #186 (storage decision), #190 (mdbook + keep_files lessons), #191 (`minimal` bench removal that motivated immutable per-release snapshots vs mutable history).
