### PR TITLE
chore(docs): close-out CHANGELOG backfill + mdbook nav for root docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,95 @@ Release prep checklist (per #179):
 
 ## [Unreleased]
 
+### Added
+
+- **`HunchResult::is_movie()`, `is_episode()`, `is_extra()` convenience
+  methods.** Pure derived getters over the existing `media_type()` typed
+  accessor. All three return `false` when media type is unknown rather
+  than defaulting to a guess — callers needing to distinguish "definitely
+  not X" from "unknown" should still use `media_type()` directly. (#156)
+- **`Property::AudioBitRate`, `Property::VideoBitRate`, `Property::Mimetype`
+  variants** with matching `HunchResult::audio_bit_rate()`,
+  `video_bit_rate()`, `mimetype()` accessors. The bit-rate split is
+  classified by unit (`Kbps` → audio, `Mbps` → video); mimetype is a
+  pure derivation from container extension (mp4 → video/mp4, mkv →
+  video/x-matroska, etc.; unknown → `None`, never fabricated). All three
+  properties moved from 0% to 100% accuracy on the compatibility corpus.
+  (#158, #165)
+- **DVD region codes R0–R6** in the property exact-match table.
+  Previously only R5 was recognized. R7–R9 are intentionally omitted to
+  limit false positives on niche release-group tokens. (#156)
+
+### Changed
+
+- **⚠️ BREAKING: public enums now carry `#[non_exhaustive]`.** Affected
+  enums: `Property`, `MediaType`, `Confidence`, `OutputFormat` (and any
+  others reachable from `pub use src/lib.rs`). Downstream code that
+  matches exhaustively on these enums **must** add a wildcard arm:
+
+  ```rust
+  match prop {
+      Property::Title => ...,
+      // ... existing arms ...
+      _ => ...,  // ← now required
+  }
+  ```
+
+  Why: this lets future minor releases add new variants (the bit-rate
+  split in #165 was the immediate trigger) without re-breaking the API
+  every time. (#172)
+
+### Fixed
+
+- **Website false-positives on country-code TLDs inside language
+  abbreviations.** Filenames like `Community.s02e20.rus.eng.720p.mkv`
+  no longer extract `s02e20.ru` as a website. The TLD alternation now
+  requires a trailing word boundary, so `.ru` cannot match inside
+  `.rus`, `.com` inside `.community`, etc. (#163, #167)
+- **Anime-release bit-rate notation** (`kbit`, `mbits`) now parsed
+  correctly via suffix alternation. (#165)
+- **`DD5.1.448kbps`-style filenames** no longer mis-parse the leading
+  digits as part of the bit-rate (regex bound tightened to `\d{1,2}`).
+  (#165)
+
+### Deprecated
+
+- **`Property::BitRate` variant** — superseded by the
+  `AudioBitRate`/`VideoBitRate` split in #165. The variant is retained
+  for enum-API stability but no parser path produces it. Callers should
+  migrate to the unit-typed variants.
+
+### Internal / Infrastructure
+
+This release lands a substantial CI and documentation investment
+motivated by the project moving from "experimental, no users" to
+"users filing real bug reports." None of the items below change
+parser behavior, but they meaningfully improve the project's
+ability to catch regressions before they ship:
+
+- **Code coverage tracking** via `cargo-llvm-cov` (advisory). (#145, #168)
+- **Mutation testing baseline** via `cargo-mutants` nightly, with
+  29 surviving mutants triaged and killed across
+  #175, #180, #181, #182, #183, #184, #185. (#146, #169, #170, #173)
+- **Fuzz baseline** via `cargo-fuzz` with two targets (single-string
+  parse + multi-segment path) and nightly CI. (#147, #174)
+- **Public API surface tripwire** that fails CI on accidental changes
+  to `pub use src/lib.rs` items. (#144, #171)
+- **Continuous benchmarking** via `criterion` + `github-action-benchmark`,
+  with PR-time regression gating (>120% threshold), per-commit history
+  on a live dashboard, and per-release immutable snapshots. See the
+  [Benchmarks reference](https://lijunzh.github.io/hunch/reference/benchmarks.html)
+  and [Release Trajectory](https://lijunzh.github.io/hunch/reference/release-trajectory.html).
+  (#148, #176, #177, #178, #179, #186, #189, #191, #192, #194)
+- **Documentation portal** at <https://lijunzh.github.io/hunch/>
+  built with mdbook. (#188, #190)
+- **Release pipeline hardening** — PR-time CI now also runs on release
+  branches; release workflow is more defensive. (#150, #151, #152, #159)
+- **Misc test additions** pinning behaviors against future regressions:
+  `TitleStrategy` fallback ordering (#154, #161), `cli_walk_dir`
+  safety boundaries (#153, #162), parse-torrent-name corpus pins
+  (#157, #164).
+
 ## [1.1.8] - 2026-04-17
 
 ### Changed

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -21,3 +21,10 @@
 - [Code Coverage](./contributor-guide/coverage.md)
 - [Mutation Testing](./contributor-guide/mutation-baseline.md)
 - [Fuzzing](./contributor-guide/fuzzing.md)
+
+# About
+
+- [Contributing](./about/contributing.md)
+- [Security Policy](./about/security.md)
+- [Design](./about/design.md)
+- [Changelog](./about/changelog.md)

--- a/docs/src/about/changelog.md
+++ b/docs/src/about/changelog.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This page is rendered from [`CHANGELOG.md`](https://github.com/lijunzh/hunch/blob/main/CHANGELOG.md)
+at the root of the repository (single source of truth). Format follows
+[Keep a Changelog](https://keepachangelog.com/) and the project adheres
+to [Semantic Versioning](https://semver.org/) per the
+[API Stability Policy](./contributing.md#api-stability-policy).
+
+{{#include ../../../CHANGELOG.md}}

--- a/docs/src/about/contributing.md
+++ b/docs/src/about/contributing.md
@@ -1,0 +1,6 @@
+# Contributing
+
+This page is rendered from [`CONTRIBUTING.md`](https://github.com/lijunzh/hunch/blob/main/CONTRIBUTING.md)
+at the root of the repository (single source of truth).
+
+{{#include ../../../CONTRIBUTING.md}}

--- a/docs/src/about/design.md
+++ b/docs/src/about/design.md
@@ -1,0 +1,15 @@
+# Design
+
+This page is rendered from [`DESIGN.md`](https://github.com/lijunzh/hunch/blob/main/DESIGN.md)
+at the root of the repository (single source of truth).
+
+The design doc covers hunch's mission, three foundational principles
+(P1–P3), and the design decisions (D1–D10) that flow from them.
+Particularly relevant for would-be contributors:
+
+- **D8: 5 features, not 15** — the anti-feature-creep principle
+- **D9: Self-contained property matchers** — how to add a new property
+- **D10: Refactor before accreting** — the tripwires that flag when to
+  consolidate before adding the next thing
+
+{{#include ../../../DESIGN.md}}

--- a/docs/src/about/security.md
+++ b/docs/src/about/security.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+This page is rendered from [`SECURITY.md`](https://github.com/lijunzh/hunch/blob/main/SECURITY.md)
+at the root of the repository (single source of truth).
+
+{{#include ../../../SECURITY.md}}


### PR DESCRIPTION
## Summary

PR-1 of the 3-step CI/docs **close-out** plan. Two purely-additive fixes for gaps surfaced by the post-v1.1.8 user-facing pivot:

1. **`CHANGELOG.md` `[Unreleased]` was empty** despite 22 PRs merged since v1.1.8
2. **Root markdown files** (`CONTRIBUTING`, `SECURITY`, `DESIGN`, `CHANGELOG`) were not surfaced from <https://lijunzh.github.io/hunch/> — discoverable on GitHub UI only

Net: **+132 lines / -0**, zero source/CI changes.

## CHANGELOG backfill

Organized per [Keep a Changelog](https://keepachangelog.com/):

| Section | Content |
|---|---|
| **Added** | `is_movie/is_episode/is_extra` (#156); 3 new `Property` variants for mimetype + audio/video bit-rate (#165); DVD region codes R0–R6 (#156) |
| **Changed (BREAKING)** | Public enums now `#[non_exhaustive]` (#172) — with migration snippet |
| **Fixed** | ccTLD-in-language-abbreviation false-positive (#167); two bit-rate parsing edge cases (#165) |
| **Deprecated** | `Property::BitRate` (superseded by audio/video split) |
| **Internal / Infrastructure** | One grouped section covering all CI/docs/infra PRs with refs |

Two known-breaking-by-strict-SemVer changes (#165 enum variants, #172 `#[non_exhaustive]`) live in `[Unreleased]`. The **version-bump decision** (v1.2.0 vs v2.0.0 per the [API Stability Policy](https://github.com/lijunzh/hunch/blob/main/CONTRIBUTING.md#api-stability-policy)) is intentionally deferred to PR-2 of the close-out plan so this PR stays purely additive.

## Mdbook nav additions

New top-level **About** section in `SUMMARY.md` with four shim pages that use mdbook's `{{#include}}` preprocessor:

```
About
├─ Contributing      → includes ../../../CONTRIBUTING.md
├─ Security Policy   → includes ../../../SECURITY.md
├─ Design            → includes ../../../DESIGN.md
└─ Changelog         → includes ../../../CHANGELOG.md
```

Single source of truth (the root files); GitHub UI keeps rendering them as before; doc-site users can now read them in the sidebar without leaving the docs context.

## Verification

- ✅ `mdbook build docs`: clean, no warnings
- ✅ All 4 new pages render with full content (28KB security → 82KB changelog) — confirms `{{#include}}` works
- ✅ Spot-checked unique strings ("API Stability Policy", "P1: Easy to reason about") appear in rendered HTML

## What this PR does NOT do

Per the "avoid over-engineering, close it ASAP" plan:

- ❌ No new CI features
- ❌ No doc-site features beyond #190's baseline
- ❌ No version bump (PR-2)
- ❌ No epic closures for #145 / #147 (separate admin step between PR-1 and PR-2)

## Close-out plan reminder

| Step | Status |
|---|---|
| **PR-1** (this) | CHANGELOG backfill + mdbook nav |
| **Admin** | Close #145 / #147 with one-line reopen criteria |
| **PR-2** | Cut v1.2.0 (or v2.0.0) release — bumps version, moves `[Unreleased]`, validates per-release snapshot pipeline |
