### PR TITLE
docs: README polish — fresh badges, scale-back accuracy claim, drop contributing/license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ Release prep checklist:
 
 ## [Unreleased]
 
+### Docs
+
+- **README polish.** Replaced the stale `Coverage` badge (the underlying
+  CI job was deleted in #216 — the 94.34% number is frozen forever) with
+  the standard four-badge row: CI status, crates.io version, docs.rs,
+  and license. Scaled back the "Real-world accuracy" section to point at
+  the live compatibility report only — the prior personal-library
+  anecdote ("99.8% across 7,838 files") was a single ad-hoc data point,
+  not a reproducible measurement, and the section header now matches
+  what's actually claimed ("Accuracy"). Dropped the inline Contributing
+  and License sections — the new license badge links to `LICENSE`, and
+  `CONTRIBUTING.md` stays in the repo root next to the README. Net diff:
+  −13 lines.
+
 ## [2.0.0] - 2026-04-20
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # 🔍 Hunch
 
-[![Coverage](https://img.shields.io/badge/coverage-94.34%25-brightgreen)](https://lijunzh.github.io/hunch/contributor-guide/coverage.html)
+[![CI](https://img.shields.io/github/actions/workflow/status/lijunzh/hunch/ci.yml?branch=main&label=CI&logo=github)](https://github.com/lijunzh/hunch/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/hunch.svg)](https://crates.io/crates/hunch)
+[![Docs](https://img.shields.io/docsrs/hunch)](https://docs.rs/hunch)
+[![License](https://img.shields.io/crates/l/hunch.svg)](LICENSE)
 
 **A fast, offline media filename parser for Rust — extract title, year,
 season, episode, codec, language, and 49 properties from messy filenames.**
@@ -62,28 +65,12 @@ assert_eq!(result.episode(), Some(3));
 | [**API Reference**](https://docs.rs/hunch) | Full Rust API docs |
 | [**Changelog**](CHANGELOG.md) | Version history |
 
-## Real-world accuracy
+## Accuracy
 
 Validated against guessit's upstream test suite — see the
 [compatibility report](https://lijunzh.github.io/hunch/user-guide/compatibility.html)
 for the live pass rate, regenerated from
-`cargo test -- --ignored guessit_compat` so it can't drift.
-
-In one real-world library audit of 7,838 files, hunch achieved **99.8%
-accuracy** across a mixed Anime / English / Japanese / Kids collection.
-The remaining edge cases are documented under
+`cargo test -- --ignored guessit_compat` so it can't drift. Edge cases
+that remain difficult are documented under
 [Known Limitations](https://lijunzh.github.io/hunch/user-guide/known-limitations.html).
 
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md). The easiest contribution is
-[reporting a failed parse](https://github.com/lijunzh/hunch/issues/new/choose).
-
-```bash
-cargo test              # full suite
-cargo test -- --ignored # guessit compatibility report
-```
-
-## License
-
-[MIT](LICENSE)


### PR DESCRIPTION
Three targeted README changes:

## Changes

### 1. Fresh badge row (replace stale Coverage badge)

The previous `Coverage` badge linked to a hardcoded 94.34% number whose CI job was **deleted in #216** — that number is frozen forever now and increasingly misleading. Replaced with the standard four-badge row downstream Rust users actually expect:

- **CI** — GitHub Actions `ci.yml` status on main
- **Crates.io** — current crate version
- **Docs** — docs.rs build status
- **License** — auto-pulled from Cargo.toml `license` field

### 2. Scaled back the "Real-world accuracy" claim

Dropped the paragraph claiming "99.8% across 7,838 files in a mixed Anime/English/Japanese/Kids collection." That was a single ad-hoc personal library scan — not a reproducible measurement, and overstating it as a project-wide accuracy claim was misleading. The section now anchors only to the **live compatibility report** (which IS reproducible via `cargo test -- --ignored guessit_compat`). Renamed section header `-world accuracy` → `Accuracy` so the heading matches the (now narrower) claim.

### 3. Dropped inline Contributing + License sections

The license badge (top of README) links to `LICENSE`, and `CONTRIBUTING.md` is in the repo root next to the README — anyone looking will find it. The inline sections were duplication.

## Diff: 2 files, +21 / -20 (README **-13 net**, CHANGELOG +14)

| File | Δ |
|---|---|
| README.md | 89 → 76 lines (-13) |
| CHANGELOG.md | added `[Unreleased]` → `### Docs` entry |

## Validation

- `cargo check` ✅ (no .rs touched, included for paranoia)
- Markdown link audit: ✅ all links closed
- Badges manually verified to use real shields.io URLs against `lijunzh/hunch` repo and `hunch` crate name

## Closes

Nothing. Pure post-2.0.0 README polish, no issue tracking it.