### PR TITLE
fix(#212): drop ancestor-path Source matches when filename has source

### DIFF
--- a/src/pipeline/zone_rules.rs
+++ b/src/pipeline/zone_rules.rs
@@ -66,7 +66,7 @@ pub fn apply_zone_rules(
         initial_count
     );
 
-    // ── source_in_title_context ───────────────────────────────────────
+    // ── source_in_title_context ───────────────────────────────
     // When multiple sources exist, drop the one(s) surrounded by title words.
     // This replaces the fragile "before anchor = title word" heuristic.
     let source_count = matches
@@ -81,6 +81,34 @@ pub fn apply_zone_rules(
             .map(|m| m.start)
             .collect();
         matches.retain(|m| m.property != Property::Source || !drop_positions.contains(&m.start));
+    }
+
+    // ── ancestor_source_yields_to_filename (#212 bug 3) ─────────────
+    // Source matches from ancestor-path segments (e.g. `tv/`, `Blu-ray/`,
+    // `WEB-DL/`) are organisational hints, not authoritative metadata.
+    // When the filename itself carries an explicit source marker (e.g.
+    // `WEB-DL`, `BDRip`, `HDTV`), that match wins and any conflicting
+    // ancestor-path matches are dropped.
+    //
+    // Example: `/Volumes/media/tv/Show.WEB-DL.mkv` previously yielded
+    // `source: ["TV", "Web"]`. After this rule: `source: "Web"`.
+    //
+    // Ancestor-only sources (no filename source) are preserved — e.g.
+    // `/Volumes/Blu-ray/Movie.mkv` still detects `source: "Blu-ray"`.
+    {
+        let has_filename_source = matches
+            .iter()
+            .any(|m| m.property == Property::Source && m.start >= fn_start);
+        if has_filename_source {
+            let before = matches.len();
+            matches.retain(|m| !(m.property == Property::Source && m.start < fn_start));
+            if matches.len() < before {
+                trace!(
+                    "zone rules: dropped {} ancestor-path Source match(es) in favor of filename source",
+                    before - matches.len()
+                );
+            }
+        }
     }
 
     // ── uhd_bluray_promotion ──────────────────────────────────────────

--- a/tests/source_ancestor_path.rs
+++ b/tests/source_ancestor_path.rs
@@ -1,0 +1,121 @@
+//! Regression tests for #212 bug 3: ancestor-path source contamination.
+//!
+//! The Source rule set is registered as `AllSegments` so that legitimate
+//! organisational dirs (`Blu-ray/`, `WEB-DL/`, `HDTV/`) still produce a
+//! source when the filename itself carries no source marker. The risk:
+//! when the filename DOES carry an explicit source (e.g. `WEB-DL`), the
+//! ancestor-path match leaks alongside it and the result becomes a
+//! `["TV", "Web"]` JSON array instead of just `"Web"`.
+//!
+//! The `ancestor_source_yields_to_filename` zone rule (added with this
+//! test) drops ancestor-path Source matches when any filename Source
+//! match exists. These tests pin that contract from both directions:
+//!
+//!   1. The reported bug is fixed (filename source wins, single value).
+//!   2. The previous behaviour is preserved when the filename has no
+//!      source signal (ancestor-only sources are still detected).
+
+use hunch::hunch;
+use serde_json::Value;
+
+/// Helper: how many distinct source values does this result expose?
+/// Returns 0 if no source, 1 for a single-value source, ≥2 for the
+/// `["TV", "Web"]` style array that bug 3 produces.
+fn source_count(r: &hunch::HunchResult) -> usize {
+    match r.to_flat_map().get("source") {
+        Some(Value::String(_)) => 1,
+        Some(Value::Array(arr)) => arr.len(),
+        Some(_) | None => 0,
+    }
+}
+
+// ── Bug 3 reproduction: filename source must dominate ancestor source ──
+
+/// The exact failing case from #212.
+#[test]
+fn issue_212_bug3_tv_ancestor_with_filename_webdl() {
+    let r = hunch(
+        "/Volumes/media/tv/Anime/[\u{665a}\u{8857}\u{4e0e}\u{706f}]\
+         [Re Zero kara Hajimeru Isekai Seikatsu]\
+         [4th - 01][\u{603b}\u{7b2c}67]\
+         [WEB-DL Remux][1080P_AVC_AAC]\
+         [\u{7b80}\u{7e41}\u{65e5}\u{5185}\u{5c01}PGS][V2].mkv",
+    );
+    assert_eq!(
+        r.source(),
+        Some("Web"),
+        "filename WEB-DL should override ancestor /tv/"
+    );
+    assert_eq!(
+        source_count(&r),
+        1,
+        "expected exactly one source value, got JSON: {:?}",
+        r.to_flat_map().get("source")
+    );
+}
+
+#[test]
+fn filename_webdl_overrides_tv_ancestor() {
+    let r = hunch("/media/tv/Show.S01E01.WEB-DL.mkv");
+    assert_eq!(r.source(), Some("Web"));
+    assert_eq!(source_count(&r), 1);
+}
+
+#[test]
+fn filename_bdrip_overrides_tv_ancestor() {
+    let r = hunch("/media/tv/Show.S01E01.BDRip.mkv");
+    assert_eq!(r.source(), Some("Blu-ray"));
+    assert_eq!(source_count(&r), 1);
+}
+
+#[test]
+fn filename_webdl_overrides_hdtv_ancestor() {
+    // Different ancestor source value (HDTV) — filename WEB-DL must still win.
+    let r = hunch("/media/HDTV/Show.S01E01.WEB-DL.mkv");
+    assert_eq!(r.source(), Some("Web"));
+    assert_eq!(source_count(&r), 1);
+}
+
+// ── Anti-regression: ancestor-only sources MUST still be detected ──
+
+#[test]
+fn ancestor_bluray_preserved_when_filename_has_no_source() {
+    // No source marker in filename → ancestor /Blu-ray/ should be the source.
+    let r = hunch("/Volumes/Blu-ray/Some.Movie.2020.mkv");
+    assert_eq!(
+        r.source(),
+        Some("Blu-ray"),
+        "ancestor-only source should still be detected when filename \
+         carries no source marker"
+    );
+    assert_eq!(source_count(&r), 1);
+}
+
+#[test]
+fn ancestor_tv_preserved_when_filename_has_no_source() {
+    let r = hunch("/media/tv/Show.S01E01.mkv");
+    assert_eq!(
+        r.source(),
+        Some("TV"),
+        "ancestor /tv/ should still produce TV source when filename has \
+         no source marker"
+    );
+    assert_eq!(source_count(&r), 1);
+}
+
+#[test]
+fn ancestor_webdl_preserved_when_filename_has_no_source() {
+    let r = hunch("/media/WEB-DL/Movie.2024.mkv");
+    assert_eq!(r.source(), Some("Web"));
+    assert_eq!(source_count(&r), 1);
+}
+
+// ── Filename-internal source dedup is unaffected ──
+
+#[test]
+fn filename_only_no_ancestor_unaffected() {
+    // Pure filename input — no path — should behave identically to before.
+    let r = hunch("Show.S01E01.WEB-DL.1080p.mkv");
+    assert_eq!(r.source(), Some("Web"));
+    assert_eq!(source_count(&r), 1);
+}

--- a/tests/source_ancestor_path.rs
+++ b/tests/source_ancestor_path.rs
@@ -119,3 +119,90 @@ fn filename_only_no_ancestor_unaffected() {
     assert_eq!(r.source(), Some("Web"));
     assert_eq!(source_count(&r), 1);
 }
+
+// ── Full end-to-end regression for #212 ──────────────────────
+
+/// The complete contract from #212: given the original reported absolute
+/// path, hunch must extract every field correctly. This test pins the
+/// interaction between three independent fixes that together close the
+/// issue:
+///
+/// 1. CJK fansub `[Nth - NN]` parsing (this branch's parent commit) —
+///    yields season + episode.
+/// 2. CJK cumulative `[总第NN]` parsing (this branch's parent commit) —
+///    yields absolute_episode.
+/// 3. Ancestor-path source dedup (this commit) — yields a single `Web`
+///    source value instead of `["TV", "Web"]`.
+///
+/// If any of those three regress, this test fails. The earlier per-
+/// concern tests (`test_212_full_filename_regression` for the patterns
+/// in `src/properties/episodes/tests.rs`, and the source-only tests
+/// above) only pin one slice each.
+#[test]
+fn issue_212_full_end_to_end_with_path() {
+    let r = hunch(
+        "/Volumes/media/tv/Anime/[\u{665a}\u{8857}\u{4e0e}\u{706f}]\
+         [Re Zero kara Hajimeru Isekai Seikatsu]\
+         [4th - 01][\u{603b}\u{7b2c}67]\
+         [WEB-DL Remux][1080P_AVC_AAC]\
+         [\u{7b80}\u{7e41}\u{65e5}\u{5185}\u{5c01}PGS][V2].mkv",
+    );
+
+    // Episode parsing (PR #213 territory)
+    assert_eq!(r.season(), Some(4), "season from [4th - 01]");
+    assert_eq!(r.episode(), Some(1), "episode from [4th - 01]");
+    let abs_ep = r
+        .to_flat_map()
+        .get("absolute_episode")
+        .and_then(|v| v.as_i64());
+    assert_eq!(
+        abs_ep,
+        Some(67),
+        "absolute_episode from [\u{603b}\u{7b2c}67]"
+    );
+
+    // Ancestor-path source dedup (PR #214 — this commit)
+    assert_eq!(
+        r.source(),
+        Some("Web"),
+        "single source value, no TV pollution"
+    );
+    assert_eq!(
+        source_count(&r),
+        1,
+        "expected single 'Web' source, not array"
+    );
+
+    // Cascading correctness (type classifier sees season+episode)
+    assert!(r.is_episode(), "type should be episode, not movie");
+
+    // Other fields that should round-trip cleanly
+    assert_eq!(r.title(), Some("Re Zero kara Hajimeru Isekai Seikatsu"));
+    assert_eq!(r.release_group(), Some("\u{665a}\u{8857}\u{4e0e}\u{706f}"));
+    assert_eq!(r.video_codec(), Some("H.264"));
+    assert_eq!(r.audio_codec(), Some("AAC"));
+    assert_eq!(r.screen_size(), Some("1080p"));
+    assert_eq!(r.container(), Some("mkv"));
+}
+
+/// Episode 02 variant (no `[V2]` suffix) — same coverage as above.
+#[test]
+fn issue_212_full_end_to_end_with_path_episode_02() {
+    let r = hunch(
+        "/Volumes/media/tv/Anime/[\u{665a}\u{8857}\u{4e0e}\u{706f}]\
+         [Re Zero kara Hajimeru Isekai Seikatsu]\
+         [4th - 02][\u{603b}\u{7b2c}68]\
+         [WEB-DL Remux][1080P_AVC_AAC]\
+         [\u{7b80}\u{7e41}\u{65e5}\u{5185}\u{5c01}PGS].mkv",
+    );
+    assert_eq!(r.season(), Some(4));
+    assert_eq!(r.episode(), Some(2));
+    let abs_ep = r
+        .to_flat_map()
+        .get("absolute_episode")
+        .and_then(|v| v.as_i64());
+    assert_eq!(abs_ep, Some(68));
+    assert_eq!(r.source(), Some("Web"));
+    assert_eq!(source_count(&r), 1);
+    assert!(r.is_episode());
+}


### PR DESCRIPTION
Replaces #214 (auto-closed by GitHub when its base branch was deleted on #213's squash-merge). Same code, now correctly based on `main` after #213 landed.

Closes the third of four bugs in #212 (bug 3: `tv/` ancestor path contaminates `source` field).

## What

Real-world failing case from #212:

```
/Volumes/media/tv/Anime/[…][Re Zero …][4th - 01][总第67][WEB-DL Remux]…mkv
```

Hunch v1.1.8 produced `"source": ["TV", "Web"]` because the `tv` rule in `rules/source.toml` is registered as `AllSegments` (so `/tv/` directories legitimately produce a source signal when the filename has none) and no zone rule suppressed the ancestor `TV` match when the filename also carried an explicit `WEB-DL` marker.

This PR adds a tiny zone rule that resolves the conflict: **filename source is authoritative; ancestor-path matches yield to it.**

## How

New `ancestor_source_yields_to_filename` rule in `src/pipeline/zone_rules.rs` (~15 lines, pure post-pass, no schema changes):

```rust
let has_filename_source = matches.iter()
    .any(|m| m.property == Property::Source && m.start >= fn_start);
if has_filename_source {
    matches.retain(|m| !(m.property == Property::Source && m.start < fn_start));
}
```

## Why not change `SOURCE_RULES` to `FilenameOnly`?

`SOURCE_RULES` is `AllSegments` for a good reason — directories like `Blu-ray/`, `WEB-DL/`, and `HDTV/` provide real metadata when the filename has none. Switching wholesale would regress those cases. Per-key TOML scoping would require schema changes. Zone-rule approach has the smallest blast radius.

## Verification matrix

| Path | Before | After |
|---|---|---|
| `/tv/Show.WEB-DL.mkv` | `["TV", "Web"]` ❌ | `Web` ✅ |
| `/tv/Show.BDRip.mkv` | `["TV", "Blu-ray"]` ❌ | `Blu-ray` ✅ |
| `/HDTV/Show.WEB-DL.mkv` | `["HDTV", "Web"]` ❌ | `Web` ✅ |
| `/Blu-ray/Movie.mkv` (no filename source) | `Blu-ray` | `Blu-ray` ✅ (preserved) |
| `/tv/Show.mkv` (no filename source) | `TV` | `TV` ✅ (preserved) |
| `Show.WEB-DL.mkv` (no path) | `Web` | `Web` ✅ (unchanged) |

## Tests

10 tests in `tests/source_ancestor_path.rs`:

**Bug 3 reproductions (4):**
- `issue_212_bug3_tv_ancestor_with_filename_webdl` — pins exact bug
- `filename_webdl_overrides_tv_ancestor`
- `filename_bdrip_overrides_tv_ancestor`
- `filename_webdl_overrides_hdtv_ancestor`

**Anti-regression (3):** ancestor-only sources still detected.

**Filename-only baseline (1):** behavior unchanged when no path.

**Full end-to-end on the original bug-report path (2):** `issue_212_full_end_to_end_with_path` + `_episode_02` — exercise BOTH #213's episode patterns AND this PR's source dedup together. Asserts every field from the bug report (season/episode/absolute_episode/source/type/title/release_group/codecs/screen_size/container).

## Quality gates (all green)

| Check | Result |
|---|---|
| `cargo test` (lib + 9 integration + doctests) | ✅ all pass |
| `cargo clippy --all-targets` | ✅ clean |
| `cargo fmt --check` | ✅ clean |
| Compatibility corpus | ✅ **1080/1311 = 82.38%** — no regression |

## End-to-end output verification

With this PR + #213 (already merged), the original bug-report filename produces:

```json
{
  "season": 4, "episode": 1, "absolute_episode": 67,
  "source": "Web", "type": "episode",
  "title": "Re Zero kara Hajimeru Isekai Seikatsu",
  ...
}
```

## Heads-up for reviewers

`Semver Checks` and `cargo bench` will fail for the same status-quo reasons as #213 — accumulated breaking changes since v1.1.8 + rustc 1.94→1.95 codegen drift. Both resolve when v2.0.0 (PR #199) ships.

## Final tally for #212

| Bug | Status |
|---|---|
| #1 `[4th - 01]` | ✅ Fixed in #213 (merged) |
| #2 `[总第67]` | ✅ Fixed in #213 (merged) |
| **#3 `tv/` source contamination** | ✅ **Fixed in this PR** |
| #4 `--context` returns `movie` | ✅ Auto-fixed by #213 (cascading) |

**All 4 bugs from #212 close once this PR merges.** 🎉
