### PR TITLE
chore: pre-v2.0.0 polish (non_exhaustive coverage + doc accuracy)

### DIFF
--- a/docs/src/reference/public-api.md
+++ b/docs/src/reference/public-api.md
@@ -85,13 +85,13 @@ rustup toolchain install nightly --profile minimal
 cargo install cargo-public-api --locked
 
 # Capture the current public API:
-cargo public-api --simplified > docs/public-api.txt
+cargo +nightly public-api --simplified 2>/dev/null > docs/src/reference/public-api.txt
 
 # Verify the diff matches what you intended:
-git diff docs/public-api.txt
+git diff docs/src/reference/public-api.txt
 ```
 
-Commit `docs/public-api.txt` together with the API change in the same PR.
+Commit `docs/src/reference/public-api.txt` together with the API change in the same PR.
 The diff in the PR review should make the API delta easy for reviewers
 to scan.
 

--- a/docs/src/reference/public-api.txt
+++ b/docs/src/reference/public-api.txt
@@ -456,7 +456,7 @@ impl core::marker::Unpin for hunch::tokenizer::BracketKind
 impl core::marker::UnsafeUnpin for hunch::tokenizer::BracketKind
 impl core::panic::unwind_safe::RefUnwindSafe for hunch::tokenizer::BracketKind
 impl core::panic::unwind_safe::UnwindSafe for hunch::tokenizer::BracketKind
-pub enum hunch::tokenizer::SegmentKind
+#[non_exhaustive] pub enum hunch::tokenizer::SegmentKind
 pub hunch::tokenizer::SegmentKind::Directory
 pub hunch::tokenizer::SegmentKind::Filename
 impl core::clone::Clone for hunch::tokenizer::SegmentKind
@@ -650,7 +650,7 @@ impl core::panic::unwind_safe::RefUnwindSafe for hunch::zone_map::ZoneMap
 impl core::panic::unwind_safe::UnwindSafe for hunch::zone_map::ZoneMap
 pub fn hunch::zone_map::build_zone_map(input: &str, token_stream: &hunch::tokenizer::TokenStream) -> hunch::zone_map::ZoneMap
 pub fn hunch::zone_map::is_tier2_token(text: &str) -> bool
-pub enum hunch::Confidence
+#[non_exhaustive] pub enum hunch::Confidence
 pub hunch::Confidence::High
 pub hunch::Confidence::Low
 pub hunch::Confidence::Medium

--- a/docs/src/user-guide/compatibility.md
+++ b/docs/src/user-guide/compatibility.md
@@ -8,7 +8,7 @@ But guessit compatibility is no longer the primary optimization target.
 Hunch is tuned first for **real-world media-library accuracy**, with guessit
 compatibility used as a reference point rather than a product goal.
 
-> **Last updated:** 2026-04-17 (v1.1.8 release)
+> **Last updated:** 2026-04-19 (pre-v2.0.0)
 
 ---
 
@@ -55,17 +55,15 @@ behavior that is more accurate and maintainable for actual media libraries.
 
 ## Intentional divergences
 
-Hunch intentionally does not mirror guessit in a few places:
+Hunch intentionally does not mirror guessit in a few places. The list is
+smaller than it used to be — several earlier divergences (notably the
+bit_rate split and mimetype derivation) were resolved in v2.0.0 (#165)
+because real-world filenames turned out to provide enough signal after
+all.
 
-- **`audio_bit_rate` / `video_bit_rate`**
-  - guessit splits these into separate properties
-  - hunch emits a single `bit_rate`, because filenames rarely contain enough
-    reliable context to disambiguate audio vs video bit rate cleanly
-
-- **`mimetype`**
-  - guessit derives MIME type from the file extension
-  - hunch does not emit it, because that is a trivial container lookup better
-    handled by the consumer
+*Active divergences as of v2.0.0: none worth listing.* If you find one,
+please file an issue — the goal is for divergences to be deliberate and
+documented, not accidental.
 
 ---
 

--- a/docs/src/user-guide/user-manual.md
+++ b/docs/src/user-guide/user-manual.md
@@ -184,9 +184,62 @@ fn main() {
         Confidence::High   => println!("Confident parse"),
         Confidence::Medium => println!("Reasonable parse"),
         Confidence::Low    => println!("Consider using --context"),
+        // `Confidence` is `#[non_exhaustive]` so future variants land
+        // without forcing a major-version bump. Add a wildcard arm to
+        // your `match`es:
+        _                  => println!("Unknown confidence level"),
     }
 }
 ```
+
+### Media-type checks (added in v2.0.0)
+
+Three convenience helpers route a result to the right downstream lookup
+(e.g., TMDb for movies vs. TVDb for episodes) without an explicit
+`MediaType` import:
+
+```rust
+use hunch::hunch;
+
+fn main() {
+    let r = hunch("Breaking.Bad.S05E16.720p.BluRay.x264-DEMAND.mkv");
+    if r.is_episode() {
+        // route to TVDb
+    }
+    if r.is_movie() {
+        // route to TMDb
+    }
+    if r.is_extra() {
+        // bonus content / specials / NCOP / NCED — may not have a DB entry
+    }
+}
+```
+
+All three return `false` when the media type is unknown (rather than
+defaulting to a guess). Callers that need to distinguish "definitely
+not X" from "unknown" should use
+[`media_type()`](https://docs.rs/hunch/latest/hunch/struct.HunchResult.html#method.media_type)
+directly.
+
+### Bit rate and MIME type (added in v2.0.0)
+
+The `bit_rate` property is split by unit (`Kbps` → audio, `Mbps` →
+video); MIME type is derived from the container extension:
+
+```rust
+use hunch::hunch;
+
+fn main() {
+    let r = hunch("Movie.2024.DD5.1.448Kbps.x264.5500Kbps.mp4");
+    assert_eq!(r.audio_bit_rate(), Some("448Kbps"));
+    assert_eq!(r.video_bit_rate(), Some("5500Kbps"));
+    assert_eq!(r.mimetype(),       Some("video/mp4"));
+}
+```
+
+MIME type returns `None` when the container is unknown rather than
+fabricating a value — callers that need a fallback should provide it
+at the call site.
 
 ### Full API reference
 

--- a/src/hunch_result.rs
+++ b/src/hunch_result.rs
@@ -22,8 +22,13 @@ use crate::matcher::span::{MatchSpan, Property};
 ///
 /// Computed from structural signals like the number of tech anchors found,
 /// whether a title was extracted, and whether cross-file context was used.
+///
+/// `#[non_exhaustive]` so future variants (e.g. a `VeryHigh` for context-
+/// resolved cross-file matches) can be added in minor releases without a
+/// SemVer break. Downstream `match`es must include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum Confidence {
     /// Few or no properties extracted; title may be wrong.
     Low,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -88,7 +88,12 @@ pub enum Separator {
 }
 
 /// Which part of the path a segment represents.
