### PR TITLE
feat!: remove deprecated Property::BitRate variant for v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,32 @@ Release prep checklist (per #179):
 
 ### Changed
 
+- **⚠️ BREAKING: removed `Property::BitRate` variant.** Deprecated in
+  this same release wave (#165) and unreachable from any parser path
+  since the bit-rate split landed: the regex captures `[KkMm]` and both
+  branches map to `Property::AudioBitRate` (Kbps) or
+  `Property::VideoBitRate` (Mbps). The previous "defensive fallback"
+  was dead code. Removing it now (under the v2.0.0 major bump) avoids
+  forcing a v3.0.0 just to delete one variant later.
+
+  **Migration:** if your code matches on `Property::BitRate`, switch to
+  the unit-typed variants. The `#[non_exhaustive]` annotation already
+  requires a wildcard arm, so the diff is usually a one-liner:
+
+  ```rust
+  match prop {
+      // Before:
+      Property::BitRate       => handle_either(value),
+      // After:
+      Property::AudioBitRate  => handle_audio(value),
+      Property::VideoBitRate  => handle_video(value),
+      _ => {}
+  }
+  ```
+
+  The matching `bit_rate` JSON output key is also gone; downstream JSON
+  consumers should read `audio_bit_rate` / `video_bit_rate`. (#144, #165)
+
 - **⚠️ BREAKING: public module surface dramatically reduced.** Four
   sub-modules were demoted from `pub mod` to `pub(crate) mod`:
   `matcher`, `properties`, `tokenizer`, `zone_map`. The intended public
@@ -120,13 +146,6 @@ Release prep checklist (per #179):
 - **`DD5.1.448kbps`-style filenames** no longer mis-parse the leading
   digits as part of the bit-rate (regex bound tightened to `\d{1,2}`).
   (#165)
-
-### Deprecated
-
-- **`Property::BitRate` variant** — superseded by the
-  `AudioBitRate`/`VideoBitRate` split in #165. The variant is retained
-  for enum-API stability but no parser path produces it. Callers should
-  migrate to the unit-typed variants.
 
 ### Internal / Infrastructure
 

--- a/docs/src/reference/public-api.txt
+++ b/docs/src/reference/public-api.txt
@@ -55,7 +55,6 @@ pub hunch::Property::AudioBitRate
 pub hunch::Property::AudioChannels
 pub hunch::Property::AudioCodec
 pub hunch::Property::AudioProfile
-pub hunch::Property::BitRate
 pub hunch::Property::Bonus
 pub hunch::Property::BonusTitle
 pub hunch::Property::Cd

--- a/docs/src/user-guide/user-manual.md
+++ b/docs/src/user-guide/user-manual.md
@@ -284,7 +284,8 @@ accessors.
 | `audio_codec` | AAC | `AAC` |
 | `audio_channels` | 5.1 | `5.1ch` |
 | `audio_profile` | HD MA | `DTS-HD.MA` |
-| `bit_rate` | 320kbps | `320kbps` |
+| `audio_bit_rate` | 320Kbps | `320kbps` |
+| `video_bit_rate` | 19.1Mbps | `19.1mbps` |
 
 ### Source & Edition
 

--- a/src/matcher/span.rs
+++ b/src/matcher/span.rs
@@ -157,14 +157,6 @@ define_properties! {
     Other => "other",
     /// File size (e.g., `"1.4 GB"`, `"700 MB"`).
     Size => "size",
-    /// Audio or video bit rate (e.g., `"320Kbps"`, `"1.5Mbps"`).
-    ///
-    /// **Deprecated**: bit rate matches are now disambiguated at parse time
-    /// into [`AudioBitRate`](Self::AudioBitRate) (`Kbps`) and
-    /// [`VideoBitRate`](Self::VideoBitRate) (`Mbps`). This variant is retained
-    /// for enum-API stability (downstream `match` arms continue to compile)
-    /// but no parser produces it as of the bit-rate split (#158).
-    BitRate => "bit_rate",
     /// CD / disc number within a multi-disc set (e.g., `"1"` from `CD1`).
     Cd => "cd",
     /// Bonus content number (e.g., `"2"` from `-x02`).

--- a/src/properties/bit_rate.rs
+++ b/src/properties/bit_rate.rs
@@ -14,9 +14,7 @@
 //!   1–50 Mbps for compressed formats).
 //!
 //! This unit-based heuristic matches guessit's behavior and reflects how the
-//! values appear in real-world filenames. The legacy [`Property::BitRate`]
-//! variant is retained on the enum for back-compat with downstream `match`
-//! arms but is no longer produced by this matcher.
+//! values appear in real-world filenames.
 
 use regex::Regex;
 
@@ -83,26 +81,22 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
         // Normalize unit prefix casing: "k" → "K", "m" → "M".
         // The trailing suffix is always normalized to "bps" regardless of
         // whether the input said "bps" or "bit" — single canonical form.
-        let normalized_unit = match unit.to_ascii_lowercase().as_str() {
-            "k" => "Kbps",
-            "m" => "Mbps",
-            // Fallback: shouldn't occur given the regex character class.
-            _ => "Kbps",
+        // Disambiguate by unit (#158): Kbps → audio, Mbps → video.
+        // The unit alone is a near-perfect signal in real-world filenames.
+        let (normalized_unit, property) = match unit.to_ascii_lowercase().as_str() {
+            "k" => ("Kbps", Property::AudioBitRate),
+            "m" => ("Mbps", Property::VideoBitRate),
+            // The regex character class is `[KkMm]`, so this is genuinely
+            // unreachable. Use `unreachable!` rather than a defensive
+            // fallback so a future regex change that breaks this contract
+            // fails loudly in tests instead of producing silently-wrong
+            // output. (Pre-v2.0.0 used a `Property::BitRate` fallback;
+            // that variant was removed in v2.0.0 — see CHANGELOG.)
+            _ => unreachable!("BIT_RATE regex captures only [KkMm] for the unit group"),
         };
 
         // Output without spaces: "320Kbps", "19.1Mbps".
         let value = format!("{num}{normalized_unit}");
-
-        // Disambiguate by unit (#158): Kbps → audio, Mbps → video.
-        // The unit alone is a near-perfect signal in real-world filenames.
-        let property = match normalized_unit {
-            "Kbps" => Property::AudioBitRate,
-            "Mbps" => Property::VideoBitRate,
-            // Fallback: shouldn't happen given the regex, but keep the
-            // legacy BitRate variant as the safety net rather than
-            // panicking on an unexpected unit (defensive).
-            _ => Property::BitRate,
-        };
 
         matches.push(
             MatchSpan::new(abs_start, abs_end, property, &value)


### PR DESCRIPTION
## Summary

PR-2c of the v2.0.0 close-out plan. Honors the deprecation deferred to "the next major bump" (#165) by **actually removing the variant now** — same logic that justified shipping `#[non_exhaustive]` (PR-2a, #196) and the module demotion (PR-2b, #197) under v2.0.0:

> Deferring a known breaking change forces the next major bump later. Bundling all known-breaking work into one major version is strictly better than spreading it across multiple.

Found during the pre-release audit triggered by @lijunzh's question: *"Before release, anything else we need to do? I don't want to release v2.0 and realize we need another breaking change immediately."*

This was the **only** lurker. (See audit notes in [#197 review thread] — the other two open issues, #143 epic and #193 tracker, are internal-only and don't affect public API.)

## What changed

| File | Change |
|---|---|
| `src/matcher/span.rs` | Removed `BitRate => "bit_rate"` from `define_properties!` |
| `src/properties/bit_rate.rs` | Replaced match-then-match with single match returning `(unit, property)`. Unreachable defensive arm now uses `unreachable!()` instead of `Property::BitRate` fallback. |
| `docs/src/user-guide/user-manual.md` | Audio table: `bit_rate` row → `audio_bit_rate` + `video_bit_rate` rows |
| `CHANGELOG.md` | Promoted `### Deprecated` entry to `### Changed` (BREAKING) with migration snippet. Removed empty `### Deprecated` section. |
| `docs/src/reference/public-api.txt` | Refreshed (202 → **201 lines**) |

## Why `unreachable!()` and not another fallback variant

- The regex character class is literally `[KkMm]` — reaching the fallback requires a regex change that breaks the unit contract
- With `unreachable!()`, such a regex change **fails loudly in tests** instead of producing silently-wrong output (audio bit rate mislabeled as video, or vice versa)
- Zen of Python: *"Errors should never pass silently. Unless explicitly silenced."* We are not silencing.

## Migration for downstream callers

```rust
match prop {
    // Before:
    Property::BitRate       => handle_either(value),
    // After:
    Property::AudioBitRate  => handle_audio(value),
    Property::VideoBitRate  => handle_video(value),
    _ => {}  // already required by #[non_exhaustive] from PR-2a
}
```

JSON output: the `bit_rate` key is gone; downstream consumers should read `audio_bit_rate` / `video_bit_rate`.

## Verification

- ✅ `cargo build --all-targets`: clean (zero warnings)
- ✅ `cargo test`: 339+ integration tests pass, 12 doctests pass
- ✅ `cargo clippy --all-targets`: clean
- ✅ `cargo fmt --check`: clean
- ✅ `public-api` diff: **exactly one removal** (`Property::BitRate`); `AudioBitRate` + `VideoBitRate` still present
- ✅ `grep BitRate src/`: only `AudioBitRate` and `VideoBitRate` remain

## v2.0.0 release plan

| Step | Status |
|---|---|
| **PR-2a** non_exhaustive + doc-drift fixes | ✅ merged (#196) |
| **PR-2b** Module demotion + dead-code cleanup | ✅ merged (#197) |
| **PR-2c** (this) Remove deprecated BitRate | ⏳ this PR |
| **PR-2d** Cut v2.0.0 — bump Cargo.toml, move CHANGELOG, tag, push | ⏸️ blocked on this |

After this lands, the [Unreleased] section will have **zero deprecations** and **zero known deferred breaking changes** — clean slate for v2.0.0.

Refs: #144, #158, #165.
