### PR TITLE
Fix: Extract title from bracket format with trailing season marker (S2)

### DIFF
--- a/src/properties/title/strategies/cjk_bracket.rs
+++ b/src/properties/title/strategies/cjk_bracket.rs
@@ -53,13 +53,25 @@ impl TitleStrategy for CjkBracket {
         }
 
         let abs_start = filename_start + second_open + 1;
-        let abs_end = filename_start + second_open + 1 + content.len();
+        
+        // Strip trailing season marker (e.g., " S2", " Season 2") from the title.
+        // This handles cases like "[Show Name S2]" where the season is part
+        // of the title bracket but should be extracted separately.
+        let title_content = strip_trailing_season_marker(content);
+        
+        if title_content.is_empty() {
+            return None;
+        }
+
+        let abs_end = filename_start + second_open + 1 + title_content.len();
 
         // Check if this bracket content is already claimed by a tech match.
+        // Season matches inside the title bracket (e.g., "S2" in "[Show S2]")
+        // should not prevent title extraction - they're part of the title.
         let is_claimed = matches.iter().any(|m| {
             !matches!(
                 m.property,
-                Property::ReleaseGroup | Property::Title | Property::Episode
+                Property::ReleaseGroup | Property::Title | Property::Episode | Property::Season
             ) && m.start < abs_end
                 && m.end > abs_start
         });
@@ -71,7 +83,65 @@ impl TitleStrategy for CjkBracket {
             abs_start,
             abs_end,
             Property::Title,
-            content.to_string(),
+            title_content.to_string(),
         ))
+    }
+}
+
+/// Strip trailing season marker like " S2", " Season 2", etc. from title content.
+/// Returns the cleaned title without the season suffix.
+fn strip_trailing_season_marker(content: &str) -> &str {
+    let trimmed = content.trim_end();
+    
+    // Try to match patterns ending with "S" + digits (e.g., "Show S2")
+    if let Some(pos) = trimmed.rfind(' ') {
+        let suffix = &trimmed[pos + 1..];
+        
+        // Match patterns like "S2", "S3", etc. (single or double digit season)
+        if suffix.len() >= 2 && (suffix.starts_with('S') || suffix.starts_with('s')) {
+            let num_part = &suffix[1..];
+            if num_part.chars().all(|c| c.is_ascii_digit()) && !num_part.is_empty() {
+                // Found a season marker like " S2", strip it.
+                return &trimmed[..pos].trim_end();
+            }
+        }
+    }
+    
+    // Try to match " Season N" pattern (case-insensitive)
+    // Look for "Season " followed by digits at the end
+    let trimmed_lower = trimmed.to_lowercase();
+    if let Some(season_pos) = trimmed_lower.rfind("season ") {
+        let after_season = &trimmed[season_pos + 7..]; // skip "Season " (7 chars)
+        if !after_season.is_empty() && after_season.chars().all(|c| c.is_ascii_digit()) {
+            // Found " Season N" pattern, strip it including the space before "Season"
+            return &trimmed[..season_pos].trim_end();
+        }
+    }
+    
+    trimmed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_trailing_season_marker_s2() {
+        assert_eq!(strip_trailing_season_marker("Re Zero kara Hajimeru Isekai Seikatsu S2"), "Re Zero kara Hajimeru Isekai Seikatsu");
+    }
+
+    #[test]
+    fn test_strip_trailing_season_marker_no_suffix() {
+        assert_eq!(strip_trailing_season_marker("Show Name"), "Show Name");
+    }
+
+    #[test]
+    fn test_strip_trailing_season_marker_season_word() {
+        assert_eq!(strip_trailing_season_marker("Show Name Season 2"), "Show Name");
+    }
+
+    #[test]
+    fn test_strip_trailing_season_marker_s10() {
+        assert_eq!(strip_trailing_season_marker("Show S10"), "Show");
     }
 }

