### PR TITLE
docs: document D2 boundary (TOML vs Rust) — decision table + 15 module headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Release prep checklist:
 
 ### Docs
 
+- **Documented the D2 boundary (vocabulary in TOML, logic in Rust)**
+  with a decision table in DESIGN.md and per-module "Why this lives in
+  Rust" header docstrings on the 14 inline-regex property modules
+  (`date`, `episodes`, `release_group`, `title`, `part`, `website`,
+  `episode_count`, `bonus`, `uuid`, `year`, `version`, `crc32`,
+  `aspect_ratio`, `size`, `bit_rate`). Closes the audit thread from
+  the now-resolved #143 epic. Pure docs — no behavior change.
+  Net diff: +153 lines across 16 files.
+
 - **README polish.** Replaced the stale `Coverage` badge (the underlying
   CI job was deleted in #216 — the 94.34% number is frozen forever) with
   the standard four-badge row: CI status, crates.io version, docs.rs,

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -110,6 +110,42 @@ Control flow (episode parsing, date detection, title extraction)
 lives in Rust. The boundary is: if it's a vocabulary lookup, it's
 TOML; if it needs branching or state, it's Rust.
 
+#### When does a property go to TOML vs stay in Rust?
+
+The D2 boundary in practice — use this table when adding a new
+property or wondering why an existing one lives where it does:
+
+| Question about your property | TOML | Rust |
+|---|:---:|:---:|
+| Fixed vocabulary lookup? (`x264` → `H.264`) | ✅ | |
+| Single capture group → string substitution with `value = "{1}"`? | ✅ | |
+| Needs >1 named capture group with semantic roles? | | ✅ |
+| Requires post-match arithmetic? (WxH → ratio float) | | ✅ |
+| Requires type conversion? (`trois` → 3, hex → bytes) | | ✅ |
+| Cross-pattern coordination or span deduplication? | | ✅ |
+| Validation beyond regex? (year range, CRC format) | | ✅ |
+| Multiple regex variants with different output meanings? (YMD vs MDY) | | ✅ |
+
+**Examples on each side as of v2.0.0:**
+
+- ✅ **TOML-only** (16 properties): `audio_codec`, `audio_profile`,
+  `color_depth`, `container`, `country`, `edition`, `episode_details`,
+  `frame_rate`, `other`, `screen_size`, `source`, `streaming_service`,
+  `video_codec`, `video_profile` — plus the hybrid pair below.
+- ✅ **Rust-only** (14 properties with inline regex): `date`,
+  `episodes`, `release_group`, `title`, `part`, `website`,
+  `episode_count`, `bonus`, `uuid`, `year`, `version`, `crc32`,
+  `aspect_ratio`, `size`, `bit_rate` — each module's docstring states
+  which row(s) of the table forced it Rust-side.
+- 🔀 **Hybrid** (TOML vocabulary + Rust logic): `subtitle_language`,
+  `language` — simple markers in TOML, positional/algorithmic patterns
+  in Rust. Module docstring names the TOML companion.
+
+If you find yourself wanting to add `min`/`max`/`format`/`transform`
+keys to a TOML schema to express logic, **stop**: that's the table
+telling you the property belongs in Rust. Inventing a Rust→TOML→Rust
+DSL is a category error (Zen: "Simple is better than complex").
+
 ### D3: Single self-contained binary (P3)
 
 All TOML rules are `include_str!`-ed at compile time. No runtime

--- a/src/properties/aspect_ratio.rs
+++ b/src/properties/aspect_ratio.rs
@@ -2,6 +2,13 @@
 //!
 //! Aspect ratio is derived from explicit WxH resolution patterns.
 //! When we see "1920x1080", we compute 1920/1080 = 1.778.
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Post-match arithmetic (WxH → ratio float, formatted to 3 decimal
+//! places) is the entire point of this module — the regex just
+//! captures the two integers. See DESIGN.md D2 decision table →
+//! "requires post-match arithmetic".
 
 use regex::Regex;
 

--- a/src/properties/bit_rate.rs
+++ b/src/properties/bit_rate.rs
@@ -15,6 +15,14 @@
 //!
 //! This unit-based heuristic matches guessit's behavior and reflects how the
 //! values appear in real-world filenames.
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Float parsing of the numeric capture, unit-based property routing
+//! (Kbps → audio, Mbps → video), and the disambiguation heuristic above
+//! are all logic the regex can't express on its own. See DESIGN.md D2
+//! decision table → "requires post-match arithmetic" + "multiple regex
+//! variants with different output meanings".
 
 use regex::Regex;
 

--- a/src/properties/bonus.rs
+++ b/src/properties/bonus.rs
@@ -1,6 +1,14 @@
 //! Bonus content detection.
 //!
 //! Detects bonus/extras markers: x01, x02 (used for bonus features).
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Capture-group title extraction (`x01-Title_Here` → bonus_number=1 +
+//! bonus_title="Title Here") emits multiple properties from one match
+//! and requires span deduplication against neighboring episode/season
+//! patterns. See DESIGN.md D2 decision table → "cross-pattern
+//! coordination".
 
 use regex::Regex;
 

--- a/src/properties/crc32.rs
+++ b/src/properties/crc32.rs
@@ -1,6 +1,13 @@
 //! CRC32 detection.
 //!
 //! Detects CRC32 checksums commonly found in anime filenames: `[ABCD1234]`.
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Hex format validation (8 chars, [0-9A-Fa-f]) wraps the regex match
+//! and the captured value is normalized to uppercase for output. See
+//! DESIGN.md D2 decision table → "validation beyond regex" + "requires
+//! type conversion".
 
 use regex::Regex;
 

--- a/src/properties/date.rs
+++ b/src/properties/date.rs
@@ -1,6 +1,16 @@
 //! Date detection.
 //!
 //! Detects air dates in filenames: 2014.12.25, 25-12-2014, etc.
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Each of the 7 regex variants has a *different* named-capture-group
+//! arrangement (YMD vs MDY vs DMY vs YYYYMMDD vs 2-digit-year). The
+//! consumer code reads `(?P<year>...)`/`(?P<month>...)`/`(?P<day>...)`
+//! to construct `Date` objects with disambiguation rules. The regex
+//! *shape* is the data, not the regex string — moving the strings to
+//! TOML wouldn't move the consumer logic. See DESIGN.md D2 decision
+//! table → "multiple regex variants with different output meanings".
 
 use regex::Regex;
 

--- a/src/properties/episode_count.rs
+++ b/src/properties/episode_count.rs
@@ -3,6 +3,13 @@
 //! Detects `X of Y` patterns for episode and season totals:
 //! - `1of4` / `1 of 4` → episode=1, episode_count=4
 //! - `Season.2of5` → season=2, season_count=5
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! A single regex match emits *two* properties (e.g., `episode` AND
+//! `episode_count`) and the season-count vs episode-count distinction
+//! requires cross-pattern span tracking to avoid double-counting. See
+//! DESIGN.md D2 decision table → "cross-pattern coordination" row.
 //! - `14.of.21` → episode=14, episode_count=21
 
 use regex::Regex;

--- a/src/properties/episodes/mod.rs
+++ b/src/properties/episodes/mod.rs
@@ -3,6 +3,15 @@
 //! Supports S01E02, 1x03, Season/Saison, Episode, 3/4-digit decomposition,
 //! anime-style, path-based seasons, and Roman numeral seasons.
 //!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Sequential parsing with range expansion (S01E02-04 → [2, 3, 4]),
+//! cross-pattern span deduplication, and anime-numbering edge cases.
+//! Multiple regex variants emit different output meanings (season vs
+//! episode vs both). See DESIGN.md "D2: Vocabulary in TOML, logic in
+//! Rust" → the decision table flags this on the "multiple variants /
+//! cross-pattern coordination" rows.
+//!
 //! The main `find_matches` orchestrates pattern groups in priority order:
 //! 1. SxxExx family (structural: S01E02, S03-E01, etc.)
 //! 2. NxN compact notation (1x03, 5x44x45)

--- a/src/properties/part.rs
+++ b/src/properties/part.rs
@@ -1,6 +1,14 @@
 //! Part, disc, CD, film detection.
 //!
 //! Detects part/disc/cd/film numbers commonly used in media filenames.
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Roman numeral conversion (`IV` → 4), French number-words (`trois` →
+//! 3), and multi-disc range expansion (`Disc.1-3` → [1, 2, 3]) are
+//! type conversions and arithmetic that TOML's `value = "{1}"`
+//! template can't express. See DESIGN.md D2 decision table →
+//! "requires type conversion" row.
 
 use regex::Regex;
 

--- a/src/properties/release_group/mod.rs
+++ b/src/properties/release_group/mod.rs
@@ -3,6 +3,14 @@
 //! Release groups typically appear at the end of the filename, after a "-".
 //! Example: `Movie.2024.1080p.BluRay.x264-GROUP.mkv` -> "GROUP"
 //!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Positional context (start vs end of filename) drives priority among
+//! ~9 fallback patterns; the *first* match wins, not the longest. That
+//! ordering is logic, not vocabulary. See DESIGN.md "D2: Vocabulary in
+//! TOML, logic in Rust" → "multiple regex variants with different
+//! output meanings" + "cross-pattern coordination" rows.
+//!
 //! ## v0.3 change: Two-pass pipeline
 //!
 //! Release group now runs AFTER conflict resolution (Pass 2), so it can

--- a/src/properties/size.rs
+++ b/src/properties/size.rs
@@ -1,6 +1,13 @@
 //! Size detection.
 //!
 //! Detects file sizes: 700MB, 1.4GB, 4.7GB, etc.
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Float parsing of the numeric capture plus unit normalization
+//! (MB/GB/TB → a single output format) requires arithmetic the TOML
+//! schema can't express. See DESIGN.md D2 decision table → "requires
+//! post-match arithmetic" + "requires type conversion".
 
 use regex::Regex;
 

--- a/src/properties/title/mod.rs
+++ b/src/properties/title/mod.rs
@@ -3,6 +3,16 @@
 //! Split into submodules:
 //! - `clean` — string cleaning (separators, brackets, casing)
 //! - `secondary` — episode_title, film_title, alternative_title, media_type
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Title is the *residual* extractor: it can't be expressed as a
+//! pattern because its definition is "the substring no other property
+//! claimed". The cleanup phase then applies algorithmic post-processing
+//! (separator normalization, bracket stripping, casing rules) that's
+//! pure logic, not vocabulary. See DESIGN.md D2 decision table →
+//! "cross-pattern coordination" (depends on every other matcher's
+//! output spans).
 
 mod clean;
 mod secondary;

--- a/src/properties/uuid.rs
+++ b/src/properties/uuid.rs
@@ -1,6 +1,13 @@
 //! UUID detection.
 //!
 //! Detects UUIDs in filenames (commonly used in obfuscated releases).
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! UUID format validation (32 hex chars in canonical hyphenation, or
+//! the bare 32-char form) requires post-match checks beyond what regex
+//! alone can express, plus normalization to a single output format.
+//! See DESIGN.md D2 decision table → "validation beyond regex".
 
 use regex::Regex;
 

--- a/src/properties/version.rs
+++ b/src/properties/version.rs
@@ -2,6 +2,13 @@
 //!
 //! Detects release versions like `v2`, `V3`, or `07v4` commonly
 //! found in anime fansub releases (e.g., `Episode.366v2`, `[Group] Show 07v4`).
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Position-sensitive parsing: the version digit can stand alone (`v2`)
+//! or trail an episode number (`07v4` → episode=7 + version=4),
+//! requiring coordination with `episodes` extraction. See DESIGN.md D2
+//! decision table → "cross-pattern coordination".
 
 use regex::Regex;
 

--- a/src/properties/website.rs
+++ b/src/properties/website.rs
@@ -1,6 +1,13 @@
 //! Website detection.
 //!
 //! Detects website names in brackets or prefixed in filenames.
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Multi-part TLD validation (e.g., distinguishing `.co.uk` from a
+//! language code) requires logic beyond a regex match — it disqualifies
+//! false positives like `s02e20.ru` matching as a `.ru` website (issue
+//! #163). See DESIGN.md D2 decision table → "validation beyond regex".
 
 use regex::Regex;
 

--- a/src/properties/year.rs
+++ b/src/properties/year.rs
@@ -1,4 +1,11 @@
 //! Year detection (4-digit years in a reasonable range).
+//!
+//! ## Why this lives in Rust (not `src/rules/`)
+//!
+//! Year-range validation (only `(?:19|20)\d{2}` are accepted, plus
+//! contextual disambiguation against episode numbers) wraps the regex
+//! match. The regex itself is one line; the validation logic is the
+//! rest. See DESIGN.md D2 decision table → "validation beyond regex".
 
 use regex::Regex;
 


### PR DESCRIPTION
Closes #230, closes #231.

Implements the audit conclusion from [#143's substantive close](https://github.com/lijunzh/hunch/issues/143#issuecomment-4281019715): the TOML-driven matcher migration is complete, but the **D2 boundary rule** ("Vocabulary in TOML, logic in Rust") was implicit. Now it isn't.

## Two parts in one PR (per discussion in chat)

### 🎯 Part 1 — DESIGN.md decision table (#231)

New subsection under D2 with an 8-question decision table that converts the principle into a rule. **If any answer puts the property on the Rust side, it stays in Rust:**

| Question | TOML | Rust |
|---|:---:|:---:|
| Fixed vocabulary lookup? (`x264` → `H.264`) | ✅ | |
| Single capture group → string substitution? | ✅ | |
| Needs >1 named capture group with semantic roles? | | ✅ |
| Requires post-match arithmetic? (WxH → ratio) | | ✅ |
| Requires type conversion? (`trois` → 3, hex → bytes) | | ✅ |
| Cross-pattern coordination or span deduplication? | | ✅ |
| Validation beyond regex? (year range, CRC format) | | ✅ |
| Multiple regex variants with different output meanings? | | ✅ |

Plus explicit examples list naming the **16 TOML-resident, 14 Rust-resident, and 2 hybrid** properties as of v2.0.0. Plus a guard against the obvious anti-pattern: *if you find yourself wanting to add `min`/`max`/`format`/`transform` keys to a TOML schema to express logic, **stop** — that's the table telling you the property belongs in Rust.*

### 🎯 Part 2 — Per-module D2 headers (#230)

Added a **"## Why this lives in Rust (not `src/rules/`)"** subsection to 14 inline-regex modules + 1 algorithmic-only module (`title/mod.rs`). Each header:

1. States the specific D2 row(s) that forced it Rust-side
2. Cites a concrete example of the logic
3. References DESIGN.md D2 decision table by name

| File | Why it stays |
|---|---|
| `episodes/mod.rs` | sequential parsing, range expansion, span dedup |
| `release_group/mod.rs` | positional priority, 9 fallback patterns |
| `title/mod.rs` | residual extractor (depends on every other matcher) |
| `date.rs` | capture-group shape is the data |
| `part.rs` | Roman numeral + French number-word conversion |
| `website.rs` | multi-part TLD validation |
| `episode_count.rs` | "X of Y" → two properties + span tracking |
| `bonus.rs` | capture-group title extraction + span dedup |
| `uuid.rs` | format validation around match |
| `year.rs` | year-range validation |
| `version.rs` | cross-pattern coordination with `episodes` |
| `crc32.rs` | hex format validation + uppercasing |
| `aspect_ratio.rs` | WxH → ratio float arithmetic |
| `size.rs` | MB/GB unit conversion |
| `bit_rate.rs` | unit-based property routing (Kbps→audio, Mbps→video) |

The Category A modules (`subtitle_language`, `language`) already had equivalent D2 headers — deliberately untouched.

## Why one PR not two

The table in DESIGN.md is the canonical answer to *"why isn't this in TOML?"*, and the headers cite the table by name. Splitting would force the headers to either land first (can't cite the table) or land second (requires circle-back PR). **One commit → future-bisect-friendly**: the D2 boundary becomes formally documented in a single atomic change.

## Validation gauntlet — all green ✅

| Check | Result |
|---|---|
| `cargo fmt --check` | ✅ |
| `cargo clippy --all-targets -- -D warnings` | ✅ zero warnings |
| `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps` | ✅ |
| `cargo test --release` | ✅ **636 tests pass** (matches v2.0.0 baseline) |

## Diff: 16 files, **+153 / -0** (pure additions)

Zero behavior change. CHANGELOG entry under `[Unreleased]` → `### Docs`.