### PR TITLE
fix(#212): parse CJK fansub patterns [Nth - NN] and [总第NN]

### DIFF
--- a/src/properties/episodes/mod.rs
+++ b/src/properties/episodes/mod.rs
@@ -185,6 +185,15 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
     // High confidence: structural markers (always run)
     try_sxxexx_family(input, &mut matches);
 
+    // CJK fansub Latin-ordinal season+episode: `[4th - 01]` etc.
+    // Runs early because it's an explicit structural marker (carries
+    // BOTH season and episode), not a heuristic. Only runs if the
+    // SxxExx family didn't already produce a match — SxxExx wins on
+    // overlap (rare in practice; CJK fansubs rarely use both).
+    if matches.is_empty() {
+        try_nth_dash_episode(input, &mut matches);
+    }
+
     // Medium-high: compact notation (only if no SxxExx found)
     if matches.is_empty() {
         try_nxn(input, &mut matches);
@@ -205,6 +214,12 @@ pub fn find_matches(input: &str) -> Vec<MatchSpan> {
     if !has_property(&matches, Property::Episode) {
         try_cjk_episode_marker(input, &mut matches);
     }
+
+    // CJK cumulative-episode marker: `[总第67]` → absolute_episode=67.
+    // Runs unconditionally (independent of Episode detection) because
+    // it produces AbsoluteEpisode, not Episode — the two coexist by
+    // design (e.g. season 4 episode 1 = cumulative episode 67).
+    try_cjk_cumulative_episode(input, &mut matches);
 
     // Low confidence: digit decomposition (only if nothing found)
     if !has_property(&matches, Property::Season) && !has_property(&matches, Property::Episode) {
@@ -856,7 +871,7 @@ fn try_cjk_bracket_episode(input: &str, matches: &mut Vec<MatchSpan>) {
     }
 }
 
-// ── Group 4c: CJK ordinal episode markers ─────────────────────────────
+// ── Group 4c: CJK ordinal episode markers ─────────────────────
 
 /// CJK ordinal episode markers: 第N話 (Japanese), 第N集 (Chinese), 第N话, 第N回.
 ///
@@ -886,6 +901,58 @@ fn try_cjk_episode_marker(input: &str, matches: &mut Vec<MatchSpan>) {
             MatchSpan::new(abs_start, abs_end, Property::Episode, ep_num.to_string())
                 .with_priority(crate::priority::KEYWORD),
         );
+    }
+}
+
+// ── Group 4d: CJK fansub Latin-ordinal season+episode ─────────────
+
+/// CJK fansub Latin-ordinal season+episode: `[4th - 01]`, `[2nd - 12]`,
+/// `[4th - 01v2]`. Common in Chinese fansub releases that bracket the
+/// English ordinal season label alongside the episode number.
+///
+/// Both season and episode are emitted at structural priority — this
+/// is an explicit marker, not a heuristic.
+///
+/// Examples:
+/// - `[晚街与灯][Re Zero ...][4th - 01][总第67]...mkv` → season=4, episode=1
+/// - `[Group][Title][2nd - 12v2][...]` → season=2, episode=12
+fn try_nth_dash_episode(input: &str, matches: &mut Vec<MatchSpan>) {
+    for cap in NTH_DASH_EPISODE.captures_iter(input) {
+        let full = cap.get(0).expect("group 0 always present");
+        let season = parse_num(&cap, "season");
+        let episode = parse_num(&cap, "episode");
+        matches.push(
+            MatchSpan::new(full.start(), full.end(), Property::Season, season)
+                .with_priority(crate::priority::STRUCTURAL),
+        );
+        matches.push(
+            MatchSpan::new(full.start(), full.end(), Property::Episode, episode)
+                .with_priority(crate::priority::STRUCTURAL),
+        );
+    }
+}
+
+// ── Group 4e: CJK cumulative-episode marker ───────────────────
+
+/// CJK cumulative-episode marker: `[总第67]` → absolute_episode=67.
+///
+/// `总第` literally means "cumulative episode" in Chinese. This is a
+/// common Chinese fansub convention for tagging the absolute episode
+/// number of a multi-season series alongside the per-season number
+/// (e.g. season 4 episode 1 = cumulative episode 67).
+///
+/// Emits [`Property::AbsoluteEpisode`] independently of regular Episode
+/// detection — the two are designed to coexist.
+fn try_cjk_cumulative_episode(input: &str, matches: &mut Vec<MatchSpan>) {
+    for cap in CJK_CUMULATIVE_EPISODE.captures_iter(input) {
+        let full = cap.get(0).expect("group 0 always present");
+        let abs_ep = parse_num(&cap, "absolute_episode");
+        matches.push(MatchSpan::new(
+            full.start(),
+            full.end(),
+            Property::AbsoluteEpisode,
+            abs_ep,
+        ));
     }
 }
 

--- a/src/properties/episodes/patterns.rs
+++ b/src/properties/episodes/patterns.rs
@@ -173,6 +173,47 @@ pub(super) static CJK_BRACKET_EPISODE: LazyLock<regex::Regex> = LazyLock::new(||
         .expect("CJK_BRACKET_EPISODE regex is valid")
 });
 
