### PR TITLE
ci: require Semver Checks on PRs (post-2.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,21 @@ jobs:
 
   semver:
     name: Semver Checks
-    # Detects SemVer-incompatible changes vs the latest crates.io release.
-    # Advisory (continue-on-error): pre-1.0 stability semantics — breaking
-    # changes land on main with the version bump deferred to release prep.
-    # Release-prep PRs MUST verify this is green or accept the bump.
+    # Required (post-2.0.0): SemVer-incompatible changes vs the latest
+    # crates.io release MUST be paired with a matching version bump in
+    # the same PR. cargo-semver-checks compares the PR's public API
+    # against the published baseline; a major-version bump in Cargo.toml
+    # makes a breaking change pass the check.
+    #
+    # If you genuinely need to break the public API:
+    #   1. Make the breaking change
+    #   2. Bump Cargo.toml version (major: 2.x.y → 3.0.0)
+    #   3. Add a CHANGELOG entry under [Unreleased] describing the break
+    #
+    # Until v1.0 this job ran with continue-on-error: true and breaking
+    # changes accumulated for batch release. That escape hatch is gone
+    # now that downstream consumers depend on stable API contracts.
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable


### PR DESCRIPTION
Drops `continue-on-error: true` from the Semver Checks job so SemVer-incompatible API changes block PR merges unless paired with a matching Cargo.toml version bump in the same PR.

## Why now

Pre-1.0 the job was advisory because breaking changes were expected to accumulate between releases — the old comment said so explicitly:

> Advisory (continue-on-error): pre-1.0 stability semantics — breaking changes land on main with the version bump deferred to release prep.

That escape hatch made sense when nobody depended on the API. **v2.0.0 is published to crates.io now**, and downstream Rust consumers expect stable contracts. Unintentional breaks need to fail loud at PR time, not get discovered weeks later by a release-prep audit.

## What this PR changes

| Change | Before | After |
|---|---|---|
| `semver` job `continue-on-error` | `true` | (removed → defaults to false) |
| Comment block | Pre-1.0 advisory rationale | Post-2.0.0 enforcement workflow |

## New developer workflow for breaking changes

If you genuinely need to break the public API:

1. Make the breaking change
2. Bump `Cargo.toml` version (major: 2.x.y → 3.0.0)
3. Add a CHANGELOG entry under `[Unreleased]` describing the break

cargo-semver-checks compares the PR's public API against the published baseline; a major-version bump in Cargo.toml makes a breaking change pass the check.

## Companion  after this lands (NOT in this PR)

GitHub repository ruleset `14114061` for the `main` branch needs `Semver Checks` added to `required_status_checks`. Currently required: Format, Clippy, Test (ubuntu/macos/windows), Docs. After ruleset update: also Semver Checks. I'll do this via the GH API right after this merges (one curl call). of scope but worth noting

`Security Audit` is similarly not-required today. Could follow the exact same pattern in a separate small PR if you want to enforce `cargo audit` too. Up to you.

## Validation

- `actionlint .github/workflows/ci.yml` ✅
- YAML parse ✅
- **Recent run history**: Semver Checks PASSED on the last 3 PRs (#225, #227, #228). The 2 hical failures were on `docs/slim-readme` while v2.0.0 was being intentionally cooked — exactly the workflow the OLD comment described. Post-2.0.0 there's a stable baseline; the job will only fail on genuine unacknowledged breaking changes.

## Diff: 1 file, +12 / -4