### PR TITLE
chore: release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ Release prep checklist:
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-04-26
+
+### Fixed
+
+- **False `AVCHD` video profile for bare `AVC` token.** `AVC` is the codec
+  name for H.264 and carries no profile information on its own. `AVCHD`
+  (Advanced Video Codec High Definition) is a specific consumer camcorder
+  delivery format and should only fire on the literal `avchd` token.
+  The incorrect mapping caused filenames containing bare `AVC` (e.g.
+  multi-audio CJK releases) to gain a spurious
+  `video_profile: "Advanced Video Codec High Definition"` field. Fixed
+  by removing the `avc` entry from `video_profile.toml`'s `[exact]`
+  table while keeping `avchd`. Regression fixture added to
+  `tests/fixtures/community.yml`. (#237, #238)
+
 ### Docs
 
 - **Documented the D2 boundary (vocabulary in TOML, logic in Rust)**
@@ -36,6 +51,20 @@ Release prep checklist:
   and License sections — the new license badge links to `LICENSE`, and
   `CONTRIBUTING.md` stays in the repo root next to the README. Net diff:
   −13 lines.
+
+### CI
+
+- **`cargo semver-checks` is now a required CI gate** (previously
+  advisory). Any PR that introduces a SemVer-incompatible public API
+  change will now hard-fail CI rather than emit a warning. Enforced
+  via `obi1kenobi/cargo-semver-checks-action`. (#229)
+
+### Dependencies
+
+- Bumped `dependabot/fetch-metadata` 2.5.0 → 3.1.0
+- Bumped `taiki-e/install-action` 2.75.17 → 2.75.20
+- Bumped `obi1kenobi/cargo-semver-checks-action` 2.8 → 2.9
+- Bumped Rust minor/patch toolchain group (Dependabot auto-merge)
 
 ## [2.0.0] - 2026-04-20
 
@@ -1102,6 +1131,7 @@ source, audio_codec, screen_size, audio_channels, date.
 
 color_depth, streaming_service, bonus, episode_details, film.
 
+[2.0.1]: https://github.com/lijunzh/hunch/releases/tag/v2.0.1
 [2.0.0]: https://github.com/lijunzh/hunch/releases/tag/v2.0.0
 [1.1.8]: https://github.com/lijunzh/hunch/releases/tag/v1.1.8
 [1.1.7]: https://github.com/lijunzh/hunch/releases/tag/v1.1.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hunch"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hunch"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Lijun Zhu"]

--- a/docs/src/reference/public-api.md
+++ b/docs/src/reference/public-api.md
@@ -26,7 +26,7 @@ Two complementary tools watch this contract:
 
 ## Current baseline
 
-Captured against `main` at the v2.0.0 release tag (post #197/#198):
+Captured against `main` at the v2.0.1 release tag (post #197/#198).
 
 | Metric | Count |
 |---|---|


### PR DESCRIPTION
## v2.0.0 → v2.0.1 (patch)

**SemVer rationale:** Patch — one bug fix (parse output change for AVCHD false positive), no public API changes, no breaking changes.

---

## Changelog

### Fixed

- **False `AVCHD` video profile for bare `AVC` token.** `AVC` is the codec name for H.264 and carries no profile information on its own. `AVCHD` (Advanced Video Codec High Definition) is a specific consumer camcorder delivery format and should only fire on the literal `avchd` token. The incorrect mapping caused filenames containing bare `AVC` (e.g. multi-audio CJK releases) to gain a spurious `video_profile: "Advanced Video Codec High Definition"` field. Fixed by removing the `avc` entry from `video_profile.toml`'s `[exact]` table while keeping `avchd`. Regression fixture added to `tests/fixtures/community.yml`. (#237, #238)

### Docs

- Documented the D2 boundary (vocabulary in TOML, logic in Rust) with decision table in DESIGN.md and 15 module-level header docstrings. Pure docs — no behavior change.
- README polish — fresh badge row, scaled-back accuracy section, removed inline Contributing/License sections.

### CI

- `cargo semver-checks` is now a **required** gate (previously advisory). (#229)

### Dependencies

- Bumped `dependabot/fetch-metadata` 2.5.0 → 3.1.0
- Bumped `taiki-e/install-action` 2.75.17 → 2.75.20
- Bumped `obi1kenobi/cargo-semver-checks-action` 2.8 → 2.9
- Bumped Rust minor/patch toolchain group

---

## Sub-agent Review Summary

All 4 agents ran pre-flight checks on current file state before flagging.

| Agent | Quality Gates | Findings |
|---|---|---|
| code-reviewer | ✅ No TODO/FIXME/dead-code/DESIGN drift | P2: public-api.md baseline annotation (fixed) |
| rust-programmer | ✅ fmt/clippy/test/doc/no-default-features all pass | P3-bundle: authors field, homepage, toml dep pin |
| security-auditor | ✅ 0 RUSTSEC, 0 unsafe, 0 secrets, no fancy_regex | P2: version mismatch (fixed in this PR) |
| qa-expert | ✅ 624 tests pass, 82.4% guessit fixture rate, no regression | P3: version bump + CHANGELOG (fixed in this PR) |

---

## Files Changed

| File | Change |
|---|---|
| `Cargo.toml` | `version` 2.0.0 → 2.0.1 |
| `Cargo.lock` | Regenerated (hunch entry only) |
| `CHANGELOG.md` | Promote `[Unreleased]` → `[2.0.1]`, add Fixed/CI/Deps sections |
| `docs/src/reference/public-api.md` | Update baseline tag annotation to v2.0.1 |

---

### Deferred items (tracked)
- [ ] #240 — Bundle: v2.0.1 release-time polish (consolidates 4 P3 audit findings)