### PR TITLE
release: v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Release prep checklist:
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-04-20
+
 ### Removed
 
 - **`benches/` directory and the `cargo bench` harness.** The Criterion
@@ -31,7 +33,17 @@ Release prep checklist:
   workflow was deleted in #217; manual contributor fuzzing isn't being
   done in practice. The library is small and deterministic enough that
   the existing 612-test integration suite is the right testing layer
-  for our scale. (#218 follow-up)
+  for our scale. (#218 follow-up, #222)
+- **CI workflow over-engineering.** The `coverage` (cargo-llvm-cov),
+  `api-surface` (cargo-public-api drift gate), and `mutants` (nightly
+  cargo-mutants) jobs were all dropped in #216 alongside the entire
+  `mutants.yml` workflow. The `benchmark.yml` and `fuzz.yml` workflows
+  were dropped in #217. Rationale: a single-author hobby crate does not
+  need 7 quality-gate workflows running on every PR. The four jobs that
+  matter — `fmt`, `clippy`, `test` (Linux/macOS/Windows), `audit` —
+  remain. The `semver` advisory job also survives. The mutation-test
+  work that landed in #180–#185 left permanent regression coverage in
+  `tests/`, so that quality investment outlives the workflow.
 
 ### Changed
 
@@ -43,7 +55,31 @@ Release prep checklist:
   remaining accessors return `Option<T>` / `Vec<T>` which are already
   `#[must_use]` in std — no need to repeat. (#205, bundled in #218)
 
+### Refactored
+
+- **Moved `rules/` to `src/rules/` for compile-time co-location.** The
+  21 TOML data files are embedded into the binary at compile time via
+  `include_str!` from `pipeline/rule_registry.rs` — they're not
+  external configuration, not user-tunable at runtime, and have no
+  purpose outside this crate. Top-level `rules/` was misleading
+  (reading as nginx-style runtime config when it's actually frozen
+  Rust data). The `../../rules/X.toml` paths in `rule_registry.rs`
+  were the universal "this should be local" code smell pointing here.
+  Pure restructure: zero behavior change, all 21 `include_str!` paths
+  + 17 doc-comment refs updated, file history preserved via `git mv`.
+  (#223)
+
 ### Docs
+
+- **Slimmed `README.md` from 178 → 89 lines (-50%).** Now that we
+  have a proper mdbook at <https://lijunzh.github.io/hunch>, the
+  README can stop trying to be canonical for everything. The verbose
+  `--batch -r` tip and the four "Known Limitations" subsections
+  (~60 lines of edge-case essays) moved to the new
+  `docs/src/user-guide/known-limitations.md` mdbook page; the README
+  links to it. Documentation table tightened: dropped dead bench
+  dashboard row (page deleted), added Migration Guide + Known
+  Limitations rows. (#224)
 
 - **New `docs/src/about/migration-v2.md` page** consolidating the v2.0.0
   breaking changes (`Property::BitRate` removal + deep-import deprecation)
@@ -74,6 +110,15 @@ Release prep checklist:
   common `extras/extra/specials/bonus`. In `--batch -r` mode, that gap
   let an unrelated movie title at the batch root leak into Extras
   subtrees of an adjacent show. (#208)
+- **CJK fansub patterns `[Nth - NN]` and `[总第NN]` are now parsed as
+  episode markers** instead of being absorbed into the title. Catches
+  real-world filenames from the Re:Zero / 12 Kingdoms / similar fansub
+  release groups. (#212, #213)
+- **Ancestor-path `Source` matches are dropped when the filename itself
+  carries a Source token.** Prevents directory-level source hints (e.g.
+  `BluRay/Show.S01E01.WEB-DL.mkv` resolving to `BluRay`) from
+  overriding the more specific filename-level signal in `--batch -r`
+  mode. (#212, #215)
 
 ### Security
 
@@ -214,26 +259,14 @@ Release prep checklist:
 
 ### Internal / Infrastructure
 
-This release lands a substantial CI and documentation investment
-motivated by the project moving from "experimental, no users" to
-"users filing real bug reports." None of the items below change
-parser behavior, but they meaningfully improve the project's
-ability to catch regressions before they ship:
+This release lands a substantial documentation investment motivated by
+the project moving from "experimental, no users" to "users filing real
+bug reports." None of the items below change parser behavior, but they
+meaningfully improve the project's ability to catch regressions before
+they ship.
 
-- **Code coverage tracking** via `cargo-llvm-cov` (advisory). (#145, #168)
-- **Mutation testing baseline** via `cargo-mutants` nightly, with
-  29 surviving mutants triaged and killed across
-  #175, #180, #181, #182, #183, #184, #185. (#146, #169, #170, #173)
-- **Fuzz baseline** via `cargo-fuzz` with two targets (single-string
-  parse + multi-segment path) and nightly CI. (#147, #174)
-- **Public API surface tripwire** that fails CI on accidental changes
-  to `pub use src/lib.rs` items. (#144, #171)
-- **Continuous benchmarking** via `criterion` + `github-action-benchmark`,
-  with PR-time regression gating (>120% threshold), per-commit history
-  on a live dashboard, and per-release immutable snapshots. See the
-  [Benchmarks reference](https://lijunzh.github.io/hunch/reference/benchmarks.html)
-  and [Release Trajectory](https://lijunzh.github.io/hunch/reference/release-trajectory.html).
-  (#148, #176, #177, #178, #179, #186, #189, #191, #192, #194)
+**What survived to v2.0.0:**
+
 - **Documentation portal** at <https://lijunzh.github.io/hunch/>
   built with mdbook. (#188, #190)
 - **Release pipeline hardening** — PR-time CI now also runs on release
@@ -242,6 +275,23 @@ ability to catch regressions before they ship:
   `TitleStrategy` fallback ordering (#154, #161), `cli_walk_dir`
   safety boundaries (#153, #162), parse-torrent-name corpus pins
   (#157, #164).
+- **Mutation-killing test additions** from the cargo-mutants triage
+  pass survive as permanent regression coverage in `tests/` even though
+  the nightly `mutants.yml` workflow itself was dropped: 29 mutants
+  killed across #175, #180, #181, #182, #183, #184, #185.
+
+**What was added during the cycle and then rolled back (see Removed):**
+
+The CI infrastructure burst between v1.1.x and v2.0.0 — cargo-llvm-cov
+coverage tracking (#145, #168), nightly cargo-mutants (#146, #169, #170,
+#173), cargo-fuzz (#147, #174), continuous benchmarking via criterion +
+github-action-benchmark (#148, #176, #177, #178, #179, #186, #189, #191,
+#192, #194), and the cargo-public-api surface tripwire (#144, #171) —
+all got built and then trimmed in #216, #217, #222 once we acknowledged
+this is a single-developer hobby crate. The investment paid for itself
+in permanent test additions (above) and in the public API audit it
+drove (#197), but the workflows themselves were over-engineered for the
+project's actual scale.
 
 ## [1.1.8] - 2026-04-17
 
@@ -1029,6 +1079,7 @@ source, audio_codec, screen_size, audio_channels, date.
 
 color_depth, streaming_service, bonus, episode_details, film.
 
+[2.0.0]: https://github.com/lijunzh/hunch/releases/tag/v2.0.0
 [1.1.8]: https://github.com/lijunzh/hunch/releases/tag/v1.1.8
 [1.1.7]: https://github.com/lijunzh/hunch/releases/tag/v1.1.7
 [1.1.6]: https://github.com/lijunzh/hunch/releases/tag/v1.1.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hunch"
-version = "1.1.8"
+version = "2.0.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hunch"
-version = "1.1.8"
+version = "2.0.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Lijun Zhu"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,12 +20,16 @@ and symlink-skipping. See the rustdoc on
 ## Supported Versions
 
 Security fixes are applied to the **latest minor release** on the
-`1.x` line. Older minor releases are not patched — please upgrade.
+`2.x` line. Older minor releases (including the `1.x` line) are not
+patched — please upgrade to `2.x`. See the
+[v2.0.0 migration guide](https://lijunzh.github.io/hunch/about/migration-v2.html)
+for breaking changes.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.1.x   | :white_check_mark: |
-| < 1.1   | :x:                |
+| 2.0.x   | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/src/contributor-guide/coverage.md
+++ b/docs/src/contributor-guide/coverage.md
@@ -1,8 +1,12 @@
 # Code Coverage
 
 Hunch tracks line, function, and region coverage via [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov).
-The CI `Coverage` job runs on every PR and uploads an LCOV report as a build
-artifact (`coverage-report`).
+Run locally during release prep or when working on test-quality
+improvements.
+
+> The dedicated CI `Coverage` job that previously ran on every PR
+> was removed in #216 as part of trimming over-engineered CI for a
+> hobby-scale crate. The tooling and the local workflow are unchanged.
 
 ## Current baseline
 
@@ -67,26 +71,15 @@ cargo llvm-cov --workspace --lcov --output-path lcov.info
 
 ## Roadmap
 
-This document captures the **first slice** of the [Code coverage CI epic
-(#145)](https://github.com/lijunzh/hunch/issues/145). Deferred to follow-up PRs:
+Long-term ideas, not actively planned post-#216:
 
-- **PR-time regression gate**: fail CI if total line coverage drops more than
-  ~0.5% below this baseline. Deferred until the baseline has settled across a
-  few merges (otherwise we'd be tuning the noise threshold against a moving
-  target).
-- **Codecov.io / Coveralls integration**: the LCOV artifact is already in the
-  right shape; just needs the upload step + a token. Optional per the epic.
-- **Per-file delta comments on PRs**: shows which newly-added lines aren't
-  covered. Most useful with codecov.io's PR comment integration.
-- **Branch coverage**: `cargo-llvm-cov` reports it but the issue scopes the
-  initial work to line coverage.
+- **Codecov.io / Coveralls integration** — the LCOV file is in the
+  right shape if anyone wants to wire it up. Local-only for now.
+- **Branch coverage** — `cargo-llvm-cov` reports it; the line-coverage
+  baseline above is the project's primary signal.
 
 ## Notes
 
-- **Why single-OS**: line/region coverage of pure-Rust code is platform-agnostic.
-  Running coverage on the cross-OS matrix would triple CI time for zero
-  additional signal. Platform-conditional branches (`cfg(unix)` symlink tests,
-  Windows path code) are still exercised by the cross-OS `test` matrix.
 - **Why not 100%**: parser code intentionally has permissive fallback branches
   (e.g., "we couldn't decide, return the empty result") that aren't worth
   contorting tests to hit. ≥ 94% is the realistic ceiling for this codebase.

--- a/docs/src/contributor-guide/mutation-baseline.md
+++ b/docs/src/contributor-guide/mutation-baseline.md
@@ -13,19 +13,18 @@ assertions**.
 
 ## How it runs
 
-A nightly GitHub Actions workflow ([`.github/workflows/mutants.yml`](https://github.com/lijunzh/hunch/blob/main/.github/workflows/mutants.yml))
-runs `cargo mutants` against the highest-value targets at 03:14 UTC and
-publishes results as a Job Summary + downloadable `mutants-out` artifact.
+Run `cargo mutants` locally during test-quality work or when adding
+fixtures around a tricky function. The mutation-killing PRs landed
+during the v1.1.x → v2.0.0 cycle (#180–#185) used this exact loop.
 
-The job is **advisory** — surviving mutants do not fail CI. They get
-triaged here and addressed in follow-up PRs. Tool-level failures
-(usage errors, build broken, crash) DO fail the job, via an explicit
-exit-code allowlist (0–3 = expected) added in #170 after the original
-`|| true` masked an `--in-place`/`--jobs` incompatibility for an
-entire run.
+> The nightly `mutants.yml` workflow that previously ran on a schedule
+> was removed in #216 along with the rest of the over-engineered CI for
+> a hobby-scale crate. The tooling and the local workflow are unchanged;
+> the surviving-mutants triage in this doc still applies when you run
+> `cargo mutants` locally.
 
-You can also trigger it on demand from the Actions UI via
-**Run workflow** → **Mutation Tests**.
+You can still capture results in the same shape the old job produced —
+see [Local usage](#local-usage) below.
 
 ## First nightly run results (2026-04-18)
 
@@ -106,19 +105,14 @@ Combined run with `--jobs 4` on a GitHub-hosted ubuntu runner: **~12–15 min**.
 
 ## Roadmap
 
-Sequenced expansion (each is its own PR within the #146 epic):
+Long-term ideas, not actively planned post-#216:
 
-1. **Add the `Pipeline` neighbours**: `pipeline/context.rs`, `pipeline/invariance.rs`,
-   `pipeline/mod.rs`'s sibling helpers.
-2. **Add the `properties/title/` strategies**: `secondary.rs`, `mod.rs`,
-   the four `strategies/*.rs` modules.
-3. **Add the matcher core**: `src/matcher/`, `src/zone_map.rs`, `src/tokenizer.rs`.
-4. **Opt-in PR-time check**: a `mutation-test` label triggers a diff-only
-   mutants run on the PR (cheap subset). Requires #146's epic-level decision
-   on labelling.
-5. **Hard kill-rate gate**: fail the nightly if kill rate drops more than
-   N% below baseline. Deferred until baseline has settled across enough
-   nightly runs to characterise noise.
+- **Re-enable a nightly workflow** if the project ever grows past
+  hobby-scale (multi-developer, downstream library users filing
+  regression-class bugs). The triage protocol below is the workflow.
+- **Hard kill-rate gate** — only meaningful with a recurring run.
+- **Diff-only PR check** — useful with a CI cadence; manual on demand
+  for now.
 
 ## Local usage
 
@@ -206,14 +200,13 @@ the *infrastructure* to find findings; fixing them is the next loop.
 
 ## Triage protocol
 
-When the nightly job posts a Job Summary with surviving mutants:
+When a local `cargo mutants` run produces surviving mutants:
 
 1. **Equivalent mutation?** (the mutation produces identical observable
    behaviour) → add a one-line entry to the "Accepted equivalents" table
    below with the mutation string + a one-sentence rationale.
 2. **Real test gap?** → file a `tech-debt` issue with the mutation string
-   in the title, link the surviving-mutants table from the most recent
-   nightly run, and assign to the next coverage-improvement loop.
+   in the title, or fix it directly in the same PR if scope allows.
 3. **Tool bug / unviable mis-classification?** → file upstream at
    <https://github.com/sourcefrog/cargo-mutants>.
 

--- a/docs/src/reference/public-api.md
+++ b/docs/src/reference/public-api.md
@@ -10,77 +10,46 @@ Two complementary tools watch this contract:
 - **`cargo-semver-checks`** (in [`ci.yml`](https://github.com/lijunzh/hunch/blob/main/.github/workflows/ci.yml))
   — compares the PR head's API against the latest release on crates.io.
   Catches *semantic* SemVer breaks (signature changes, trait-bound
-  tightening, etc.). Advisory pre-1.0; will become a release-prep gate.
-- **`cargo-public-api`** (this doc + the `Public API Surface` CI job)
-  — produces a flat text inventory of every `pub` item. Diffed against
-  the committed snapshot in [`public-api.txt`](https://github.com/lijunzh/hunch/blob/main/docs/src/reference/public-api.txt) on every
-  PR. Catches *additive* surface drift (new `pub` items that probably
-  shouldn't be exposed) that semver-checks doesn't flag because adding
-  is SemVer-minor, not major.
+  tightening, etc.). Runs as an **advisory** CI job (non-blocking).
+- **`cargo-public-api`** (this doc + the snapshot at [`public-api.txt`](https://github.com/lijunzh/hunch/blob/main/docs/src/reference/public-api.txt))
+  — produces a flat text inventory of every `pub` item. Run **locally**
+  during release prep to verify the snapshot still matches the actual
+  surface; commit any intentional drift in the same PR. Catches
+  *additive* surface drift (new `pub` items that probably shouldn't be
+  exposed) that semver-checks doesn't flag because adding is
+  SemVer-minor, not major.
+
+> The dedicated "Public API Surface" CI job that previously diffed the
+> snapshot on every PR was removed in #216 as part of trimming
+> over-engineered CI for a hobby-scale crate. The contract still holds;
+> the verification step just moved from "every PR" to "release prep".
 
 ## Current baseline
 
-Captured against `main` on **2026-04-18** (post #170):
+Captured against `main` at the v2.0.0 release tag (post #197/#198):
 
 | Metric | Count |
 |---|---|
-| Total API lines | **853** |
-| Public modules | 40 |
-| Public functions | 199 |
-| Public structs | 17 |
-| Public enums | 11 |
+| Total API lines | **201** |
+| Public modules | 1 (`hunch`) |
+| Public functions | 70 |
+| Public structs | 2 (`HunchResult`, `Pipeline`) |
+| Public enums | 3 (`Confidence`, `MediaType`, `Property`) |
 
-### Top exposure offenders (lines per module path)
+The intentional public surface is: `hunch()`, `hunch_with_context()`,
+`Pipeline`, `HunchResult`, `Confidence`, `MediaType`, `Property`. The
+v2.0.0 audit (#144 / #197) demoted the `matcher`, `properties`,
+`tokenizer`, and `zone_map` modules from `pub mod` to `pub(crate) mod`,
+shrinking the surface from 853 → 201 lines (76% reduction). See the
+[v2.0.0 migration guide](../about/migration-v2.md) for the migration
+path for downstream code that was using deep imports.
 
-| Module path | API lines | Comment |
-|---|---|---|
-| `hunch::matcher::*` | 88 | Regex helpers, span types — mostly internal scaffolding |
-| `hunch::HunchResult::*` | 44 | Public result type — keep, but field accessors warrant audit |
-| `hunch::properties::*` | 54 (32 mods + 22 fns) | Every property is a `pub mod` exposing its `find_matches` — almost certainly should be `pub(crate)` |
-| `hunch::tokenizer::*` | 25 | Internal — should be `pub(crate)` |
-| `hunch::zone_map::*` | 10 | Internal — should be `pub(crate)` |
-| `hunch::Confidence::*` | 6 | Public, intentional |
-| `hunch::Pipeline::*` | 5 | Public, intentional |
-
-The intentional public surface is roughly: `hunch()`, `hunch_with_context()`,
-`Pipeline`, `HunchResult`, `Confidence`. Everything else is incidental
-exposure that grew organically and was never audited.
-
-This is exactly what the [Public-API visibility audit epic
-(#144)](https://github.com/lijunzh/hunch/issues/144) is for.
-
-## How the CI tripwire works
-
-The `Public API Surface` job in [`ci.yml`](https://github.com/lijunzh/hunch/blob/main/.github/workflows/ci.yml):
-
-1. Installs Rust nightly (`cargo-public-api` requires the unstable
-   rustdoc-JSON output).
-2. Installs `cargo-public-api` via `taiki-e/install-action` (prebuilt
-   binary; matches the pattern set by the coverage and mutation jobs).
-3. Generates the current API listing.
-4. `diff -u`s it against [`docs/src/reference/public-api.txt`](https://github.com/lijunzh/hunch/blob/main/docs/src/reference/public-api.txt).
-5. Posts the diff to the GitHub Job Summary.
-
-The job is **advisory** (`continue-on-error: true`), matching the
-existing `semver-checks` advisory job. It will *not* block merging a
-PR — but the diff in the Job Summary makes any drift impossible to
-miss in code review.
-
-## When the diff fires
-
-| Diff content | What to do |
-|---|---|
-| New `pub` items | **Audit**: should they be `pub(crate)` instead? If yes, demote in the same PR. If genuinely public, regenerate the snapshot (below) and document the addition in the PR body. |
-| Removed `pub` items | This is a SemVer-major change. The `semver-checks` job should also be flagging it. Confirm intent, regenerate the snapshot, and bump the version per [CONTRIBUTING.md → API Stability Policy](https://github.com/lijunzh/hunch/blob/main/CONTRIBUTING.md). |
-| Signature changes | Same as removed — SemVer-major. Confirm with `semver-checks`. |
-| Reordered lines (no real diff) | The snapshot is sorted by `cargo-public-api`'s internal logic; reordering shouldn't happen in normal use. If you see this, regenerate. |
-
-## Regenerating the baseline
+## Verifying the snapshot during release prep
 
 Required when an intentional API change lands.
 
 ```bash
-# One-time install (uses Walmart proxy if needed):
+# One-time install:
 rustup toolchain install nightly --profile minimal
 cargo install cargo-public-api --locked
 
@@ -91,39 +60,31 @@ cargo +nightly public-api --simplified 2>/dev/null > docs/src/reference/public-a
 git diff docs/src/reference/public-api.txt
 ```
 
-Commit `docs/src/reference/public-api.txt` together with the API change in the same PR.
-The diff in the PR review should make the API delta easy for reviewers
-to scan.
+Commit `docs/src/reference/public-api.txt` together with the API change
+in the same PR. The diff in PR review should make the API delta easy
+for reviewers to scan.
 
-## Roadmap
+## Interpreting a diff
 
-This document captures the **first slice** of the [API audit epic
-(#144)](https://github.com/lijunzh/hunch/issues/144). Deferred to follow-up
-PRs:
+| Diff content | What to do |
+|---|---|
+| New `pub` items | **Audit**: should they be `pub(crate)` instead? If yes, demote in the same PR. If genuinely public, regenerate the snapshot and document the addition in the PR body. |
+| Removed `pub` items | This is a SemVer-major change. The `semver-checks` job should also be flagging it. Confirm intent, regenerate the snapshot, and bump the major version. |
+| Signature changes | Same as removed — SemVer-major. Confirm with `semver-checks`. |
 
-- **Triage pass**: classify every `pub` item as Keep / Demote / Deprecate
-  per the epic's definition-of-done. Each demotion lands in its own PR
-  to make the visibility change reviewable in isolation.
-- **Reverse-dep check**: query crates.io for downstream users of items
-  marked Demote/Deprecate before actually pulling the trigger.
-- **`pub use` cleanup**: collapse the obvious "should never have been
-  exposed" cases (`tokenizer`, `zone_map`, `matcher::engine`'s internals,
-  the property modules) en masse.
-- **`#[non_exhaustive]`** on the public enums (`Confidence`,
-  `HunchResult` field types) so future variant additions aren't
-  SemVer-major. _Partially landed in #172: `Property`, `MediaType`,
-  `Source`, `Separator`, `BracketKind`, `ZoneScope`, `CharClass` now
-  bear the attribute. `Confidence` and `SegmentKind` deliberately
-  excluded — they're conceptually saturated (Low/Med/High and
-  Directory/Filename respectively)._
-- **Promote the CI job from advisory → blocking** once the surface has
-  stabilised post-audit.
+## Public enum policy
+
+All public enums carry `#[non_exhaustive]` as of v2.0.0 (#172, #196):
+`Property`, `MediaType`, `Confidence`. Downstream code must include a
+wildcard arm (`_ => …`) when matching on any of these. This lets
+future minor releases add new variants without re-breaking the API.
 
 ## References
 
 - [`cargo-public-api`](https://github.com/Enselic/cargo-public-api)
 - [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks)
-  (sibling tool, already in CI)
-- [CONTRIBUTING.md → API Stability Policy](https://github.com/lijunzh/hunch/blob/main/CONTRIBUTING.md)
-- Sibling docs: [Coverage](../contributor-guide/coverage.md) (line coverage),
-  [Mutation Testing](../contributor-guide/mutation-baseline.md) (assertion quality)
+  (sibling tool, advisory CI job)
+- [v2.0.0 migration guide](../about/migration-v2.md) — what the surface
+  shrink means for callers
+- Sibling docs: [Coverage](../contributor-guide/coverage.md) (run locally),
+  [Mutation Testing](../contributor-guide/mutation-baseline.md) (run locally)


### PR DESCRIPTION
## v2.0.0 release-prep PR

Reopens the v2.0.0 release after PR #199 was closed. Picks up the doc-drift cleanup the sub-agent review cycle surfaced (and that #199 missed).

## What's in this PR

**Version + changelog (P1 from all 4 sub-agents):**
- `Cargo.toml` 1.1.8 → 2.0.0 (+ `Cargo.lock` regenerated)
- `CHANGELOG.md`: promote `[Unreleased]` → `[2.0.0] - 2026-04-20` + add link reference
- Add missing changelog entries: #213 (CJK fansub patterns), #215 (drop ancestor-path Source when filename has source), #216 (CI cleanup), #222 (benches/+fuzz/ removal), #223 (rules → src/rules), #224 (README slim)
- Restructure Internal/Infrastructure section into "survived to v2.0.0" vs "added then rolled back in same cycle" — readers shouldn't see deleted infra advertised as a v2.0.0 feature

**Doc drift (P2 from code-reviewer, release-day visible):**
- `docs/src/reference/public-api.md`: regenerate baseline (**853 → 201 lines** post-#197), drop dead "Public API Surface CI job" description, drop already-shipped Roadmap items, reframe as "run locally during release prep". Adds cross-link to migration-v2.md.
- `docs/src/contributor-guide/coverage.md`: remove "CI Coverage job runs on every PR" (job deleted in #216); reframe Roadmap as long-term ideas.
- `docs/src/contributor-guide/mutation-baseline.md`: remove nightly workflow description (deleted in #216); reframe How-it-runs and Triage protocol around local execution.
- `SECURITY.md`: bump Supported Versions table from `1.1.x` → `2.0.x` with link to migration guide.

## Validation gauntlet — all green ✅

| Check | Result |
|---|---|
| `cargo fmt --check` | ✅ clean |
| `cargo clippy --all-targets -- -D warnings` | ✅ zero warnings |
| `cargo test --release` | ✅ **636 passed**, 0 failed, 3 intentional ignores |
| `cargo build --no-default-features` | ✅ library-only consumers compile |
| `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps` | ✅ |
| `cargo publish --dry-run` | not run locally (the corporate VPN can't reach index.crates.io); release.yml verify-version + publish jobs will exercise on tag push |

## Sub-agent review summary (4/4 green to ship after this PR)

Phase 2 of the release skill ran 4 mandatory sub-agents in parallel with strict pre-flight verification + severity classification:

| Agent | P1 blockers | P2 | P3-bundle |
|---|---|---|---|
| **code-reviewer** | 1 (this PR) | 4 doc-drift items (this PR) | 4 nits |
| **rust-programmer** | 1 (this PR) | 0 — cargo metadata publish-ready | 4 nice-to-haves |
| **security-auditor** | 0 | 0 | 3 defensive nits |
| **qa-expert** | 1 (this PR) | 2 deferred (Windows symlink coverage, --context CLI test) | 3 nits |

Notable green checks:
- `cargo audit`: 0 vulns vs 1,049 advisories, 91 deps
- Zero `unsafe` in src/
- Symlink hardening present + tested at all 4 file-walk entry points
- All breaking changes documented with migration snippets in CHANGELOG
- migration-v2.md is genuinely excellent for a major bump

## P3 follow-up

Per the skill's audit-dust prevention rule, P3-bundle items (8 nits across the 4 agents) will be filed as ONE tracking issue post-merge — not as 8 separate issues. Items: stale `/fuzz/` entries in `.gitignore`, 5 `docs/` moved-stub pages, scattered `regex.unwrap()` → `expect()` consistency, `public-api.md` Confidence `#[non_exhaustive]` description drift, Cargo.toml categories headroom (2 of 5 used), `mutants.out.old/` cleanup, Windows symlink coverage, dedicated --context CLI integration test.

## After merge

1. Tag `v2.0.0` on main (release.yml verify-version will gate against Cargo.toml = 2.0.0 ✅)
2. release.yml will: build 5 cross-compiled binaries → publish to crates.io → create GitHub Release
3. File P3 tracking issue
4. Mark old #199 as superseded by this PR
