### PR TITLE
chore: v2.0.1 release-time polish (#240)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,10 @@ name = "hunch"
 version = "2.0.1"
 edition = "2024"
 rust-version = "1.85"
-authors = ["Lijun Zhu"]
 description = "A media filename parser for movies, TV, and anime — built in Rust, inspired by guessit"
 license = "MIT"
 repository = "https://github.com/lijunzh/hunch"
-homepage = "https://github.com/lijunzh/hunch"
+homepage = "https://lijunzh.github.io/hunch/"
 keywords = ["media", "parser", "filename", "movies", "episodes"]
 categories = ["multimedia", "parser-implementations", "command-line-utilities", "text-processing"]
 readme = "README.md"
@@ -16,7 +15,7 @@ readme = "README.md"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "1.1"
+toml = "1"
 log = "0.4"
 
 # CLI-only deps (not pulled in when used as a library)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,14 @@ pub use pipeline::Pipeline;
 /// This is the main entry point for the library. It creates a default
 /// [`Pipeline`] and runs it against the input string.
 ///
+/// # Input
+///
+/// `input` is expected to be a single media filename (or release name),
+/// typically well under 255 bytes — the POSIX `NAME_MAX` for a path
+/// component. There is no hard upper bound; parsing is linear-time and
+/// allocation-bounded, but supplying multi-kilobyte strings is outside
+/// the intended use case.
+///
 /// # Performance
 ///
 /// Creates a new [`Pipeline`] on every call. For batch processing,


### PR DESCRIPTION
Closes #240.

Bundle of low-severity items flagged by AI auditor agents during the v2.0.1 release prep (PR #239), addressed together per the tracking-issue convention.

## Changes

### `Cargo.toml`
- **Drop deprecated `authors` field.** Cargo 1.73+ no longer surfaces it on crates.io; the field is inert manifest noise. _(rust-programmer)_
- **Repoint `homepage` → `https://lijunzh.github.io/hunch/`.** Was duplicating `repository`. The issue suggested `docs.rs/hunch`, but crates.io already auto-links to docs.rs via its **Documentation** button whenever the `documentation` field is unset — so pointing `homepage` there would just reproduce the same duplication the auditor was trying to fix. The GH Pages mdBook covers the user manual, design docs, migration guide, and contributor guides — strictly broader than the rustdoc API reference, and a better fit for a homepage button. _(rust-programmer; deviation from literal recommendation, rationale above)_
- **Relax `toml` dep from `"1.1"` → `"1"`.** Aligns with the major-only bound used by every other dep and unblocks downstreams that pin `toml = "1.0.x"`. _(rust-programmer)_

### `src/lib.rs`
- **Add an `# Input` section to the `hunch()` rustdoc** clarifying the expected input class (single filename, typically <255 bytes — POSIX `NAME_MAX`). No hard upper bound; parsing is linear-time and allocation-bounded, so this is documentation-only — behavior unchanged. _(security-auditor)_

## Resulting crates.io button layout

| Button | URL | Source |
|---|---|---|
| Homepage | `https://lijunzh.github.io/hunch/` | `homepage` (this PR) |
| Repository | `https://github.com/lijunzh/hunch` | `repository` (unchanged) |
| Documentation | `https://docs.rs/hunch` | auto (no field set) |

Three distinct destinations, zero duplication.

## Verification

```
cargo build           ✅
cargo test --lib      ✅ 348 passed
cargo test --doc      ✅ 12 passed, 2 ignored
cargo clippy -D warnings  ✅
cargo doc --no-deps   ✅
```
