### PR TITLE
fix(parse): remove false AVCHD video_profile for bare AVC token (#237)

### DIFF
--- a/src/rules/video_profile.toml
+++ b/src/rules/video_profile.toml
@@ -2,8 +2,10 @@
 property = "video_profile"
 
 [exact]
+# AVCHD is a specific consumer camcorder delivery format — only fire when
+# the literal "avchd" token is present. The bare "avc" token is just the
+# codec name (= H.264) and carries no profile information.
 avchd = "Advanced Video Codec High Definition"
-avc   = "Advanced Video Codec High Definition"
 hevc  = "High Efficiency Video Coding"
 hp    = "High"
 

--- a/tests/fixtures/community.yml
+++ b/tests/fixtures/community.yml
@@ -16,7 +16,23 @@
 
 # --- Episodes ---
 
-# (add community-reported episode cases here)
+# Regression: #237 — bare "AVC" token must NOT produce video_profile=AVCHD.
+# AVC is the codec name (= H.264), not the AVCHD camcorder delivery format.
+# AVCHD is only valid when the literal "avchd" token is present.
+? "[晚街与灯][Re Zero kara Hajimeru Isekai Seikatsu][4th - 03][总第69][WEB-DL Remux][1080P_AVC_AAC][简繁日内封PGS].mkv"
+: release_group: 晚街与灯
+  title: Re Zero kara Hajimeru Isekai Seikatsu
+  season: 4
+  episode: 3
+  absolute_episode: 69
+  source: Web
+  other: Remux
+  screen_size: 1080p
+  video_codec: H.264
+  audio_codec: AAC
+  container: mkv
+  type: episode
+  video_profile: !!null
 
 # --- Edge Cases ---
 

--- a/tests/fixtures/rules/video_codec.yml
+++ b/tests/fixtures/rules/video_codec.yml
@@ -72,9 +72,10 @@
 : video_codec: H.264
   video_profile: Scalable Video Coding
 
+# mpeg4-AVC — AVC here means the codec (H.264), NOT the AVCHD camcorder format.
+# No video_profile should be emitted.
 ? mpeg4-AVC
 : video_codec: H.264
-  video_profile: Advanced Video Codec High Definition
 
 ? AVCHD-SC
 ? H.264-AVCHD-SC


### PR DESCRIPTION
## Problem

Closes #237.

`video_profile.toml` had a wrong exact mapping:

```toml
avc = "Advanced Video Codec High Definition"
```

**AVC** = Advanced Video *Coding* — it's just the H.264 codec name.  
**AVCHD** = Advanced Video Codec High *Definition* — a specific consumer camcorder delivery format.

These are different things. Treating any bare `AVC` token as the AVCHD camcorder profile is a category error. A filename like `[1080P_AVC_AAC]` is using AVC as a codec tag (= H.264), and should produce zero `video_profile`.

## Changes

| File | What changed |
|---|---|
| `src/rules/video_profile.toml` | Drop `avc` from `[exact]`; keep `avchd` (literal token is unambiguous) |
| `tests/fixtures/rules/video_codec.yml` | Remove `video_profile` expectation from `mpeg4-AVC` case (same wrong assumption) |
| `tests/fixtures/community.yml` | Full regression fixture for the exact filename from #237; asserts `video_profile: !!null` |

## Testing

`cargo test` — all 43 test suites pass, 0 failures.

## What is NOT changed

- `avchd = "Advanced Video Codec High Definition"` is **kept** — literal AVCHD tokens are unambiguous.
- The `AVCHD-SC` and `H.264-AVCHD-SC` fixtures are **unchanged**.
- The `Gangs of New York ... x264-AVCHD` fixture is **unchanged**.