### PR TITLE
fix(#209): skip symlinks in list_media_files for walk_dir parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ Release prep checklist (per #179):
   let an unrelated movie title at the batch root leak into Extras
   subtrees of an adjacent show. (#208)
 
+### Security
+
+- **`list_media_files` now skips symlinks**, mirroring the hardening
+  already applied to `walk_dir_inner` for `--batch -r`. The function
+  backs both `--context` mode and `--batch <dir>` (without `-r`); the
+  previous use of `Path::is_file()` followed symlinks, allowing an
+  attacker who controls files inside the user-chosen directory to inject
+  crafted basenames from outside the directory into the parser. Hunch
+  only reads basenames (not file contents), so the impact was low — but
+  matching `walk_dir`'s defense story keeps both CLI entry points
+  consistent. (#209)
+
 ### Added
 
 - **`HunchResult::is_movie()`, `is_episode()`, `is_extra()` convenience

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,6 +345,16 @@ fn print_result(filename: &str, result: &hunch::HunchResult, json: bool) {
 // ── File listing ────────────────────────────────────────────────────────
 
 /// List media files in a directory (non-recursive).
+///
+/// **Symlink-safe** — uses [`std::fs::DirEntry::file_type`] (which does
+/// NOT follow symlinks) and skips symlinked entries entirely, mirroring
+/// the defense in [`walk_dir_inner`]. Without this guard, `--context`
+/// mode could collect basenames of files outside the user-chosen
+/// directory via a symlink, slightly broadening the parser's input
+/// surface to attacker-controlled bytes. Hunch only reads basenames,
+/// not file contents, so the impact is low — but matching `walk_dir`'s
+/// hardening keeps the defense story consistent across both `--context`
+/// and `--batch -r` entry points. (#209)
 fn list_media_files(dir: &Path) -> Vec<PathBuf> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         eprintln!("Error: cannot read directory {}", dir.display());
@@ -352,8 +362,17 @@ fn list_media_files(dir: &Path) -> Vec<PathBuf> {
     };
     let mut files: Vec<PathBuf> = entries
         .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| p.is_file() && is_media_extension(p))
+        .filter_map(|e| {
+            // Use file_type() (does NOT follow symlinks) instead of
+            // path.is_file() (which DOES). Skip symlinks entirely for
+            // parity with walk_dir_inner.
+            let ft = e.file_type().ok()?;
+            if ft.is_symlink() || !ft.is_file() {
+                return None;
+            }
+            let path = e.path();
+            is_media_extension(&path).then_some(path)
+        })
         .collect();
     files.sort();
     files

--- a/tests/cli_context_symlink_safety.rs
+++ b/tests/cli_context_symlink_safety.rs
@@ -1,0 +1,111 @@
+//! Issue #209 regression: `list_media_files` (the non-recursive directory
+//! listing used by both `--context` mode AND `hunch --batch <dir>` without
+//! `-r`) must skip symlinks for parity with `walk_dir_inner` (used by
+//! `--batch -r`).
+//!
+//! Previously `list_media_files` used `Path::is_file()` which follows
+//! symlinks, allowing an attacker who controls files inside the directory
+//! the user explicitly chose to scan to inject crafted basenames into the
+//! parser via symlinks pointing outside the directory. Hunch only reads
+//! basenames (not file contents), so the impact was low — but matching
+//! `walk_dir`'s hardening keeps the defense story consistent across both
+//! CLI entry points.
+//!
+//! Symlink creation requires elevated privileges on Windows
+//! (`SeCreateSymbolicLinkPrivilege`); this test is therefore `#[cfg(unix)]`,
+//! mirroring the convention in `cli_walk_dir_safety.rs`.
+
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use std::fs;
+use std::os::unix::fs::symlink;
+use tempfile::TempDir;
+
+/// We exercise `list_media_files` through `--batch <dir>` (without `-r`)
+/// because that path produces a deterministic one-output-line-per-file
+/// signal we can count, making "was the symlink processed?" a sharp test.
+/// `--context` mode uses the same function but funnels the result through
+/// invariance (which needs same-name siblings to surface anything visible)
+/// so observable behavior would be muddier there.
+#[test]
+fn issue_209_batch_flat_skips_symlinks() {
+    let tmp = TempDir::new().expect("temp dir");
+    let outside = tmp.path().join("outside");
+    let scan = tmp.path().join("scan");
+    fs::create_dir_all(&outside).unwrap();
+    fs::create_dir_all(&scan).unwrap();
+
+    // Bait file lives outside the scan directory entirely — without the
+    // symlink-skip guard, its basename would be injected into the parser
+    // input despite the user never choosing it.
+    let bait = outside.join("bait.Movie.2024.1080p.mkv");
+    fs::write(&bait, b"").unwrap();
+
+    // One real file in the scan directory.
+    fs::write(scan.join("Show.S01E01.mkv"), b"").unwrap();
+
+    // Symlink injecting an attacker-controlled basename into the scan dir.
+    symlink(&bait, scan.join("linked.Other.S99E99.mkv")).expect("symlink");
+
+    let output = Command::cargo_bin("hunch")
+        .expect("hunch binary")
+        .args(["--batch", scan.to_str().unwrap(), "-j"])
+        .output()
+        .expect("hunch ran");
+    assert!(
+        output.status.success(),
+        "hunch failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| l.contains("_filename")).collect();
+
+    // With the fix: exactly 1 result (Show.S01E01), the symlink is skipped.
+    // Without the fix: 2 results (Show + the symlink-injected bait basename).
+    assert_eq!(
+        lines.len(),
+        1,
+        "expected exactly 1 file (the real one); the symlink should be \
+         skipped. Got {} lines:\n{stdout}",
+        lines.len(),
+    );
+    assert!(
+        lines[0].contains("Show.S01E01.mkv"),
+        "the surviving file should be Show.S01E01.mkv, got: {}",
+        lines[0],
+    );
+
+    // Belt-and-suspenders: the symlink's basename must not appear anywhere
+    // in stdout. Catches any future code path that might surface it
+    // through siblings/context even if the file count check passed.
+    assert!(
+        !stdout.contains("linked.Other.S99E99.mkv"),
+        "symlinked entry should be invisible. Got: {stdout}",
+    );
+}
+
+/// Companion check: real (non-symlink) files in the same directory still
+/// ARE seen by `--batch`. Guards against an over-broad fix that
+/// accidentally drops legitimate files.
+#[test]
+fn issue_209_batch_flat_still_sees_real_files() {
+    let tmp = TempDir::new().expect("temp dir");
+    let scan = tmp.path();
+
+    fs::write(scan.join("Show.S01E01.mkv"), b"").unwrap();
+    fs::write(scan.join("Show.S01E02.mkv"), b"").unwrap();
+    fs::write(scan.join("Show.S01E03.mkv"), b"").unwrap();
+
+    let output = Command::cargo_bin("hunch")
+        .expect("hunch binary")
+        .args(["--batch", scan.to_str().unwrap(), "-j"])
+        .output()
+        .expect("hunch ran");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let count = stdout.lines().filter(|l| l.contains("_filename")).count();
+    assert_eq!(count, 3, "expected 3 real files. Got:\n{stdout}");
+}


### PR DESCRIPTION
# 🔒 Fix #209: skip symlinks in --context mode for walk_dir parity

## The bug

`list_media_files` (the function backing both `--context` mode and `hunch --batch <dir>` without `-r`) used `Path::is_file()`, which **follows symlinks**. Meanwhile `walk_dir_inner` (used by `--batch -r`) already used `DirEntry::file_type()` which does NOT follow them. Inconsistent defense story.

**Severity: low.** Hunch never opens file bytes — only basenames are read. Worst case an attacker who controls files inside the directory the user *explicitly chose to scan* could inject crafted basenames from elsewhere into the parser, influencing title/season/episode detection. Not arbitrary file read.

But the discrepancy with `walk_dir`'s already-hardened path is a real wart, and a 23-line fix kills it cleanly before v2.0.0 ships.

## The fix

```diff
 fn list_media_files(dir: &Path) -> Vec<PathBuf> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         eprintln!("Error: cannot read directory {}", dir.display());
         std::process::exit(1);
     };
     let mut files: Vec<PathBuf> = entries
         .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| p.is_file() && is_media_extension(p))
+        .filter_map(|e| {
+            // Use file_type() (does NOT follow symlinks) instead of
+            // path.is_file() (which DOES). Skip symlinks entirely for
+            // parity with walk_dir_inner.
+            let ft = e.file_type().ok()?;
+            if ft.is_symlink() || !ft.is_file() {
+                return None;
+            }
+            let path = e.path();
+            is_media_extension(&path).then_some(path)
+        })
         .collect();
     files.sort();
     files
 }
```

Plus an upgraded doc comment explaining the symlink-safety guarantee with a backreference to `walk_dir` (DRY on the rationale, not the code — the surrounding control flow differs enough that a shared helper would feel forced for just two callers per YAGNI).

`list_media_files_recursive` needed no change — it already delegates to `walk_dir`.

## Tests (`tests/cli_context_symlink_safety.rs`, `#[cfg(unix)]`)

| Test | What it proves |
|---|---|
| `issue_209_batch_flat_skips_symlinks` | Verbatim attack scenario. **FAILED before the fix** with literal output `"_filename":"linked.Other.S99E99.mkv","title":"linked Other","season":99,"episode":99` — the attacker-controlled basename WAS being injected. PASSES after. |
| `issue_209_batch_flat_still_sees_real_files` | Companion check that the fix doesn't accidentally drop legitimate files. |

### Why test through `--batch` flat instead of `--context`?

Both paths exercise `list_media_files`, but `--batch` flat produces a **deterministic one-result-per-file output** we can count, making "was the symlink processed?" a sharp boolean test. `--context` mode funnels results through invariance, which needs same-titled siblings to surface visible behavior — would muddy the signal.

## Diff

```
 CHANGELOG.md                        |  12 ++++
 src/main.rs                         |  23 +++++++-
 tests/cli_context_symlink_safety.rs | 111 ++++++++++++++++++++++++++++++++++++
 3 files changed, 144 insertions(+), 2 deletions(-)
```

## Pre-flight

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] All 612+ existing tests pass (zero regressions)
- [x] New test FAILS on pre-fix code (validated via stash + re-run; output literally showed the injected basename)
- [x] Symlink test gated `#[cfg(unix)]` matching `cli_walk_dir_safety.rs` precedent (Windows symlink creation requires elevated privileges)

Closes #209 — slated for v2.0.0.
