### PR TITLE
docs: slim README, extract Known Limitations to user-guide page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,15 @@
 
 [![Coverage](https://img.shields.io/badge/coverage-94.34%25-brightgreen)](https://lijunzh.github.io/hunch/contributor-guide/coverage.html)
 
-**A fast, offline media filename parser for Rust — extract title, year, season,
-episode, codec, language, and 49 properties from messy filenames.**
+**A fast, offline media filename parser for Rust — extract title, year,
+season, episode, codec, language, and 49 properties from messy filenames.**
 
-Hunch is a Rust rewrite of Python's [guessit](https://github.com/guessit-io/guessit).
+A Rust rewrite of Python's [guessit](https://github.com/guessit-io/guessit).
 Pure, deterministic, single-binary, linear-time regex only (ReDoS-immune).
 
 ## Quick Start
 
 ```bash
-# Install
 brew install lijunzh/hunch/hunch   # macOS/Linux
 cargo install hunch                 # from source
 cargo binstall hunch                # pre-built binary
@@ -34,133 +33,46 @@ $ hunch "The.Walking.Dead.S05E03.720p.BluRay.x264-DEMAND.mkv"
 }
 ```
 
+For batch parsing across a media library and cross-file context for
+ambiguous CJK / anime filenames, see the
+[User Manual](https://lijunzh.github.io/hunch/user-guide/user-manual.html).
+
 ### Library
 
 ```rust
 use hunch::hunch;
 
-fn main() {
-    let result = hunch("The.Walking.Dead.S05E03.720p.BluRay.x264-DEMAND.mkv");
-    assert_eq!(result.title(), Some("The Walking Dead"));
-    assert_eq!(result.season(), Some(5));
-    assert_eq!(result.episode(), Some(3));
-}
+let result = hunch("The.Walking.Dead.S05E03.720p.BluRay.x264-DEMAND.mkv");
+assert_eq!(result.title(), Some("The Walking Dead"));
+assert_eq!(result.season(), Some(5));
+assert_eq!(result.episode(), Some(3));
 ```
-
-### Cross-file context
-
-For CJK, anime, or ambiguous filenames, hunch uses sibling files and
-directory names as context for better title extraction and type detection.
-
-```bash
-# Single file with sibling context:
-hunch --context ./Season1/ "(BD)十二国記 第13話(1440x1080 x264-10bpp flac).mkv"
-
-# Batch-parse a single directory:
-hunch --batch ./Season1/ --json
-
-# Batch-parse an entire media library (recommended):
-hunch --batch /path/to/tv/ -r -j
-```
-
-> **💡 Tip:** Always use `--batch -r` from your library root (e.g., `tv/`,
-> `movies/`) rather than running `--batch` on each leaf directory individually.
-> The `-r` flag preserves full relative paths like
-> `tv/Anime/Show/Extra/Menu.mkv`, giving the parser critical context from
-> directory names (`tv/`, `Anime/`, `Season 1/`) for accurate type detection.
-> Without `-r`, files in deep subdirectories lose their path context and
-> bonus content (SP, OVA, NCED) may be misclassified.
 
 ## Documentation
 
 📖 **Full documentation site:** <https://lijunzh.github.io/hunch>
 
-| Document | Audience | Content |
-|---|---|---|
-| [**User Manual**](https://lijunzh.github.io/hunch/user-guide/user-manual.html) | Users | Install, CLI, library API, all 49 properties, FAQ |
-| [**Design**](DESIGN.md) | Contributors | Principles, architecture, key decisions |
-| [**Compatibility**](https://lijunzh.github.io/hunch/user-guide/compatibility.html) | Everyone | guessit test suite pass rates by property |
-| [**Benchmark Dashboard**](https://lijunzh.github.io/hunch/reference/benchmark-dashboard.html) | Maintainers | Live perf trends per commit |
-| [**API Reference**](https://docs.rs/hunch) | Developers | Full Rust API docs |
-| [**Changelog**](CHANGELOG.md) | Everyone | Version history |
+| Document | What's there |
+|---|---|
+| [**User Manual**](https://lijunzh.github.io/hunch/user-guide/user-manual.html) | Install, CLI, library API, all 49 properties, batch parsing, cross-file context |
+| [**guessit Compatibility**](https://lijunzh.github.io/hunch/user-guide/compatibility.html) | Pass rates per property, methodology |
+| [**Known Limitations**](https://lijunzh.github.io/hunch/user-guide/known-limitations.html) | Edge cases that remain difficult to handle |
+| [**Migrating to v2.0.0**](https://lijunzh.github.io/hunch/about/migration-v2.html) | Breaking-change guide |
+| [**Design**](https://lijunzh.github.io/hunch/about/design.html) | Principles, architecture, key decisions |
+| [**API Reference**](https://docs.rs/hunch) | Full Rust API docs |
+| [**Changelog**](CHANGELOG.md) | Version history |
 
-## guessit Compatibility
+## Real-world accuracy
 
-All 49 guessit properties implemented. Validated against guessit's
-upstream test suite — see [the compatibility
-report](https://lijunzh.github.io/hunch/user-guide/compatibility.html)
-for the live pass rate, per-property breakdowns, and the methodology
-behind the numbers. (Single source of truth: that page is regenerated
-from `cargo test -- --ignored guessit_compat` so it can't drift.)
-
-## Known Limitations
+Validated against guessit's upstream test suite — see the
+[compatibility report](https://lijunzh.github.io/hunch/user-guide/compatibility.html)
+for the live pass rate, regenerated from
+`cargo test -- --ignored guessit_compat` so it can't drift.
 
 In one real-world library audit of 7,838 files, hunch achieved **99.8%
-accuracy** across a mixed Anime / English / Japanese / Kids collection. The
-remaining failures fall into a small number of edge-case categories that are
-difficult to solve reliably with a deterministic, offline filename parser.
-
-These examples illustrate the main categories of remaining failures rather than
-an exhaustive list of every individual filename.
-
-### Bonus content without episode numbers
-
-Files in bonus directories such as `Bonus/` or `特典映像/` that contain no
-numeric episode marker may still be classified as `episode` with no episode
-number. Hunch recognizes these directory names for title cleanup but does not
-currently infer `type=extra` from directory names alone.
-
-```
-tv/Anime/.../特典映像/[DBD-Raws][Natsume Yuujinchou Shichi][声優トークショー][1080P][BDRip][HEVC-10bit][FLAC].mkv
-  → type=episode, episode=None  (expected: type=extra)
-
-tv/English/Power Rangers/17 - Power Rangers RPM/Bonus/Power Rangers RPM - Stuntman Behind The Scenes (Japanese).mp4
-  → type=episode, episode=None  (expected: type=extra)
-```
-
-**Why this remains difficult:** directory names are useful context, but using
-them alone to infer `type=extra` would require an open-ended set of
-library-specific rules (`Extras/`, `Featurettes/`, `Behind the Scenes/`,
-`Making Of/`, etc.), increasing regression risk across other collections.
-
-### Sample / preview clips
-
-Verification clips such as `Sample1.mkv` inside `Samples/` directories may have
-their digits interpreted as episode numbers.
-
-```
-movie/.../Samples/Sample1.mkv
-  → type=episode, episode=1  (expected: not real media content)
-```
-
-**Why this is low priority:** sample files are typically release artifacts
-rather than meaningful library entries. Reliable detection would require
-special-casing many filename and directory conventions that vary across release
-groups.
-
-### Ambiguous special / episode cross-references
-
-Some filenames contain both special markers (`SP`) and episode markers (`EP`),
-where the episode number refers to a related TV episode rather than the file
-itself.
-
-```
-movie/.../[Detective Conan][Tokuten BD][SP02][TV Series EP1080][BDRIP][1080P][H264_FLAC].mkv
-  → type=episode, episode=1080  (EP1080 is a cross-reference, not this file's episode)
-```
-
-**Why this remains difficult:** distinguishing "this file is episode 1080" from
-"this file references episode 1080" requires semantic understanding beyond
-hunch's current deterministic filename heuristics.
-
-### Malformed filenames
-
-Genuinely malformed inputs such as `1.The.mkv.mkv` can still produce poor
-results.
-
-**Why this is not prioritized:** hunch assumes filenames contain at least some
-recoverable structure. Severely malformed input is treated as garbage-in,
-garbage-out.
+accuracy** across a mixed Anime / English / Japanese / Kids collection.
+The remaining edge cases are documented under
+[Known Limitations](https://lijunzh.github.io/hunch/user-guide/known-limitations.html).
 
 ## Contributing
 
@@ -170,7 +82,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). The easiest contribution is
 ```bash
 cargo test              # full suite
 cargo test -- --ignored # guessit compatibility report
-cargo bench             # benchmarks
 ```
 
 ## License

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
 
 - [User Manual](./user-guide/user-manual.md)
 - [guessit Compatibility](./user-guide/compatibility.md)
+- [Known Limitations](./user-guide/known-limitations.md)
 
 # Reference
 

--- a/docs/src/user-guide/known-limitations.md
+++ b/docs/src/user-guide/known-limitations.md
@@ -1,0 +1,71 @@
+# Known Limitations
+
+In one real-world library audit of 7,838 files, hunch achieved **99.8%
+accuracy** across a mixed Anime / English / Japanese / Kids collection.
+The remaining failures fall into a small number of edge-case categories
+that are difficult to solve reliably with a deterministic, offline
+filename parser.
+
+These examples illustrate the main categories of remaining failures
+rather than an exhaustive list of every individual filename.
+
+## Bonus content without episode numbers
+
+Files in bonus directories such as `Bonus/` or `特典映像/` that contain
+no numeric episode marker may still be classified as `episode` with no
+episode number. Hunch recognizes these directory names for title
+cleanup but does not currently infer `type=extra` from directory names
+alone.
+
+```text
+tv/Anime/.../特典映像/[DBD-Raws][Natsume Yuujinchou Shichi][声優トークショー][1080P][BDRip][HEVC-10bit][FLAC].mkv
+  → type=episode, episode=None  (expected: type=extra)
+
+tv/English/Power Rangers/17 - Power Rangers RPM/Bonus/Power Rangers RPM - Stuntman Behind The Scenes (Japanese).mp4
+  → type=episode, episode=None  (expected: type=extra)
+```
+
+**Why this remains difficult:** directory names are useful context, but
+using them alone to infer `type=extra` would require an open-ended set
+of library-specific rules (`Extras/`, `Featurettes/`, `Behind the Scenes/`,
+`Making Of/`, etc.), increasing regression risk across other
+collections.
+
+## Sample / preview clips
+
+Verification clips such as `Sample1.mkv` inside `Samples/` directories
+may have their digits interpreted as episode numbers.
+
+```text
+movie/.../Samples/Sample1.mkv
+  → type=episode, episode=1  (expected: not real media content)
+```
+
+**Why this is low priority:** sample files are typically release
+artifacts rather than meaningful library entries. Reliable detection
+would require special-casing many filename and directory conventions
+that vary across release groups.
+
+## Ambiguous special / episode cross-references
+
+Some filenames contain both special markers (`SP`) and episode markers
+(`EP`), where the episode number refers to a related TV episode rather
+than the file itself.
+
+```text
+movie/.../[Detective Conan][Tokuten BD][SP02][TV Series EP1080][BDRIP][1080P][H264_FLAC].mkv
+  → type=episode, episode=1080  (EP1080 is a cross-reference, not this file's episode)
+```
+
+**Why this remains difficult:** distinguishing "this file is episode
+1080" from "this file references episode 1080" requires semantic
+understanding beyond hunch's current deterministic filename heuristics.
+
+## Malformed filenames
+
+Genuinely malformed inputs such as `1.The.mkv.mkv` can still produce
+poor results.
+
+**Why this is not prioritized:** hunch assumes filenames contain at
+least some recoverable structure. Severely malformed input is treated
+as garbage-in, garbage-out.


### PR DESCRIPTION
# 📝 Slim README, extract Known Limitations to user-guide page

The README ballooned to 178 lines because it was trying to be the canonical home for everything: install, CLI, library, batch tips, full docs index, accuracy report, and ~60 lines of edge-case essays under Known Limitations. Now that we have `docs/src/` as the canonical mdbook home for everything beyond "what is this and how do I use it in 30 seconds", the README can be a true landing page.

## Diff: README **178 → 89 lines (-50%)**

| File | Change |
|---|---|
| `README.md` | -145 / +28 — see breakdown below |
| `docs/src/user-guide/known-limitations.md` | **+71 (NEW)** — verbatim move from README |
| `docs/src/SUMMARY.md` | +1 — add Known Limitations to User Guide |

## What was cut from README

| Section | Lines | Where it lives now |
|---|---|---|
| Verbose `💡 Tip` callout on `--batch -r` | 12 | One-line pointer to [User Manual](https://lijunzh.github.io/hunch/user-guide/user-manual.html) |
| 4 "Known Limitations" subsections (Bonus content, Sample clips, Ambiguous SP/EP, Malformed) | ~60 | New mdbook page: [Known Limitations](https://lijunzh.github.io/hunch/user-guide/known-limitations.html) |
| `cargo bench` line in Contributing | 2 | Deleted — bench harness gone in #222 |
| Benchmark Dashboard row in docs table | 1 | Deleted — page gone in #222 |

## What was added to README

- **Migration to v2.0.0** row in docs table
- **Known Limitations** row in docs table (linking to the new page)
- Documentation table reworded `Audience` → `What's there` for clarity

## Why this split is right

Per the Zen of Python, "beautiful is better than ugly." A ~80-line README that fits on one screen is more inviting than a 178-line wall of edge-case prose. The README's job is to convince a visitor in 30 seconds that hunch is worth their `cargo add`. The mdbook is where they go once they're sold and need the nuance.

## Verification

- [x] `mdbook build` clean (new page renders, SUMMARY.md link resolves)
- [x] `cargo test --lib` clean (348 tests pass; README isn't compiled)
- [x] All external doc links in the trimmed Documentation table point at pages that exist in the deployed mdbook

## Wave summary

Final PR of the pre-v2.0.0 hygiene wave:

| PR | Action |
|---|---|
| #222 ✅ merged | dropped `benches/` + `fuzz/` + dependent doc pages |
| #223 (auto-merge) | moved `rules/` → `src/rules/` for compile-time co-location |
| **This PR** | slims README, extracts Known Limitations to user-guide |

After this lands, the repo is ready for the v2.0.0 release tagging.