--- a/tests/issue_244_title_with_season.rs
+++ b/tests/issue_244_title_with_season.rs
@@ -1,0 +1,100 @@
+//! Regression tests for Issue #244: Anime filenames in bracket format fail to extract title field.
+//!
+//! The bug was that when a title bracket contains a season marker like "S2" 
+//! (e.g., `[Show Name S2]`), the `S_ONLY` pattern would match just "S2" within 
+//! that bracket, creating a Season match inside the title content. The CJK bracket 
+//! strategy then rejected the entire bracket as "claimed" because it found this 
+//! Season match inside.
+//!
+//! The fix:
+//! 1. Allow Season matches inside title brackets (they're part of the title)
+//! 2. Strip trailing season markers like " S2", " Season 2" from the extracted title
+
+use hunch::hunch;
+
+// ── Main issue: S2 in title bracket should extract title correctly ────
+
+#[test]
+fn issue_244_s2_in_title_bracket() {
+    // The exact failing case from issue #244
+    let r = hunch("[DBD-Raws][Re Zero kara Hajimeru Isekai Seikatsu S2][01][1080P][BDRip][HEVC-10bit][FLACx2].mkv");
+    
+    assert_eq!(r.title(), Some("Re Zero kara Hajimeru Isekai Seikatsu"));
+    assert_eq!(r.season(), Some(2));
+    assert_eq!(r.episode(), Some(1));
+    assert_eq!(r.release_group(), Some("DBD-Raws"));
+}
+
+#[test]
+fn issue_244_s3_in_title_bracket() {
+    // Test with S3 as well
+    let r = hunch("[DBD-Raws][Re Zero kara Hajimeru Isekai Seikatsu S3][02][1080P][BDRip].mkv");
+    
+    assert_eq!(r.title(), Some("Re Zero kara Hajimeru Isekai Seikatsu"));
+    assert_eq!(r.season(), Some(3));
+    assert_eq!(r.episode(), Some(2));
+}
+
+#[test]
+fn issue_244_season_word_in_title_bracket() {
+    // Test with "Season 2" instead of "S2"
+    let r = hunch("[DBD-Raws][Re Zero kara Hajimeru Isekai Seikatsu Season 2][01][1080P][BDRip].mkv");
+    
+    assert_eq!(r.title(), Some("Re Zero kara Hajimeru Isekai Seikatsu"));
+    assert_eq!(r.season(), Some(2));
+    assert_eq!(r.episode(), Some(1));
+}
+
+// ── Anti-regression: titles without season markers should still work ────
+
+#[test]
+fn issue_244_no_season_marker_still_works() {
+    // Title without season marker should extract correctly
+    let r = hunch("[DBD-Raws][Re Zero kara Hajimeru Isekai Seikatsu][01][1080P][BDRip].mkv");
+    
+    assert_eq!(r.title(), Some("Re Zero kara Hajimeru Isekai Seikatsu"));
+    // Season should be absent since there's no season marker
+    assert_eq!(r.season(), None);
+}
+
+// ── Anti-regression: titles with additional content after S2 should not strip ────
+
+#[test]
+fn issue_244_s2_with_additional_content() {
+    // When there's additional content after the season marker, don't strip it
+    let r = hunch("[DBD-Raws][Show Name S2 Special][01][1080P].mkv");
+    
+    // "S2 Special" is not just a season marker - it's part of the title
+    assert_eq!(r.title(), Some("Show Name S2 Special"));
+    assert_eq!(r.season(), Some(2));
+}
+
+// ── Anti-regression: mini-animations without season markers ────
+
+#[test]
+fn issue_244_mini_animation_without_season() {
+    // Mini-animations like "Break Time Otto's Diary" should still work
+    let r = hunch("[DBD-Raws][Re Zero Kara Hajimeru Break Time Otto's Diary][01][1080P][BDRip].mkv");
+    
+    assert_eq!(r.title(), Some("Re Zero Kara Hajimeru Break Time Otto's Diary"));
+}
+
+// ── Edge cases: S10, s2 (lowercase) ────
+
+#[test]
+fn issue_244_s10_in_title_bracket() {
+    // Test with double-digit season number
+    let r = hunch("[Group][Show Name S10][01].mkv");
+    
+    assert_eq!(r.title(), Some("Show Name"));
+    assert_eq!(r.season(), Some(10));
+}
+
+#[test]
+fn issue_244_lowercase_s2_in_title_bracket() {
+    // Test with lowercase 's'
+    let r = hunch("[Group][Show Name s2][01].mkv");
+    
+    assert_eq!(r.title(), Some("Show Name"));
+    assert_eq!(r.season(), Some(2));
+}


### PR DESCRIPTION
## Fixes Issue #244

  Anime filenames in bracket format like `[DBD-Raws][Re Zero kara Hajimeru Isekai Seikatsu S2][01]...` were failing to extract the `title` field.

  ### Root Cause
  When the title bracket contained a season marker like "S2", the `S_ONLY` pattern would match just "S2" within that bracket, creating a Season match inside the title content. The CJK
bracket strategy then rejected the entire bracket as "claimed".

  ### Fix
  1. Allow Season matches inside title brackets (they are part of the title)
  2. Strip trailing season markers like " S2", " Season 2" from the extracted title

  ### Changes
  - `src/properties/title/strategies/cjk_bracket.rs`: Updated `is_claimed` check to exclude `Property::Season`, added `strip_trailing_season_marker()` function
  - `tests/issue_244_title_with_season.rs`: New test file with 8 regression tests

  ### Test Results
  All 567 tests pass.