+///
+/// `#[non_exhaustive]` so future variants (e.g. `Volume` for disk-image
+/// roots, `Archive` for in-archive paths) can be added in minor releases
+/// without a SemVer break. Downstream `match`es must include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SegmentKind {
     /// A directory component (e.g., "Movies", "Season 01").
     Directory,


### PR DESCRIPTION
## Summary

PR-2a of the v2.0.0 close-out plan. Three small cleanups that are **free under the v2.0.0 major bump** but would each cost a separate major bump if deferred. Plus two documentation drift fixes that real users would hit immediately.

Net: **+77 / -16**, no behavior change.

## API hygiene (free under v2.0.0)

Brings every `pub enum` in the public surface into full alignment with the documented [API Stability Policy](https://github.com/lijunzh/hunch/blob/main/CONTRIBUTING.md#api-stability-policy):

| Enum | Before | After | Why now |
|---|---|---|---|
| `Confidence` | exhaustive (3 variants) | `#[non_exhaustive]` | Appears in user-facing examples; hypothetical `VeryHigh` should land in v2.x minor, not force v3.0.0 |
| `SegmentKind` | exhaustive (2 variants) | `#[non_exhaustive]` | In public surface (line 459); future `Volume`/`Archive` variants should land in minor |

`docs/src/reference/public-api.txt` refresh: surgical 2-line diff at lines 459 + 653 — no other API changes snuck in.

## Documentation drift fixes

| File | Fix |
|---|---|
| `compatibility.md` | Removed stale "Intentional divergences" entries for `audio_bit_rate`/`video_bit_rate`/`mimetype` — #165 implemented all three! Replaced with "no active divergences worth listing." Bumped "Last updated" stamp. |
| `user-manual.md` | Added Library API subsections for the v2.0.0 additions: **Media-type checks** (`is_movie`/`is_episode`/`is_extra`) + **Bit rate and MIME type**. Updated the `Confidence` `match` example with a wildcard arm to compile against the now-non_exhaustive enum. |

## Path typo fix

`docs/src/reference/public-api.md` regenerate-the-baseline instructions referenced the pre-mdbook-port path `docs/public-api.txt`. Fixed to actual `docs/src/reference/public-api.txt` and corrected the invocation to redirect stderr (the version without `2>/dev/null` bleeds cargo-build progress lines into the snapshot — discovered while regenerating for this PR 🐛).

## Verification

- ✅ `cargo test --lib`: 339 passed (no internal exhaustive matches broke)
- ✅ `cargo clippy --all-targets`: clean
- ✅ `cargo fmt --check`: clean
- ✅ `mdbook build docs`: clean
- ✅ `public-api` diff is exactly the 2 expected lines

## Plan reminder

| Step | Status |
|---|---|
| **PR-2a** (this) | non_exhaustive + doc-drift fixes |
| **PR-2b** | #144 API audit triage — inventory the 853-line public surface, propose demotions, land them as one PR |
| **PR-2c** | Cut v2.0.0 — bump Cargo.toml, move CHANGELOG `[Unreleased]` → `[2.0.0]`, add to RELEASE_TAGS, tag, push |

Refs: #144, #165, #172.