+// ── CJK fansub Latin-ordinal season+episode ──
+
+/// CJK fansub Latin-ordinal season+episode: `[4th - 01]`, `[2nd - 12]`,
+/// `[4th - 01v2]`. Common in Chinese fansub releases that bracket the
+/// English ordinal season label alongside the episode number.
+///
+/// Examples:
+/// - `[4th - 01]` → season=4, episode=1
+/// - `[2nd - 12v2]` → season=2, episode=12 (the `v2` revision suffix is
+///   absorbed by the regex but ignored — the existing `VERSIONED_EPISODE`
+///   pattern handles the version separately).
+///
+/// We only accept ordinals 1st–10th (single digit) to avoid false
+/// positives on group names or scene tags that happen to end in those
+/// suffixes.
+pub(super) static NTH_DASH_EPISODE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r"\[\s*(?P<season>\d)(?:st|nd|rd|th)\s*[-\u2013\u2014]\s*(?P<episode>\d{1,4})(?:[vV]\d+)?\s*\]",
+    )
+    .expect("NTH_DASH_EPISODE regex is valid")
+});
+
+// ── CJK cumulative episode ──
+
+/// CJK cumulative-episode marker: `[总第NN]` (Chinese: "cumulative
+/// episode N"). A common Chinese fansub convention for tagging the
+/// absolute episode number of a multi-season series alongside the
+/// per-season episode number.
+///
+/// Examples:
+/// - `[总第67]` → absolute_episode=67
+/// - `[总第 100]` → absolute_episode=100
+///
+/// Maps to [`Property::AbsoluteEpisode`] (existing property), not a new
+/// variant — the semantics match the existing absolute-episode concept
+/// (e.g. anime that runs cumulatively across seasons).
+pub(super) static CJK_CUMULATIVE_EPISODE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"\[\s*总第\s*(?P<absolute_episode>\d{1,4})\s*\]")
+        .expect("CJK_CUMULATIVE_EPISODE regex is valid")
+});
+
 // ── Week pattern ──
 
 /// Week 45, Week.12, etc.

--- a/src/properties/episodes/tests.rs
+++ b/src/properties/episodes/tests.rs
@@ -304,3 +304,174 @@ fn test_season_range_word() {
         .collect();
     assert_eq!(seasons.len(), 3, "Expected 3 seasons, got: {:?}", seasons);
 }
+
+// ── Issue #212: CJK fansub patterns ──────────────────────────────
+
+#[test]
+fn test_nth_dash_episode_basic() {
+    // [4th - 01] → season 4, episode 1
+    let m = find_matches("[Group][Title][4th - 01][1080P].mkv");
+    assert!(
+        m.iter()
+            .any(|x| x.property == Property::Season && x.value == "4"),
+        "Expected season 4, got: {:?}",
+        m.iter()
+            .filter(|x| x.property == Property::Season)
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        m.iter()
+            .any(|x| x.property == Property::Episode && x.value == "1"),
+        "Expected episode 1, got: {:?}",
+        m.iter()
+            .filter(|x| x.property == Property::Episode)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_nth_dash_episode_all_ordinals() {
+    // 1st through 9th should all parse.
+    for (label, season) in [
+        ("1st", "1"),
+        ("2nd", "2"),
+        ("3rd", "3"),
+        ("4th", "4"),
+        ("5th", "5"),
+        ("9th", "9"),
+    ] {
+        let filename = format!("[Group][Title][{} - 03][1080P].mkv", label);
+        let m = find_matches(&filename);
+        assert!(
+            m.iter()
+                .any(|x| x.property == Property::Season && x.value == season),
+            "Expected season {} for {:?}, got: {:?}",
+            season,
+            filename,
+            m
+        );
+    }
+}
+
+#[test]
+fn test_nth_dash_episode_with_version() {
+    // [4th - 01v2] — the v2 is a revision suffix; episode is still 1.
+    let m = find_matches("[Group][Title][4th - 01v2][1080P].mkv");
+    assert!(
+        m.iter()
+            .any(|x| x.property == Property::Season && x.value == "4")
+    );
+    assert!(
+        m.iter()
+            .any(|x| x.property == Property::Episode && x.value == "1")
+    );
+}
+
+#[test]
+fn test_nth_dash_episode_em_dash() {
+    // Some fansubs use em-dash (—) or en-dash (–) instead of hyphen.
+    let m = find_matches("[Group][Title][3rd – 12][1080P].mkv");
+    assert!(
+        m.iter()
+            .any(|x| x.property == Property::Season && x.value == "3")
+    );
+    assert!(
+        m.iter()
+            .any(|x| x.property == Property::Episode && x.value == "12")
+    );
+}
+
+#[test]
+fn test_nth_dash_episode_ignores_two_digit_ordinals() {
+    // We deliberately only match single-digit ordinals (1st-9th) to
+    // avoid false positives on group names / scene tags.
+    let m = find_matches("[Group][Title][10th - 05][1080P].mkv");
+    assert!(
+        !m.iter()
+            .any(|x| x.property == Property::Season && x.value == "10"),
+        "Should NOT match two-digit ordinals like '10th', got: {:?}",
+        m.iter()
+            .filter(|x| x.property == Property::Season)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_cjk_cumulative_episode_basic() {
+    // [总第67] → absolute_episode 67
+    let m = find_matches("[Group][Title][4th - 01][总第67][1080P].mkv");
+    assert!(
+        m.iter()
+            .any(|x| x.property == Property::AbsoluteEpisode && x.value == "67"),
+        "Expected absolute_episode 67, got: {:?}",
+        m.iter()
+            .filter(|x| x.property == Property::AbsoluteEpisode)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_cjk_cumulative_episode_with_whitespace() {
+    // [总第 100] with space — should still match.
+    let m = find_matches("[Group][Title][总第 100][1080P].mkv");
+    assert!(
+        m.iter()
+            .any(|x| x.property == Property::AbsoluteEpisode && x.value == "100")
+    );
+}
+
+#[test]
+fn test_cjk_cumulative_episode_independent_of_episode() {
+    // The cumulative pattern emits AbsoluteEpisode even when no
+    // regular Episode is present in the filename.
+    let m = find_matches("[Group][Title][总第42][1080P].mkv");
+    assert!(
+        m.iter()
+            .any(|x| x.property == Property::AbsoluteEpisode && x.value == "42")
+    );
+}
+
+#[test]
+fn test_212_full_filename_regression() {
+    // The exact filenames from issue #212. Pins season + episode +
+    // absolute_episode + (implicitly) `type: episode` via the
+    // cascading effect on type classification.
+    let cases = [
+        (
+            "[晚街与灯][Re Zero kara Hajimeru Isekai Seikatsu][4th - 01][总第67][WEB-DL Remux][1080P_AVC_AAC][简繁日内封PGS][V2].mkv",
+            "4",
+            "1",
+            "67",
+        ),
+        (
+            "[晚街与灯][Re Zero kara Hajimeru Isekai Seikatsu][4th - 02][总第68][WEB-DL Remux][1080P_AVC_AAC][简繁日内封PGS].mkv",
+            "4",
+            "2",
+            "68",
+        ),
+    ];
+    for (filename, season, episode, abs_ep) in cases {
+        let m = find_matches(filename);
+        assert!(
+            m.iter()
+                .any(|x| x.property == Property::Season && x.value == season),
+            "Expected season {} in {:?}",
+            season,
+            filename
+        );
+        assert!(
+            m.iter()
+                .any(|x| x.property == Property::Episode && x.value == episode),
+            "Expected episode {} in {:?}",
+            episode,
+            filename
+        );
+        assert!(
+            m.iter()
+                .any(|x| x.property == Property::AbsoluteEpisode && x.value == abs_ep),
+            "Expected absolute_episode {} in {:?}",
+            abs_ep,
+            filename
+        );
+    }
+}


### PR DESCRIPTION
Closes most of #212 (bugs 1, 2, and the cascading bug 4 `type: movie`).

## What

Two new regex patterns for Chinese fansub releases that were silently dropped:

| Pattern | Example | Emits |
|---|---|---|
| `NTH_DASH_EPISODE` | `[4th - 01]`, `[2nd - 12v2]` | `Season` + `Episode` (both at `STRUCTURAL` priority) |
| `CJK_CUMULATIVE_EPISODE` | `[总第67]`, `[总第 100]` | `AbsoluteEpisode` (reuses existing property) |

## Why

Reported in #212. Real-world Chinese fansub filenames from the 晚街与灯 group:

```
[晚街与灯][Re Zero kara Hajimeru Isekai Seikatsu][4th - 01][总第67][WEB-DL Remux][1080P_AVC_AAC][简繁日内封PGS][V2].mkv
```

Hunch v1.1.8 extracted title/group/codec correctly but dropped season, episode, and the cumulative count — and *because* no episode was detected, the type classifier defaulted to `movie`.

## Before vs after

```diff
- {"title":"...","source":"Web","type":"movie"}
+ {"season":4,"episode":1,"absolute_episode":67,
+  "title":"...","type":"episode"}
```

So this PR fixes **three of the four bugs** in #212 with a single targeted change. The cascading `type: movie` fix is essentially free — it falls out of correct episode detection.

## Design notes

**Single-digit ordinals only (1st–9th).** A deliberate guardrail against false positives on scene tags / group names that happen to end in `th`. If real-world filenames need `10th+`, easy to relax later.

**Em-dash + en-dash + hyphen all accepted** as separators since fansubs vary.

**`AbsoluteEpisode` reuse, not a new variant.** The semantics (`总第` = "cumulative episode") match the existing concept used for anime that runs cumulatively across seasons. No need for `Property::CumulativeEpisode`.

**`try_cjk_cumulative_episode` runs unconditionally** in the dispatch chain, independent of regular `Episode` detection — the two are designed to coexist (S04E01 = absolute episode 67).

## Tests

9 new tests in `src/properties/episodes/tests.rs`:

- `test_nth_dash_episode_basic` — happy path
- `test_nth_dash_episode_all_ordinals` — 1st through 9th
- `test_nth_dash_episode_with_version` — `[4th - 01v2]`
- `test_nth_dash_episode_em_dash` — en-dash separator variant
- `test_nth_dash_episode_ignores_two_digit_ordinals` — anti-FP guardrail
- `test_cjk_cumulative_episode_basic` — happy path
- `test_cjk_cumulative_episode_with_whitespace` — `[总第 100]`
- `test_cjk_cumulative_episode_independent_of_episode` — coexists with no Episode
- `test_212_full_filename_regression` — both exact filenames from #212 pinned

## Quality gates

| Check | Result |
|---|---|
| `cargo test` (lib + integration + doctests) | ✅ all pass |
| `cargo clippy --all-targets` | ✅ clean |
| `cargo fmt --check` | ✅ clean |
| Compatibility corpus (`guessit_regression`) | ✅ **1080/1311 = 82.38%** — no regression |

## Out of scope (residual #212 work)

Two bugs from #212 are deliberately deferred to keep this PR focused:

- **Bug 3:** Path component `tv/` contaminates `source: TV`. Needs source matcher hardening or pipeline token-origin tagging. Estimated 2h.
- **Residual bug 4:** `--context` single-file mode flips to `type: movie` even when `--batch` correctly says `episode`. Needs investigation across the two CLI code paths. Estimated 2-4h.

I'll open follow-up PRs for these once this lands.
