### PR TITLE
Fix #244: title bracket inline season + extras-dir leak + .ass dropped + [menu] case (4 of 6 bugs)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,17 @@ use clap::Parser;
 use hunch::{Confidence, Pipeline};
 
 /// Media file extensions recognized for batch/context scanning.
+///
+/// Includes both video containers and external-subtitle formats. The pipeline
+/// classifies each container correctly via `rules/container.toml`, so subtitle
+/// files share the same code path as videos — they just yield different
+/// `container` / `mimetype` properties. (#244)
 const MEDIA_EXTENSIONS: &[&str] = &[
+    // Video containers
     "mkv", "mp4", "avi", "wmv", "flv", "ts", "m4v", "webm", "ogv", "mov", "mpg", "mpeg", "m2ts",
     "iso", "img", "rmvb", "rm",
+    // External subtitle formats (most common in anime workflows)
+    "srt", "ass", "ssa", "sub", "idx", "vtt", "sup", "smi",
 ];
 
 #[derive(Parser)]

--- a/src/pipeline/context.rs
+++ b/src/pipeline/context.rs
@@ -41,16 +41,29 @@ pub(crate) struct UnclaimedGap {
 ///
 /// Gaps are regions of the input that no `MatchSpan` covers. These are the
 /// candidate regions for title text. The extension (last `.xxx`) is excluded.
+///
+/// **Scope**: only the filename portion of `input` is scanned. Path-prefix
+/// text (everything before the last `/` or `\`) is excluded from gap
+/// analysis because cross-file invariance against path components produces
+/// misleading "titles" — e.g., siblings sharing parent dir `hunch_show2/`
+/// would yield invariant text `"hunch show"`, not the actual show title in
+/// the brackets. The pipeline layer was previously patching this up with a
+/// post-hoc `is_path_dir_name` check; scoping to filename eliminates the
+/// problem at the source. Path-derived title hints are the responsibility
+/// of the explicit `ParentDir` strategy / ancestor-fallback API, which use
+/// directory components deliberately rather than via accidental invariance.
 pub(crate) fn find_unclaimed_gaps(input: &str, matches: &[MatchSpan]) -> Vec<UnclaimedGap> {
     // Sort matches by start position.
     let mut sorted: Vec<(usize, usize)> = matches.iter().map(|m| (m.start, m.end)).collect();
     sorted.sort_by_key(|&(s, _)| s);
 
-    // Find the input region to scan (exclude file extension).
+    // Confine the scan to the filename portion. The path prefix is
+    // structurally unsuitable for invariance analysis (see doc above).
+    let filename_start = crate::filename_start(input);
     let scan_end = strip_extension_pos(input);
 
     let mut gaps = Vec::new();
-    let mut cursor = 0;
+    let mut cursor = filename_start;
 
     for (start, end) in &sorted {
         let start = *start;

--- a/src/pipeline/invariance.rs
+++ b/src/pipeline/invariance.rs
@@ -13,7 +13,7 @@ use std::sync::LazyLock;
 use super::context::{
     SEPS, TRIM_CHARS, UnclaimedGap, find_invariant_text, find_unclaimed_gaps, strip_extension_pos,
 };
-use crate::matcher::span::MatchSpan;
+use crate::matcher::span::{MatchSpan, Property};
 
 // ── InvarianceReport: unified cross-file analysis ─────────────────────────
 // Phase 1 of #52/#53: structs + analysis logic.
@@ -116,9 +116,27 @@ pub(crate) fn analyze_invariance(
         .map(|s| find_unclaimed_gaps(s.input, s.matches))
         .collect();
 
-    // 2. Title: invariant text (existing algorithm).
-    let all_gap_refs: Vec<&[UnclaimedGap]> = std::iter::once(target_gaps.as_slice())
-        .chain(sibling_gaps.iter().map(|v| v.as_slice()))
+    // 2. Title: invariant text in *pre-anchor* gaps only.
+    //
+    //    A gap qualifies as a title candidate only when it precedes the
+    //    first content anchor (Season/Episode/Year) in the filename.
+    //    Rationale: titles structurally appear *before* the
+    //    season/episode/year identifier; text that's invariant *after*
+    //    that identifier is per-episode-title commonality, not show
+    //    title. Without this filter, files like
+    //    `Show/S01E10 - Pups Save Ryder's Robot.mkv` and
+    //    `Show/S01E11 - Pups and the Ghost Pirate.mkv` would yield an
+    //    invariance title of `"Pups"` (the common prefix of two
+    //    episode-title strings) and clobber the correct `"Show"` from
+    //    the parent directory. (#244 follow-up bug A)
+    let target_pre = title_candidate_gaps(&target_gaps, target.input, target.matches);
+    let sibling_pre: Vec<Vec<UnclaimedGap>> = siblings
+        .iter()
+        .zip(&sibling_gaps)
+        .map(|(s, gaps)| title_candidate_gaps(gaps, s.input, s.matches))
+        .collect();
+    let all_gap_refs: Vec<&[UnclaimedGap]> = std::iter::once(target_pre.as_slice())
+        .chain(sibling_pre.iter().map(|v| v.as_slice()))
         .collect();
     let (title, title_start) = match find_invariant_text(&all_gap_refs) {
         Some((start, text)) => (Some(text), Some(start)),
@@ -162,6 +180,49 @@ pub(crate) fn analyze_invariance(
         title_start,
         year_signals,
         episode_signals,
+    }
+}
+
+/// Filter `gaps` to those eligible to contribute a title via invariance.
+///
+/// A gap qualifies when it ends **at or before** the start of the first
+/// content anchor (Season / Episode / Year) in the filename. Anything
+/// after the first such anchor is post-title territory — release-group
+/// noise, episode titles, language tags, etc. — where cross-file
+/// commonality reflects naming convention, not show identity.
+///
+/// Files with **no** content anchor in the filename pass all gaps
+/// through unchanged: the whole filename body is title territory (e.g.
+/// `Movie.Name.2020.mkv` only has a Year, but `Movie.Name.mkv` has none
+/// and the entire stem is fair game).
+///
+/// Path-prefix gaps were already excluded structurally by
+/// [`find_unclaimed_gaps`].
+fn title_candidate_gaps(
+    gaps: &[UnclaimedGap],
+    input: &str,
+    matches: &[MatchSpan],
+) -> Vec<UnclaimedGap> {
+    let fn_start = crate::filename_start(input);
+    let first_anchor = matches
+        .iter()
+        .filter(|m| {
+            m.start >= fn_start
+                && matches!(
+                    m.property,
+                    Property::Season | Property::Episode | Property::Year
+                )
+        })
+        .map(|m| m.start)
+        .min();
+
+    match first_anchor {
+        Some(anchor) => gaps
+            .iter()
+            .filter(|g| find_gap_end_in_input(input, g) <= anchor)
+            .cloned()
+            .collect(),
+        None => gaps.to_vec(),
     }
 }
 

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -54,6 +54,32 @@ use crate::priority;
 use crate::properties::part;
 use crate::properties::release_group;
 use crate::properties::title;
+use crate::properties::title::{TitleConfidence, TitleExtraction};
+
+/// A title supplied to [`Pipeline::pass2`] from outside the file itself.
+///
+/// Two cross-file sources can produce a hint:
+///   - **Invariance**: sibling consensus on filename content
+///     (`source = "invariance"`, `position = Some(byte_offset)` from the
+///     [`InvarianceReport`](invariance::InvarianceReport)).
+///   - **Ancestor fallback**: a title cached from a parent directory
+///     during batch ‑r traversal (`source = "fallback"`, `position = None`
+///     because the text usually doesn't appear verbatim in the input).
+///
+/// The pipeline disambiguates between the two before constructing the
+/// hint (invariance preferred). Pass2 then weighs this hint against the
+/// file's own extraction via [`pick_final_title`].
+///
+/// Replaces the previous `(title_override, last_resort_title)` pair and
+/// the `filename_has_bracket` / `is_path_dir_name` ad-hoc heuristics.
+struct TitleHint {
+    /// The title text.
+    value: String,
+    /// Byte offset of `value` in `input`, when known.
+    position: Option<usize>,
+    /// Where the hint came from (debug/trace logs only).
+    source: &'static str,
+}
 
 /// The two-pass parsing pipeline.
 ///
@@ -193,11 +219,17 @@ impl Pipeline {
             return self.run(input);
         }
 
-        // If we have no siblings but do have a fallback title, run Pass 1
-        // and use the fallback directly in Pass 2.
+        // No siblings but a fallback title: skip invariance, run pass1
+        // and let pass2 weigh the fallback against the file's own
+        // extraction by confidence.
         if siblings.is_empty() {
             let (mut matches, ts, zm) = self.pass1(input);
-            return self.pass2(input, &mut matches, &zm, &ts, fallback_title, None);
+            let hint = fallback_title.map(|fb| TitleHint {
+                value: fb.to_string(),
+                position: None,
+                source: "fallback",
+            });
+            return self.pass2(input, &mut matches, &zm, &ts, hint, None);
         }
 
         // 1. Run Pass 1 on target + all siblings.
@@ -205,6 +237,10 @@ impl Pipeline {
         let sibling_results: Vec<_> = siblings.iter().map(|s| self.pass1(s)).collect();
 
         // 2. Unified invariance analysis (title + year + episode signals).
+        //    Invariance gaps are filename-scoped (see
+        //    `find_unclaimed_gaps`), so any title produced here came
+        //    from actual filename content shared across siblings — not
+        //    from path-prefix accidents.
         let sibling_analyses: Vec<_> = siblings
             .iter()
             .zip(&sibling_results)
@@ -241,108 +277,43 @@ impl Pipeline {
             );
         }
 
-        // 3. Run Pass 2 with invariance report.
-        // If invariance found a title from actual filename content, use it.
-        // If it found a title that's just a directory name from the path,
-        // treat it as weak evidence:
-        //   - Prefer the parent fallback title if available (#94).
-        //   - Otherwise let pass2's normal extractor try first. If pass2
-        //     also fails, use the dir-name title as last resort — an
-        //     imprecise title beats no title (#97).
+        // 3. Pick the title hint to pass to pass2.
         //
-        // **Self-describing files** (#244 follow-up): when the filename
-        // itself contains a bracket group (the dominant convention for
-        // explicit titles in fansub releases), the file is treated as
-        // self-describing. BOTH invariance and ancestor fallback are
-        // demoted from override to last-resort — they only fire if the
-        // file's own extraction returns nothing. This prevents two
-        // failure modes seen in batch -r mode against anime libraries:
-        //   1. Sibling-consensus clobbering distinct sub-show titles
-        //      (e.g. mini-anims under `迷你动画/` getting the parent
-        //      show's title because the parent dir cached it).
-        //   2. Invariance picking up a normalized path-prefix as the
-        //      title (e.g. `hunch_show2/...` → invariance title
-        //      `"hunch show"`) when `is_path_dir_name`'s exact match
-        //      misses the normalization.
-        let invariance_title = report.title.as_deref();
-        let filename_self_describing = filename_has_bracket(input);
-        let (title_hint, last_resort_title) = match (invariance_title, fallback_title) {
-            (Some(inv), _) if filename_self_describing => {
-                // Self-describing file: any cross-file signal (invariance
-                // OR ancestor fallback) is held as last-resort. The
-                // file's own bracket extraction wins if it succeeds.
-                debug!(
-                    "filename has bracket structure — demoting cross-file title {:?} to last-resort (fallback={:?})",
-                    inv, fallback_title
-                );
-                (None, fallback_title.or(Some(inv)))
-            }
-            (Some(inv), _) if is_path_dir_name(input, inv) => {
-                // Invariance only found a directory name. Real invariance
-                // (siblings agreeing on actual filename content) is strong;
-                // dir-name invariance is weak. Prefer ancestor fallback.
-                debug!(
-                    "invariance title {:?} is a directory name — {}",
-                    inv,
-                    fallback_title
-                        .map(|fb| format!("preferring parent fallback {:?}", fb))
-                        .unwrap_or_else(|| "letting pass2 try first".to_string())
-                );
-                // With fallback: use fallback, no last resort needed.
-                // Without fallback: pass2 tries first, dir name is last resort.
-                (
-                    fallback_title,
-                    if fallback_title.is_none() {
-                        Some(inv)
-                    } else {
-                        None
-                    },
-                )
-            }
-            (Some(inv), _) => (Some(inv), None),
-            (None, Some(fb)) if filename_self_describing => {
-                // Self-describing file with no invariance signal: let
-                // pass2 extract from the filename's bracket. The ancestor
-                // fallback is held as last-resort only. (#244 follow-up)
-                debug!(
-                    "filename has bracket structure — demoting ancestor fallback {:?} to last-resort",
-                    fb
-                );
-                (None, Some(fb))
-            }
-            (None, fb) => (fb, None),
+        //    Two cross-file signals exist; both can potentially override
+        //    a Weak extraction. Invariance (sibling consensus on actual
+        //    filename content) is more authoritative than ancestor
+        //    fallback (a parent-dir-derived guess), so it takes priority
+        //    when both are present.
+        //
+        //    Pass2 then resolves the final title by comparing this hint
+        //    against the file's own extraction confidence (see
+        //    [`pick_final_title`]). The pipeline never overrides Strong
+        //    extractions — a self-describing file always wins, because
+        //    second-guessing explicit author markup is exactly the bug
+        //    `filename_has_bracket` was patching around.
+        let title_hint = match (report.title.as_ref(), fallback_title) {
+            (Some(inv), _) => Some(TitleHint {
+                value: inv.clone(),
+                position: report.title_start,
+                source: "invariance",
+            }),
+            (None, Some(fb)) => Some(TitleHint {
+                value: fb.to_string(),
+                position: None,
+                source: "fallback",
+            }),
+            (None, None) => None,
         };
+
         let mut matches = target_matches;
-        let mut result = self.pass2(
+        self.pass2(
             input,
             &mut matches,
             &target_zm,
             &target_ts,
             title_hint,
             Some(&report),
-        );
-
-        // Last resort: if pass2 found no title and we have a dir-name
-        // invariance title stashed, use it — but only if it's a meaningful
-        // name (not a generic category like "movie", "Japanese", "Anime").
-        if result.title().is_none() {
-            if let Some(lr) = last_resort_title {
-                if crate::properties::title::is_generic_dir(lr) {
-                    debug!(
-                        "pass2 found no title — last-resort {:?} is generic, skipping",
-                        lr
-                    );
-                } else {
-                    debug!(
-                        "pass2 found no title — using last-resort dir-name title {:?}",
-                        lr
-                    );
-                    result.set(Property::Title, lr);
-                }
-            }
-        }
-
-        result
+        )
     }
 
     /// Run Pass 1: tokenize → zone map → match → conflict resolve → zone disambiguate.
@@ -452,7 +423,7 @@ impl Pipeline {
         all_matches: &mut Vec<MatchSpan>,
         zone_map: &ZoneMap,
         token_stream: &TokenStream,
-        title_override: Option<&str>,
+        title_hint: Option<TitleHint>,
         report: Option<&invariance::InvarianceReport>,
     ) -> HunchResult {
         // Step 5a: Release group (post-resolution — can see claimed positions).
@@ -483,47 +454,28 @@ impl Pipeline {
         }
 
         // Step 5b: Title extraction.
-        if let Some(override_title) = title_override {
-            // Cross-file context provided a title — use it directly.
-            // Use the pre-computed byte offset from InvarianceReport if available,
-            // falling back to input.find() for backwards compatibility.
-            let title_start = report
-                .and_then(|r| r.title_start)
-                .or_else(|| input.find(override_title));
-            if let Some(start) = title_start {
-                let (start, end) = pass2_helpers::compute_override_title_span(
-                    start,
-                    override_title.len(),
-                    input.len(),
-                );
-                let title_match = MatchSpan::new(start, end, Property::Title, override_title);
-                debug!(
-                    "step 5b: title override — \"{}\" at {}..{}",
-                    title_match.value, title_match.start, title_match.end
-                );
-                title::absorb_reclaimable(&title_match, all_matches);
-                all_matches.push(title_match);
-            } else {
-                // Title text not found verbatim — set it without a byte range.
-                debug!(
-                    "step 5b: title override (no byte range) — \"{}\"",
-                    override_title
-                );
-                all_matches.push(MatchSpan::new(0, 0, Property::Title, override_title));
-            }
-        } else if let Some(title_match) =
-            title::extract_title(input, all_matches, zone_map, token_stream)
-        {
+        //
+        // The pipeline orchestrates between three possible title sources:
+        //   1. The file's own pass2 extraction (with declared
+        //      `TitleConfidence`).
+        //   2. A cross-file `title_hint` (invariance OR ancestor
+        //      fallback, already disambiguated by the caller).
+        //
+        // [`pick_final_title`] applies the precedence:
+        //   - Strong extraction always wins (file is self-describing).
+        //   - Otherwise, hint wins if present.
+        //   - Otherwise, weak extraction is used.
+        //   - Otherwise, no title.
+        let extraction = title::extract_title(input, all_matches, zone_map, token_stream);
+        if let Some(final_title) = pick_final_title(input, extraction, title_hint.as_ref()) {
             debug!(
-                "step 5b: title extracted — \"{}\" at {}..{}",
-                title_match.value, title_match.start, title_match.end
+                "step 5b: title → {:?} at {}..{}",
+                final_title.value, final_title.start, final_title.end
             );
-            // Remove reclaimable matches absorbed into the title.
-            // (This is also where Part matches inside anime titles like
-            // "Show Part 2 - 13" get dropped — they were marked reclaimable
-            // in pass1 step 4b when an Episode was present.)
-            title::absorb_reclaimable(&title_match, all_matches);
-            all_matches.push(title_match);
+            // Reclaimables inside the title span (e.g. `Part N` in anime
+            // titles, or `3D` in `Pacific.Rim.3D`) get absorbed.
+            title::absorb_reclaimable(&final_title, all_matches);
+            all_matches.push(final_title);
         }
         // Film title: when -fNN- marker exists, split franchise from movie title.
         if let Some((film_title, adjusted_title)) =
@@ -591,7 +543,7 @@ impl Pipeline {
 
         // Step 7: Compute confidence.
         let confidence =
-            pass2_helpers::compute_confidence(&result, title_override.is_some(), all_matches);
+            pass2_helpers::compute_confidence(&result, title_hint.is_some(), all_matches);
         result.set_confidence(confidence);
         debug!("step 7: confidence = {:?}", confidence);
 
@@ -668,129 +620,87 @@ impl Pipeline {
     }
 }
 
-/// Returns `true` when the **filename** portion of `input` contains a
-/// `[` — the dominant convention for explicit titles in fansub/anime
-/// releases (`[Group][Title][Episode][Quality]...`).
+/// Pick the final title from the file's own extraction and an optional
+/// cross-file [`TitleHint`].
 ///
-/// Used by [`Pipeline::run_with_context_and_fallback_inner`] to decide
-/// whether a file is "self-describing" enough that ancestor-directory
-/// fallback should defer to the file's own title extraction. Files
-/// without brackets (e.g. `Show.S01E01.mkv`, `Special.720p.mkv`) keep
-/// the legacy behavior where ancestor fallback overrides extraction.
-/// (#244 follow-up)
+/// Precedence (highest first):
+/// 1. **Strong extraction.** The file declared its own title via an
+///    explicit structural marker (bracket group, year/episode anchor,
+///    structural separator). The author is self-describing; second-
+///    guessing them is exactly the bug `filename_has_bracket` was
+///    patching around. Hint is ignored.
+/// 2. **Hint.** No strong self-description was found. The cross-file
+///    signal (invariance OR ancestor fallback, already prioritized by
+///    the caller) wins.
+/// 3. **Weak extraction.** No hint either. Use whatever residual title
+///    the file produced.
+/// 4. **Nothing.** Pass2 produced no title; no hint exists.
 ///
-/// Only the filename component is checked — bracket characters in
-/// parent directory names (a common artifact of release-group dir
-/// naming like `[DBD-Raws][Show]/file.mkv`) do **not** count.
-fn filename_has_bracket(input: &str) -> bool {
-    let fn_start = crate::filename_start(input);
-    input[fn_start..].contains('[')
-}
-
-/// Check whether `title` is derived from directory components of `input`.
-///
-/// Returns `true` when the invariance title is:
-/// - An exact match to a single directory component (e.g., `"特典映像"`)
-/// - A concatenation of consecutive directory components joined by spaces
-///   (e.g., `"夏目友人帐 特典映像"` from path `夏目友人帐/特典映像/file.mkv`)
-/// - Composed entirely of directory components, even non-consecutive
-///   (e.g., `"Anime  特典映像"` from `tv/Anime/ShowDir/特典映像/file.mkv`
-///   where `ShowDir` was consumed by matchers, leaving a double space) (#97)
-///
-/// When the invariance engine finds a title that came from directory
-/// structure rather than filename content, it's weak evidence. The caller
-/// can then prefer a fallback title or let pass2 extract from the filename.
-///
-/// Comparison is case-insensitive.
-fn is_path_dir_name(input: &str, title: &str) -> bool {
-    use std::path::Path;
-    let path = Path::new(input);
-    let title_lower = title.to_lowercase();
-
-    // Collect directory components (excluding the filename itself).
-    let dir_names: Vec<String> = path
-        .ancestors()
-        .skip(1) // skip the file itself
-        .filter_map(|a| a.file_name().and_then(|n| n.to_str()))
-        .map(|n| n.to_lowercase())
-        .collect();
-
-    // 1. Exact match to a single directory component.
-    if dir_names.contains(&title_lower) {
-        return true;
-    }
-
-    // 2. Concatenation of consecutive directory components (space-joined).
-    //    The path produces components in reverse (child → parent), so
-    //    reverse to get parent → child order, then check all contiguous
-    //    subsequences.
-    let ordered: Vec<&str> = dir_names.iter().rev().map(|s| s.as_str()).collect();
-    for start in 0..ordered.len() {
-        let mut concat = String::new();
-        for component in ordered.iter().skip(start) {
-            if !concat.is_empty() {
-                concat.push(' ');
-            }
-            concat.push_str(component);
-            if concat == title_lower {
-                return true;
-            }
+/// When the hint wins, this function locates its byte span in `input`
+/// (using `hint.position` if available, then a verbatim `find`, finally
+/// falling back to a zero-width span at offset 0 when the text doesn't
+/// appear literally — e.g. a normalized fallback like `"Paw Patrol"`
+/// against an input like `"Paw Patrol/SP/Special.720p.mkv"` *will* be
+/// found, but normalized titles often won't).
+fn pick_final_title(
+    input: &str,
+    extraction: Option<TitleExtraction>,
+    hint: Option<&TitleHint>,
+) -> Option<MatchSpan> {
+    match (extraction, hint) {
+        // Strong extraction beats any hint.
+        (Some(ex), _) if ex.confidence == TitleConfidence::Strong => {
+            trace!(
+                "title decision: STRONG extraction wins ({:?}); hint discarded",
+                ex.span.value
+            );
+            Some(ex.span)
+        }
+        // No strong self-description — use the hint when present.
+        (ex, Some(h)) => {
+            trace!(
+                "title decision: hint wins (source={}, value={:?}); extraction was {:?}",
+                h.source,
+                h.value,
+                ex.as_ref().map(|e| (&e.span.value, e.confidence))
+            );
+            Some(hint_to_match(input, h))
+        }
+        // No hint, use weak extraction if any.
+        (Some(ex), None) => {
+            trace!(
+                "title decision: weak extraction wins ({:?}); no hint available",
+                ex.span.value
+            );
+            Some(ex.span)
+        }
+        (None, None) => {
+            trace!("title decision: no extraction, no hint — no title");
+            None
         }
     }
+}
 
-    // 3. All-parts check: every non-empty whitespace-delimited part of
-    //    the title is a directory component. Catches non-consecutive dir
-    //    names joined by double spaces (e.g., "Anime  特典映像" from
-    //    tv/Anime/ShowDir/特典映像/ where ShowDir was consumed). (#97)
-    let parts: Vec<&str> = title_lower.split_whitespace().collect();
-    if parts.len() >= 2 && parts.iter().all(|part| dir_names.iter().any(|d| d == part)) {
-        return true;
+/// Materialize a [`TitleHint`] into a [`MatchSpan`], locating its byte
+/// span in `input` if possible.
+fn hint_to_match(input: &str, hint: &TitleHint) -> crate::matcher::span::MatchSpan {
+    use crate::matcher::span::{MatchSpan, Property};
+
+    let value = hint.value.as_str();
+    let position = hint.position.or_else(|| input.find(value));
+    if let Some(start) = position {
+        let (start, end) =
+            pass2_helpers::compute_override_title_span(start, value.len(), input.len());
+        MatchSpan::new(start, end, Property::Title, value)
+    } else {
+        // Title text not in input verbatim — emit a zero-width span.
+        MatchSpan::new(0, 0, Property::Title, value)
     }
-
-    false
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_is_path_dir_name() {
-        // Single directory component match.
-        assert!(is_path_dir_name("夏目友人帐/特典映像/file.mkv", "特典映像"));
-        assert!(is_path_dir_name(
-            "夏目友人帐/特典映像/file.mkv",
-            "夏目友人帐"
-        ));
-        assert!(is_path_dir_name("ShowDir/Extras/file.mkv", "Extras"));
-        assert!(is_path_dir_name("ShowDir/Extras/file.mkv", "ShowDir"));
-        // Case-insensitive.
-        assert!(is_path_dir_name("ShowDir/file.mkv", "showdir"));
-        // Compound: consecutive dir names joined by space.
-        assert!(is_path_dir_name(
-            "夏目友人帐/特典映像/file.mkv",
-            "夏目友人帐 特典映像"
-        ));
-        assert!(is_path_dir_name(
-            "Show/Season 1/Extras/file.mkv",
-            "Show Season 1"
-        ));
-        // Filename itself should NOT match.
-        assert!(!is_path_dir_name("ShowDir/file.mkv", "file"));
-        // Text not in path should NOT match.
-        assert!(!is_path_dir_name("ShowDir/file.mkv", "OtherDir"));
-        // Non-contiguous dir names should match via all-parts check (#97).
-        assert!(is_path_dir_name(
-            "tv/Anime/ShowDir/特典映像/file.mkv",
-            "Anime  特典映像"
-        ));
-        assert!(is_path_dir_name("A/B/C/file.mkv", "A C"));
-        assert!(is_path_dir_name("A/B/C/file.mkv", "A  C"));
-        // Single word that is NOT a dir name should NOT match.
-        assert!(!is_path_dir_name("A/B/C/file.mkv", "D E"));
-        // Mixed: one part is a dir, the other isn't.
-        assert!(!is_path_dir_name("A/B/C/file.mkv", "A D"));
-    }
 
     // ---- match_overlaps_any_title_year ----
     //

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -249,9 +249,38 @@ impl Pipeline {
         //   - Otherwise let pass2's normal extractor try first. If pass2
         //     also fails, use the dir-name title as last resort — an
         //     imprecise title beats no title (#97).
+        //
+        // **Self-describing files** (#244 follow-up): when the filename
+        // itself contains a bracket group (the dominant convention for
+        // explicit titles in fansub releases), the file is treated as
+        // self-describing. BOTH invariance and ancestor fallback are
+        // demoted from override to last-resort — they only fire if the
+        // file's own extraction returns nothing. This prevents two
+        // failure modes seen in batch -r mode against anime libraries:
+        //   1. Sibling-consensus clobbering distinct sub-show titles
+        //      (e.g. mini-anims under `迷你动画/` getting the parent
+        //      show's title because the parent dir cached it).
+        //   2. Invariance picking up a normalized path-prefix as the
+        //      title (e.g. `hunch_show2/...` → invariance title
+        //      `"hunch show"`) when `is_path_dir_name`'s exact match
+        //      misses the normalization.
         let invariance_title = report.title.as_deref();
+        let filename_self_describing = filename_has_bracket(input);
         let (title_hint, last_resort_title) = match (invariance_title, fallback_title) {
+            (Some(inv), _) if filename_self_describing => {
+                // Self-describing file: any cross-file signal (invariance
+                // OR ancestor fallback) is held as last-resort. The
+                // file's own bracket extraction wins if it succeeds.
+                debug!(
+                    "filename has bracket structure — demoting cross-file title {:?} to last-resort (fallback={:?})",
+                    inv, fallback_title
+                );
+                (None, fallback_title.or(Some(inv)))
+            }
             (Some(inv), _) if is_path_dir_name(input, inv) => {
+                // Invariance only found a directory name. Real invariance
+                // (siblings agreeing on actual filename content) is strong;
+                // dir-name invariance is weak. Prefer ancestor fallback.
                 debug!(
                     "invariance title {:?} is a directory name — {}",
                     inv,
@@ -271,6 +300,16 @@ impl Pipeline {
                 )
             }
             (Some(inv), _) => (Some(inv), None),
+            (None, Some(fb)) if filename_self_describing => {
+                // Self-describing file with no invariance signal: let
+                // pass2 extract from the filename's bracket. The ancestor
+                // fallback is held as last-resort only. (#244 follow-up)
+                debug!(
+                    "filename has bracket structure — demoting ancestor fallback {:?} to last-resort",
+                    fb
+                );
+                (None, Some(fb))
+            }
             (None, fb) => (fb, None),
         };
         let mut matches = target_matches;
@@ -627,6 +666,25 @@ impl Pipeline {
 
         matches
     }
+}
+
+/// Returns `true` when the **filename** portion of `input` contains a
+/// `[` — the dominant convention for explicit titles in fansub/anime
+/// releases (`[Group][Title][Episode][Quality]...`).
+///
+/// Used by [`Pipeline::run_with_context_and_fallback_inner`] to decide
+/// whether a file is "self-describing" enough that ancestor-directory
+/// fallback should defer to the file's own title extraction. Files
+/// without brackets (e.g. `Show.S01E01.mkv`, `Special.720p.mkv`) keep
+/// the legacy behavior where ancestor fallback overrides extraction.
+/// (#244 follow-up)
+///
+/// Only the filename component is checked — bracket characters in
+/// parent directory names (a common artifact of release-group dir
+/// naming like `[DBD-Raws][Show]/file.mkv`) do **not** count.
+fn filename_has_bracket(input: &str) -> bool {
+    let fn_start = crate::filename_start(input);
+    input[fn_start..].contains('[')
 }
 
 /// Check whether `title` is derived from directory components of `input`.

--- a/src/properties/title/clean.rs
+++ b/src/properties/title/clean.rs
@@ -534,6 +534,26 @@ pub(crate) fn is_generic_dir(name: &str) -> bool {
             | "特典"      // tokuten — bonus/extras (JP)
             | "映像特典"  // eizou tokuten — video bonus (JP)
             | "sp"
+            // Anime-extras structural directory names. Real-world layouts:
+            //   Show/PV/file.mkv, Show/NCOP&NCED/file.mkv, Show/menu/file.mkv
+            // These are STRUCTURAL groupings (preview clips, creditless
+            // openings/endings, BD menu screens) — not the show title.
+            // Without this list, parent_dir would leak "PV"/"menu"/etc.
+            // as the title in --batch -r mode. (#244)
+            | "pv"
+            | "op"
+            | "ed"
+            | "ncop"
+            | "nced"
+            | "ncop&nced"
+            | "nced&ncop"
+            | "menu"
+            | "menus"
+            | "ova"
+            | "oad"
+            | "ona"
+            | "cm"
+            | "tokuten"
             // Subtitles / audio
             | "subs"
             | "subtitles"

--- a/src/properties/title/clean.rs
+++ b/src/properties/title/clean.rs
@@ -274,8 +274,14 @@ static RE_TRAILING_PART: LazyLock<regex::Regex> = LazyLock::new(|| {
 });
 
 static RE_TRAILING_SEASON: LazyLock<regex::Regex> = LazyLock::new(|| {
+    // Matches trailing season tokens in two flavors:
+    //   1. Long form: `Season 2`, `Saison 2`, `Stagione II`, `Temporada 3 & 4`, ...
+    //   2. Short form: `S2`, `S03`, `S10` (anime fansub convention).
+    //
+    // The short form is anchored with `\b` and bounded to 1-3 digits so it
+    // doesn't eat trailing words like `Inus` (which ends in `s`) or `Spider-Man`.
     regex::Regex::new(
-        r"(?i)\s+(?:Saison|Temporada|Stagione|Tem\.?|Season|Seasons?)\s*(?:I{1,4}|IV|VI{0,3}|IX|X{0,3}|[0-9]+)?(?:\s*(?:&|and)\s*(?:I{1,4}|IV|VI{0,3}|IX|X{0,3}|[0-9]+))?\s*$"
+        r"(?i)\s+(?:S\d{1,3}|(?:Saison|Temporada|Stagione|Tem\.?|Season|Seasons?)\s*(?:I{1,4}|IV|VI{0,3}|IX|X{0,3}|[0-9]+)?(?:\s*(?:&|and)\s*(?:I{1,4}|IV|VI{0,3}|IX|X{0,3}|[0-9]+))?)\s*$"
     ).expect("RE_TRAILING_SEASON regex is valid")
 });
 

--- a/src/properties/title/mod.rs
+++ b/src/properties/title/mod.rs
@@ -18,10 +18,10 @@ mod clean;
 mod secondary;
 mod strategies;
 
-pub(crate) use clean::is_generic_dir;
 pub use secondary::{
     extract_alternative_titles, extract_episode_title, extract_film_title, infer_media_type,
 };
+pub use strategies::{TitleConfidence, TitleExtraction};
 
 use crate::FILENAME_SEPS as SEPS;
 use crate::matcher::span::{MatchSpan, Property};
@@ -61,12 +61,24 @@ fn is_tech_property(p: Property) -> bool {
 /// Reclaimable matches (marked by TOML `requires_nearby`) are transparent
 /// to the title boundary: they don't stop the title, and if absorbed into
 /// the title span they are removed from `matches`.
+/// Extract title from the input string by finding the gap before the first
+/// recognized match. This is a post-processing step, not a `PropertyMatcher`.
+///
+/// The `zone_map` is used for year-as-title disambiguation (e.g., "2001" in
+/// "2001.A.Space.Odyssey.1968" is a title word, not the release year).
+///
+/// to the title boundary: they don't stop the title, and if absorbed into
+/// the title span they are removed from `matches`.
+///
+/// Returns a [`TitleExtraction`] pairing the title span with a confidence
+/// score that the pipeline uses to decide whether cross-file context
+/// (invariance, ancestor fallback) should override this title.
 pub fn extract_title(
     input: &str,
     matches: &[MatchSpan],
     zone_map: &ZoneMap,
     _token_stream: &TokenStream,
-) -> Option<MatchSpan> {
+) -> Option<TitleExtraction> {
     let filename_start = input.rfind(['/', '\\']).map(|i| i + 1).unwrap_or(0);
     let filename = &input[filename_start..];
 
@@ -115,10 +127,31 @@ pub fn extract_title(
     let raw_title = &input[filename_start..title_end_abs];
 
     // Truncate at structural separators (" - ", "--", "(").
-    let title_end_abs = find_first_structural_separator(raw_title)
+    let structural_sep_offset = find_first_structural_separator(raw_title);
+    let title_end_abs = structural_sep_offset
         .map(|offset| filename_start + offset)
         .unwrap_or(title_end_abs);
     let raw_title = &input[filename_start..title_end_abs];
+
+    // Confidence classification for the residual extractor.
+    //
+    // Strong: the title was bounded by an explicit author-placed marker
+    //   - a structural separator (" - ", "(", "--")
+    //   - a content property (Year, Season, Episode, Part, ...)
+    //   The file is self-describing.
+    //
+    // Weak: the title is just "the bytes before the first tech token"
+    //   or "the bytes before the extension" — no deliberate marker. A
+    //   filename like `Special.720p.mkv` extracts "Special" as a Weak
+    //   title, and the pipeline will prefer ancestor fallback if any.
+    let confidence = if structural_sep_offset.is_some() {
+        TitleConfidence::Strong
+    } else {
+        match first_match_in_filename {
+            Some(m) if !is_tech_property(m.property) => TitleConfidence::Strong,
+            _ => TitleConfidence::Weak,
+        }
+    };
 
     let cleaned = clean_title(raw_title);
 
@@ -146,11 +179,9 @@ pub fn extract_title(
     {
         let best = pick_better_casing(&cleaned, &parent_match.value);
         if best != cleaned {
-            return Some(MatchSpan::new(
-                filename_start,
-                title_end_abs,
-                Property::Title,
-                best,
+            return Some(TitleExtraction::new(
+                MatchSpan::new(filename_start, title_end_abs, Property::Title, best),
+                confidence,
             ));
         }
     }
@@ -164,14 +195,15 @@ pub fn extract_title(
             filename_start,
         })
     {
-        return Some(parent_title);
+        return Some(TitleExtraction::new(
+            parent_title,
+            strategies::ParentDir.confidence(),
+        ));
     }
 
-    Some(MatchSpan::new(
-        filename_start,
-        title_end_abs,
-        Property::Title,
-        cleaned,
+    Some(TitleExtraction::new(
+        MatchSpan::new(filename_start, title_end_abs, Property::Title, cleaned),
+        confidence,
     ))
 }
 
@@ -197,14 +229,15 @@ fn handle_empty_title(
     matches: &[MatchSpan],
     zone_map: &ZoneMap,
     first_match_in_filename: Option<&MatchSpan>,
-) -> Option<MatchSpan> {
+) -> Option<TitleExtraction> {
     // Year-as-title via ZoneMap: e.g., "2001" in "2001.A.Space.Odyssey.1968".
     if let Some(ref yi) = zone_map.year
         && let Some(ty) = yi.title_years.iter().find(|ty| ty.start == filename_start)
         && let Some(title) =
             extract_title_after_position(input, ty.end, filename_start, filename, matches)
     {
-        return Some(title);
+        // Year-anchored title is a structural marker.
+        return Some(TitleExtraction::new(title, TitleConfidence::Strong));
     }
     // Fallback: first match is a Year at filename start.
     if let Some(first_m) = first_match_in_filename
@@ -213,7 +246,7 @@ fn handle_empty_title(
         && let Some(title) =
             extract_title_after_position(input, first_m.end, filename_start, filename, matches)
     {
-        return Some(title);
+        return Some(TitleExtraction::new(title, TitleConfidence::Strong));
     }
     // Leading tech tokens at filename start (e.g., "h265 - HEVC Riddick...").
     // Skip past all contiguous tech matches at the start to find the title gap.
@@ -239,14 +272,18 @@ fn handle_empty_title(
         if let Some(title) =
             extract_title_after_position(input, skip_end, filename_start, filename, matches)
         {
-            return Some(title);
+            // Bounded by tech only — weak (residual extraction).
+            return Some(TitleExtraction::new(title, TitleConfidence::Weak));
         }
     }
     // Single short word with no path/extension → treat as title.
     if !input.contains(['/', '\\']) && !input.contains('.') && input.len() <= 10 {
         let cleaned = clean_title(input);
         if !cleaned.is_empty() {
-            return Some(MatchSpan::new(0, input.len(), Property::Title, cleaned));
+            return Some(TitleExtraction::new(
+                MatchSpan::new(0, input.len(), Property::Title, cleaned),
+                TitleConfidence::Weak,
+            ));
         }
     }
     // Unclaimed bracket content: when everything is in brackets and one
@@ -258,9 +295,14 @@ fn handle_empty_title(
         filename_start,
     };
     if let Some(title) = strategies::UnclaimedBracket.try_extract(&ctx) {
-        return Some(title);
+        return Some(TitleExtraction::new(
+            title,
+            strategies::UnclaimedBracket.confidence(),
+        ));
     }
-    strategies::ParentDir.try_extract(&ctx)
+    strategies::ParentDir
+        .try_extract(&ctx)
+        .map(|t| TitleExtraction::new(t, strategies::ParentDir.confidence()))
 }
 
 /// Extract title from position `start` to the next match in the filename.
@@ -408,7 +450,7 @@ mod tests {
         let zm = test_zone_map(input);
         let ts = test_ts(input);
         let title = extract_title(input, &matches, &zm, &ts).unwrap();
-        assert_eq!(title.value, "The Matrix");
+        assert_eq!(title.span.value, "The Matrix");
     }
 
     #[test]
@@ -417,7 +459,7 @@ mod tests {
         let zm = test_zone_map(input);
         let ts = test_ts(input);
         let title = extract_title(input, &[], &zm, &ts).unwrap();
-        assert_eq!(title.value, "JustATitle");
+        assert_eq!(title.span.value, "JustATitle");
     }
 
     #[test]
@@ -427,7 +469,7 @@ mod tests {
         let zm = test_zone_map(input);
         let ts = test_ts(input);
         let title = extract_title(input, &matches, &zm, &ts).unwrap();
-        assert_eq!(title.value, "The Movie");
+        assert_eq!(title.span.value, "The Movie");
     }
 
     #[test]
@@ -438,7 +480,7 @@ mod tests {
         let ts = test_ts(input);
         let title = extract_title(input, &matches, &zm, &ts);
         assert!(title.is_some());
-        assert_eq!(title.unwrap().value, "Alice in Wonderland");
+        assert_eq!(title.unwrap().span.value, "Alice in Wonderland");
     }
 
     #[test]
@@ -458,9 +500,9 @@ mod tests {
         let zm = test_zone_map(input);
         let ts = test_ts(input);
         let title = extract_title(input, &matches, &zm, &ts).unwrap();
-        assert_eq!(title.value, "Harold And Kumar 3D Christmas");
+        assert_eq!(title.span.value, "Harold And Kumar 3D Christmas");
         // Absorb should remove the reclaimable match.
-        absorb_reclaimable(&title, &mut matches);
+        absorb_reclaimable(&title.span, &mut matches);
         assert!(matches.is_empty(), "reclaimable 3D should be absorbed");
     }
 
@@ -474,7 +516,7 @@ mod tests {
         let zm = test_zone_map(input);
         let ts = test_ts(input);
         let title = extract_title(input, &matches, &zm, &ts).unwrap();
-        assert_eq!(title.value, "Pacific Rim");
+        assert_eq!(title.span.value, "Pacific Rim");
     }
 
     #[test]

--- a/src/properties/title/strategies/after_bracket_group.rs
+++ b/src/properties/title/strategies/after_bracket_group.rs
@@ -10,13 +10,20 @@ use crate::matcher::span::{MatchSpan, Property};
 
 use super::super::clean::{clean_title, clean_title_preserve_dashes};
 use super::super::find_first_structural_separator;
-use super::{StrategyContext, TitleStrategy};
+use super::{StrategyContext, TitleConfidence, TitleStrategy};
 
 pub(crate) struct AfterBracketGroup;
 
 impl TitleStrategy for AfterBracketGroup {
     fn name(&self) -> &'static str {
         "after_bracket_group"
+    }
+
+    /// Anime `[Group] Title - Ep [tags]` is a deliberate convention
+    /// with the title bounded by an explicit episode marker. The author
+    /// is self-describing.
+    fn confidence(&self) -> TitleConfidence {
+        TitleConfidence::Strong
     }
 
     fn try_extract(&self, ctx: &StrategyContext<'_>) -> Option<MatchSpan> {

--- a/src/properties/title/strategies/cjk_bracket.rs
+++ b/src/properties/title/strategies/cjk_bracket.rs
@@ -5,6 +5,7 @@
 
 use crate::matcher::span::{MatchSpan, Property};
 
+use super::super::clean::clean_title;
 use super::{StrategyContext, TitleStrategy};
 
 pub(crate) struct CjkBracket;
@@ -56,10 +57,16 @@ impl TitleStrategy for CjkBracket {
         let abs_end = filename_start + second_open + 1 + content.len();
 
         // Check if this bracket content is already claimed by a tech match.
+        //
+        // Season/Episode matches inside the title bracket (e.g., `S2` in
+        // `[Re Zero ... Seikatsu S2]`) do NOT disqualify the bracket from
+        // being the title — they're inline metadata that lives ALONGSIDE
+        // the title, not a competing claim on it. Trailing `S2`/`Season N`
+        // is then stripped by `clean_title` via `RE_TRAILING_SEASON`. (#244)
         let is_claimed = matches.iter().any(|m| {
             !matches!(
                 m.property,
-                Property::ReleaseGroup | Property::Title | Property::Episode
+                Property::ReleaseGroup | Property::Title | Property::Season | Property::Episode
             ) && m.start < abs_end
                 && m.end > abs_start
         });
@@ -67,11 +74,15 @@ impl TitleStrategy for CjkBracket {
             return None;
         }
 
-        Some(MatchSpan::new(
-            abs_start,
-            abs_end,
-            Property::Title,
-            content.to_string(),
-        ))
+        // Run the bracket content through the standard title-cleaning
+        // pipeline. This strips trailing `S2` / `Season N` / `Part N` /
+        // bonus markers using the same regexes used by every other title
+        // path — no parallel implementation. (#244)
+        let cleaned = clean_title(content);
+        if cleaned.is_empty() {
+            return None;
+        }
+
+        Some(MatchSpan::new(abs_start, abs_end, Property::Title, cleaned))
     }
 }

--- a/src/properties/title/strategies/cjk_bracket.rs
+++ b/src/properties/title/strategies/cjk_bracket.rs
@@ -6,13 +6,21 @@
 use crate::matcher::span::{MatchSpan, Property};
 
 use super::super::clean::clean_title;
-use super::{StrategyContext, TitleStrategy};
+use super::{StrategyContext, TitleConfidence, TitleStrategy};
 
 pub(crate) struct CjkBracket;
 
 impl TitleStrategy for CjkBracket {
     fn name(&self) -> &'static str {
         "cjk_bracket"
+    }
+
+    /// `[Group][Title][Episode]` is a deliberate, structurally-marked
+    /// title in the dominant fansub convention. The author placed the
+    /// title inside a bracket bounded by an episode anchor — about as
+    /// explicit a self-description as a filename can be.
+    fn confidence(&self) -> TitleConfidence {
+        TitleConfidence::Strong
     }
 
     fn try_extract(&self, ctx: &StrategyContext<'_>) -> Option<MatchSpan> {

--- a/src/properties/title/strategies/mod.rs
+++ b/src/properties/title/strategies/mod.rs
@@ -46,9 +46,65 @@ pub(super) use cjk_bracket::CjkBracket;
 pub(super) use parent_dir::ParentDir;
 pub(super) use unclaimed_bracket::UnclaimedBracket;
 
+/// How much the pipeline should trust an extracted title.
+///
+/// The pipeline orchestrates between three title sources:
+///   1. The file's own pass2 extraction (this enum).
+///   2. Cross-file invariance (sibling consensus).
+///   3. Ancestor fallback (a parent directory's cached title).
+///
+/// Confidence determines who wins when multiple sources disagree. The
+/// general rule: **a structurally-marked self-description beats any
+/// external hint, because the file is asserting its own identity.**
+///
+/// Replaces the previous `filename_has_bracket` heuristic with a
+/// per-strategy declaration of strength.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TitleConfidence {
+    /// Positional / residual extraction. The title is whatever bytes
+    /// remained after other matchers consumed structural tokens. There
+    /// was no explicit syntactic marker (bracket group, structural
+    /// separator, etc.) bounding the title — just "the leftover".
+    ///
+    /// Examples:
+    ///   - `Special.720p.mkv` → "Special" (just the bytes before tech)
+    ///   - `Interview.720p.mkv` → "Interview"
+    ///   - `S01E01.mkv` with no other content → ParentDir last resort
+    ///
+    /// Weak signals lose to ancestor fallback and to invariance.
+    Weak,
+
+    /// Title bounded by a structural marker that the file author
+    /// deliberately placed: a bracket group (`[Title]`), a structural
+    /// separator (` - `), an explicit episode/season/year anchor, or a
+    /// fansub convention like `[Group][Title][Ep]`.
+    ///
+    /// Examples:
+    ///   - `[DBD-Raws][Otto's Diary][01].mkv` → CJK bracket
+    ///   - `[Group] Title - 01 [tags].mkv` → AfterBracketGroup
+    ///   - `Show.Name.S01E01.mkv` → dotted with explicit episode anchor
+    ///
+    /// The file is self-describing. Beats invariance and ancestor
+    /// fallback — we don't second-guess the author's explicit markup.
+    Strong,
+}
+
+/// A title extraction result paired with its confidence.
+#[derive(Debug, Clone)]
+pub struct TitleExtraction {
+    pub span: MatchSpan,
+    pub confidence: TitleConfidence,
+}
+
+impl TitleExtraction {
+    pub(super) fn new(span: MatchSpan, confidence: TitleConfidence) -> Self {
+        Self { span, confidence }
+    }
+}
+
 /// Inputs every strategy needs. Bundled into a struct so adding a new
 /// piece of context (e.g. `zone_map`) is a one-line change to every
-/// strategy signature \u2014 not N.
+/// strategy signature — not N.
 pub(super) struct StrategyContext<'a> {
     pub input: &'a str,
     pub matches: &'a [MatchSpan],
@@ -63,6 +119,10 @@ pub(super) trait TitleStrategy: Sync {
     /// Short, debug-friendly identifier (e.g. `"cjk_bracket"`). Used in
     /// trace logs to explain *which* strategy claimed the title.
     fn name(&self) -> &'static str;
+
+    /// How much the pipeline should trust this strategy's extraction.
+    /// See [`TitleConfidence`] for the semantic contract.
+    fn confidence(&self) -> TitleConfidence;
 
     /// Try to produce a title match. Return `None` if the strategy does
     /// not apply to this input (the next strategy in the ladder is then
@@ -90,18 +150,22 @@ pub(super) static FALLBACK_STRATEGIES: &[&dyn TitleStrategy] = &[
     &ParentDir,
 ];
 
-/// Run the ladder; return the first hit.
-pub(super) fn run_fallback_ladder(ctx: &StrategyContext<'_>) -> Option<MatchSpan> {
+/// Run the ladder; return the first hit paired with that strategy's
+/// declared confidence. The pipeline uses the confidence to decide
+/// whether cross-file context (invariance, ancestor fallback) should
+/// override this title.
+pub(super) fn run_fallback_ladder(ctx: &StrategyContext<'_>) -> Option<TitleExtraction> {
     for strategy in FALLBACK_STRATEGIES {
         if let Some(title) = strategy.try_extract(ctx) {
             trace!(
-                "title fallback: {} claimed {:?} at {}..{}",
+                "title fallback: {} ({:?}) claimed {:?} at {}..{}",
                 strategy.name(),
+                strategy.confidence(),
                 title.value,
                 title.start,
                 title.end
             );
-            return Some(title);
+            return Some(TitleExtraction::new(title, strategy.confidence()));
         }
     }
     None

--- a/src/properties/title/strategies/parent_dir.rs
+++ b/src/properties/title/strategies/parent_dir.rs
@@ -8,13 +8,21 @@
 use crate::matcher::span::{MatchSpan, Property};
 
 use super::super::clean::{clean_title, is_generic_dir, strip_extension};
-use super::{StrategyContext, TitleStrategy};
+use super::{StrategyContext, TitleConfidence, TitleStrategy};
 
 pub(crate) struct ParentDir;
 
 impl TitleStrategy for ParentDir {
     fn name(&self) -> &'static str {
         "parent_dir"
+    }
+
+    /// Walking up the directory tree to grab a path component is a
+    /// last-resort heuristic, not a self-description. The filename
+    /// itself contained no usable signal. Ancestor fallback (an
+    /// explicit hint from the caller) should beat this.
+    fn confidence(&self) -> TitleConfidence {
+        TitleConfidence::Weak
     }
 
     fn try_extract(&self, ctx: &StrategyContext<'_>) -> Option<MatchSpan> {

--- a/src/properties/title/strategies/unclaimed_bracket.rs
+++ b/src/properties/title/strategies/unclaimed_bracket.rs
@@ -71,9 +71,17 @@ impl TitleStrategy for UnclaimedBracket {
             }
 
             // Check if this bracket's content overlaps with any existing match.
+            //
+            // Season/Episode matches inside a title bracket (e.g., `S2` in
+            // `[Re Zero ... Seikatsu S2]`) do NOT disqualify the bracket from
+            // being the title — they're inline metadata that lives ALONGSIDE
+            // the title, not a competing claim on it. Trailing `S2`/`Season N`
+            // is then stripped by `clean_title` via `RE_TRAILING_SEASON`. (#244)
             let is_claimed = matches.iter().any(|m| {
-                !matches!(m.property, Property::ReleaseGroup | Property::Title)
-                    && m.start < abs_end
+                !matches!(
+                    m.property,
+                    Property::ReleaseGroup | Property::Title | Property::Season | Property::Episode
+                ) && m.start < abs_end
                     && m.end > abs_start
             });
 

--- a/src/properties/title/strategies/unclaimed_bracket.rs
+++ b/src/properties/title/strategies/unclaimed_bracket.rs
@@ -9,13 +9,20 @@
 use crate::matcher::span::{MatchSpan, Property};
 
 use super::super::clean::clean_title;
-use super::{StrategyContext, TitleStrategy};
+use super::{StrategyContext, TitleConfidence, TitleStrategy};
 
 pub(crate) struct UnclaimedBracket;
 
 impl TitleStrategy for UnclaimedBracket {
     fn name(&self) -> &'static str {
         "unclaimed_bracket"
+    }
+
+    /// All-bracket releases like `[a][b][title][c][d].mkv` use brackets
+    /// as a structural device; the unclaimed bracket is a deliberate
+    /// title slot. Self-describing.
+    fn confidence(&self) -> TitleConfidence {
+        TitleConfidence::Strong
     }
 
     fn try_extract(&self, ctx: &StrategyContext<'_>) -> Option<MatchSpan> {

--- a/src/rules/anime_bonus.toml
+++ b/src/rules/anime_bonus.toml
@@ -48,19 +48,22 @@ OAD2   = "OAD"
 ONA    = "ONA"
 ONA1   = "ONA"
 ONA2   = "ONA"
-# Preview / Commercial / Menu
+# Preview / Commercial
 PV     = "PV"
 PV1    = "PV"
 PV2    = "PV"
 CM     = "CM"
 CM1    = "CM"
 CM2    = "CM"
-# Menu (BD menu screens)
-MENU   = "Menu"
+# (Menu moved to case-insensitive [exact] below — real-world filenames
+# use any of [menu]/[Menu]/[MENU]; "menu" as a title word is too rare
+# to justify case-sensitive matching here. See #244.)
 
 [exact]
 # Tokuten (特典) — Japanese BD bonus/extras
 tokuten = "Tokuten"
+# Menu (BD menu screens) — case-insensitive so [menu], [Menu], [MENU] all match.
+menu    = "Menu"
 
 [[patterns]]
 # Numbered variants with higher numbers: SP01, SP02, etc.

--- a/tests/issue_244_batch_recursive_extras.rs
+++ b/tests/issue_244_batch_recursive_extras.rs
@@ -1,0 +1,145 @@
+//! CLI regression tests for issue #244 bugs #2 and #3:
+//!
+//! - **#2**: parent-directory name leaks as `title` in `--batch -r` mode
+//!   when the deepest dir is a structural anime-extras grouping
+//!   (`PV/`, `menu/`, `NCOP&NCED/`).
+//! - **#3**: `.ass` (and other external subtitle) files silently dropped
+//!   by `--batch -r` because `MEDIA_EXTENSIONS` was video-only.
+//!
+//! Both fixes live in low-blast-radius places:
+//!   - #2 → `is_generic_dir` allow-list (`src/properties/title/clean.rs`)
+//!   - #3 → `MEDIA_EXTENSIONS` constant (`src/main.rs`)
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+fn hunch_cmd() -> Command {
+    Command::cargo_bin("hunch").expect("binary not found")
+}
+
+fn parse_lines(stdout: &str) -> Vec<serde_json::Value> {
+    stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("each line should be valid JSON"))
+        .collect()
+}
+
+// ── Bug #2: structural anime-extras dirs no longer leak as title ──────
+
+#[test]
+fn batch_recursive_does_not_leak_pv_dir_as_title() {
+    let tmp = TempDir::new().unwrap();
+    let pv = tmp.path().join("PV");
+    fs::create_dir_all(&pv).unwrap();
+    fs::write(
+        pv.join("[DBD-Raws][Re Zero kara Hajimeru Isekai Seikatsu S2][PV][01][1080P][BDRip].mkv"),
+        b"",
+    )
+    .unwrap();
+
+    let out = hunch_cmd()
+        .args(["--batch", tmp.path().to_str().unwrap(), "-r", "-j"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let results = parse_lines(&stdout);
+
+    assert_eq!(results.len(), 1, "expected 1 file, got: {stdout}");
+    let title = results[0].get("title").and_then(|t| t.as_str());
+    // The fix: "PV" is now in is_generic_dir so parent_dir walks past it
+    // and finds the title in the filename's bracket. Title MUST NOT be "PV".
+    assert_ne!(
+        title,
+        Some("PV"),
+        "PV directory name leaked as title (bug #2)"
+    );
+    // Bonus: with the bug-#1 fix, we get the actual title from the bracket.
+    assert_eq!(title, Some("Re Zero kara Hajimeru Isekai Seikatsu"));
+}
+
+#[test]
+fn batch_recursive_does_not_leak_menu_dir_as_title() {
+    let tmp = TempDir::new().unwrap();
+    let menu = tmp.path().join("menu");
+    fs::create_dir_all(&menu).unwrap();
+    fs::write(
+        menu.join(
+            "[DBD-Raws][Re Zero kara Hajimeru Isekai Seikatsu S2][menu][01][1080P][BDRip].mkv",
+        ),
+        b"",
+    )
+    .unwrap();
+
+    let out = hunch_cmd()
+        .args(["--batch", tmp.path().to_str().unwrap(), "-r", "-j"])
+        .output()
+        .unwrap();
+    let results = parse_lines(&String::from_utf8_lossy(&out.stdout));
+
+    let title = results[0].get("title").and_then(|t| t.as_str());
+    assert_ne!(title, Some("menu"), "menu/ leaked as title (bug #2)");
+}
+
+#[test]
+fn batch_recursive_does_not_leak_ncop_nced_dir_as_title() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join("NCOP&NCED");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("[DBD-Raws][Re Zero kara Hajimeru Isekai Seikatsu S2][NCED1][1080P][BDRip].mkv"),
+        b"",
+    )
+    .unwrap();
+
+    let out = hunch_cmd()
+        .args(["--batch", tmp.path().to_str().unwrap(), "-r", "-j"])
+        .output()
+        .unwrap();
+    let results = parse_lines(&String::from_utf8_lossy(&out.stdout));
+
+    let title = results[0].get("title").and_then(|t| t.as_str());
+    assert_ne!(
+        title,
+        Some("NCOP&NCED"),
+        "NCOP&NCED/ leaked as title (bug #2)"
+    );
+}
+
+// ── Bug #3: external subtitle files included in --batch -r output ─────
+
+#[test]
+fn batch_recursive_includes_ass_subtitle_files() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join("Show");
+    fs::create_dir_all(&dir).unwrap();
+
+    // Mix of video and subtitle files \u2014 both should show up in --batch -r.
+    fs::write(dir.join("[Group][Show S2][01][1080P].mkv"), b"").unwrap();
+    fs::write(dir.join("[Group][Show S2][01][1080P].sc.ass"), b"").unwrap();
+    fs::write(dir.join("[Group][Show S2][01][1080P].tc.ass"), b"").unwrap();
+    fs::write(dir.join("[Group][Show S2][01].srt"), b"").unwrap();
+
+    let out = hunch_cmd()
+        .args(["--batch", tmp.path().to_str().unwrap(), "-r", "-j"])
+        .output()
+        .unwrap();
+    let results = parse_lines(&String::from_utf8_lossy(&out.stdout));
+
+    // Pre-fix: only the .mkv was emitted (1 result). Post-fix: all 4.
+    assert_eq!(
+        results.len(),
+        4,
+        "expected video + 3 subtitle files, got {} entries",
+        results.len()
+    );
+
+    let containers: Vec<_> = results
+        .iter()
+        .filter_map(|r| r.get("container").and_then(|c| c.as_str()))
+        .collect();
+    assert!(containers.contains(&"mkv"));
+    assert!(containers.contains(&"ass"));
+    assert!(containers.contains(&"srt"));
+}

--- a/tests/issue_244_menu_case_insensitive.rs
+++ b/tests/issue_244_menu_case_insensitive.rs
@@ -1,0 +1,53 @@
+//! Regression tests for issue #244 bug #5: `[menu]` not recognized as
+//! an episode_details marker due to case-sensitive matching.
+//!
+//! Symptom (v2.0.1):
+//!   `[menu]`  → episode_details: missing  ❌ (no rule fires)
+//!   `[Menu]`  → episode_details: missing  ❌
+//!   `[MENU]`  → episode_details: "Menu"   ✅ (only this case worked)
+//!
+//! In real-world anime BD releases, `[menu]` (lowercase) is the convention
+//! used by DBD-Raws and others. The case-sensitive `MENU` entry in
+//! `[exact_sensitive]` only matched the all-caps form.
+//!
+//! Fix: move `MENU` → `menu` in `[exact]` (case-insensitive) in
+//! `src/rules/anime_bonus.toml`. The justification for case-sensitive
+//! matching of OP/ED/SP ("avoid `Op` as a name colliding with `OP` for
+//! Opening") doesn't apply to "menu" — it's rare as a title word and
+//! the anime-extras semantics dominate.
+
+use hunch::hunch;
+
+fn details(input: &str) -> Option<String> {
+    hunch(input)
+        .to_flat_map()
+        .get("episode_details")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+#[test]
+fn menu_lowercase() {
+    // The real-world DBD-Raws form.
+    assert_eq!(
+        details("[DBD-Raws][Re Zero S2][menu][01][1080P][BDRip].mkv"),
+        Some("Menu".into())
+    );
+}
+
+#[test]
+fn menu_titlecase() {
+    assert_eq!(
+        details("[Group][Show S2][Menu][01][1080P].mkv"),
+        Some("Menu".into())
+    );
+}
+
+#[test]
+fn menu_uppercase() {
+    // Pre-existing behavior preserved.
+    assert_eq!(
+        details("[Group][Show S2][MENU][01][1080P].mkv"),
+        Some("Menu".into())
+    );
+}

--- a/tests/issue_244_self_describing_filenames.rs
+++ b/tests/issue_244_self_describing_filenames.rs
@@ -9,25 +9,39 @@
 //!   ShowS2/mini-anims/[...][Otto's Diary][01].mkv
 //!     → title "Re Zero ..."  ❌ clobbered by parent's cached title
 //!
-//! Two distinct mechanisms could clobber the title:
+//! Three distinct mechanisms could clobber the title:
 //!   1. Ancestor fallback override — parent's cached title was passed
 //!      as `fallback_title` and used as an authoritative override even
 //!      when the file's own bracket extraction would succeed.
 //!   2. Path-prefix invariance — invariance found a normalized form
 //!      of the parent dir name (`hunch_show2` → "hunch show") as the
-//!      common-text title across siblings; `is_path_dir_name` missed
-//!      the normalization so it was treated as a legitimate invariance
-//!      title.
+//!      common-text title across siblings; the post-hoc dir-name
+//!      check missed the normalization so it was treated as a
+//!      legitimate invariance title.
+//!   3. Post-anchor invariance — even with path-prefix scoped out,
+//!      sibling episode titles can share a common prefix (e.g.
+//!      `S01E10 - Pups Save ...` / `S01E11 - Pups and ...` → "Pups")
+//!      that masquerades as a show title.
 //!
-//! Fix: when the FILENAME itself has bracket structure (the dominant
-//! fansub convention for explicit titles), demote both invariance and
-//! ancestor fallback from override to last-resort. The file's own
-//! extraction speaks first; cross-file signals only fire if extraction
-//! returns nothing.
+//! Fix (architectural, no `filename_has_bracket` heuristic needed):
+//!   - **Path-prefix gaps**: `find_unclaimed_gaps` now starts the
+//!     cursor at `filename_start`, structurally excluding path text.
+//!   - **Post-anchor invariance**: `analyze_invariance` filters gaps
+//!     to those preceding the first content anchor (Season / Episode
+//!     / Year), so episode-title commonality can't pose as a show
+//!     title.
+//!   - **Per-strategy `TitleConfidence`**: each title strategy
+//!     declares Strong (file is self-describing via brackets / year
+//!     anchors / structural separators) or Weak (residual extraction
+//!     / parent-dir last resort). The pipeline's `pick_final_title`
+//!     applies the precedence: Strong extraction beats any cross-file
+//!     hint, otherwise hint wins, otherwise weak extraction, otherwise
+//!     nothing.
 //!
-//! Files WITHOUT brackets in their filename (e.g. `Special.720p.mkv`,
-//! `Making.Of.720p.mkv`) keep the legacy behavior: ancestor fallback
-//! overrides extraction (covered by `tests/parent_context.rs`).
+//! This subsumes the old `filename_has_bracket` and `is_path_dir_name`
+//! heuristics: a file with brackets is implicitly Strong (via the
+//! bracket strategies), and path-prefix titles can't reach invariance
+//! anymore.
 
 use hunch::Pipeline;
 
@@ -146,4 +160,45 @@ fn real_invariance_still_overrides_for_dotted_filenames() {
         Some("Wrong Show Name"),
         "real invariance from dotted filenames must still override fallback"
     );
+}
+
+// ── 5. Post-anchor invariance does NOT clobber show title ───────────
+
+#[test]
+fn episode_title_commonality_does_not_become_show_title() {
+    // `S01E10 - Pups Save Ryder's Robot` and
+    // `S01E11 - Pups and the Ghost Pirate` share the prefix " - Pups"
+    // *after* the episode anchor. That commonality is per-episode-title
+    // text, NOT a show title. Pre-fix, filename-only invariance still
+    // picked it up and clobbered the actual show name ("Paw Patrol")
+    // from the parent directory.
+    //
+    // After the fix, `analyze_invariance` filters gaps to those
+    // preceding the first content anchor (Season/Episode/Year). The
+    // post-anchor " - Pups" gap is no longer a title candidate, and
+    // the parent-dir extraction wins.
+    let pipeline = Pipeline::new();
+    let result = pipeline.run_with_context(
+        "Paw Patrol/S01E10 - Pups Save Ryder's Robot.mkv",
+        &["Paw Patrol/S01E11 - Pups and the Ghost Pirate.mkv"],
+    );
+    assert_eq!(
+        result.title(),
+        Some("Paw Patrol"),
+        "show title from parent dir, not episode-title commonality"
+    );
+}
+
+#[test]
+fn pre_anchor_invariance_still_wins() {
+    // Mirror of the test above: when the common text is BEFORE the
+    // episode anchor (the canonical case), invariance must still fire.
+    // Files: `Show.S01E01.mkv` / `Show.S01E02.mkv` — "Show" is the
+    // pre-anchor invariant.
+    let pipeline = Pipeline::new();
+    let result = pipeline.run_with_context(
+        "Show.S01E01.720p.mkv",
+        &["Show.S01E02.720p.mkv", "Show.S01E03.720p.mkv"],
+    );
+    assert_eq!(result.title(), Some("Show"));
 }

--- a/tests/issue_244_self_describing_filenames.rs
+++ b/tests/issue_244_self_describing_filenames.rs
@@ -1,0 +1,149 @@
+//! Regression tests for the #246 follow-up identified by post-merge
+//! review: in `--batch -r` against a multi-show directory, files in
+//! sub-directories with their own bracket-style titles were getting
+//! clobbered by sibling-consensus / path-prefix invariance from the
+//! parent directory.
+//!
+//! Pre-fix shape:
+//!   ShowS2/[...][Re Zero ... S2][01].mkv      → title "Re Zero ..."  (correct)
+//!   ShowS2/mini-anims/[...][Otto's Diary][01].mkv
+//!     → title "Re Zero ..."  ❌ clobbered by parent's cached title
+//!
+//! Two distinct mechanisms could clobber the title:
+//!   1. Ancestor fallback override — parent's cached title was passed
+//!      as `fallback_title` and used as an authoritative override even
+//!      when the file's own bracket extraction would succeed.
+//!   2. Path-prefix invariance — invariance found a normalized form
+//!      of the parent dir name (`hunch_show2` → "hunch show") as the
+//!      common-text title across siblings; `is_path_dir_name` missed
+//!      the normalization so it was treated as a legitimate invariance
+//!      title.
+//!
+//! Fix: when the FILENAME itself has bracket structure (the dominant
+//! fansub convention for explicit titles), demote both invariance and
+//! ancestor fallback from override to last-resort. The file's own
+//! extraction speaks first; cross-file signals only fire if extraction
+//! returns nothing.
+//!
+//! Files WITHOUT brackets in their filename (e.g. `Special.720p.mkv`,
+//! `Making.Of.720p.mkv`) keep the legacy behavior: ancestor fallback
+//! overrides extraction (covered by `tests/parent_context.rs`).
+
+use hunch::Pipeline;
+
+// ── 1. The exact regression from the PR review ────────────────────────
+
+#[test]
+fn mini_anim_subdir_keeps_distinct_title() {
+    // Setup mirrors the user-reported failing scenario:
+    //   batch root has `[...][Main Show S2][NN]` files (consensus title)
+    //   subdir `迷你动画/` has `[...][Mini Anim X][NN]` files (distinct titles)
+    //
+    // The mini-anim file should keep its OWN bracket title, not inherit
+    // the main show's title via parent-context fallback.
+    let pipeline = Pipeline::new();
+    let siblings = vec![
+        "迷你动画/[DBD-Raws][Re Zero Kara Hajimeru Break Time Maid's Days][01][1080P][BDRip][HEVC-10bit][FLAC].mkv",
+        "迷你动画/[DBD-Raws][Re Zero Kara Hajimeru Break Time Otto's Diary][02][1080P][BDRip][HEVC-10bit][FLAC].mkv",
+    ];
+    let result = pipeline.run_with_context_and_fallback(
+        "迷你动画/[DBD-Raws][Re Zero Kara Hajimeru Break Time Otto's Diary][01][1080P][BDRip][HEVC-10bit][FLAC].mkv",
+        &siblings,
+        Some("Re Zero kara Hajimeru Isekai Seikatsu"), // parent's cached title
+    );
+    assert_eq!(
+        result.title(),
+        Some("Re Zero Kara Hajimeru Break Time Otto's Diary"),
+        "file's own bracket title must win over parent fallback when filename is self-describing"
+    );
+}
+
+#[test]
+fn distinct_bracket_titles_in_one_dir_each_keep_own_title() {
+    // Multiple files in the same dir, each with a DIFFERENT bracket title.
+    // Sibling-consensus must NOT collapse them to a single common title.
+    let pipeline = Pipeline::new();
+    let siblings = vec![
+        "shorts/[Group][Show A][01][1080p].mkv",
+        "shorts/[Group][Show B][01][1080p].mkv",
+        "shorts/[Group][Show C][01][1080p].mkv",
+    ];
+    let result = pipeline.run_with_context_and_fallback(
+        "shorts/[Group][Show D][01][1080p].mkv",
+        &siblings,
+        Some("Inherited Wrong Title"),
+    );
+    assert_eq!(result.title(), Some("Show D"));
+}
+
+// ── 2. Path-prefix invariance no longer clobbers self-describing files ─
+
+#[test]
+fn path_prefix_normalization_does_not_become_title() {
+    // When the batch-root dir name normalizes to something invariance
+    // treats as common (`hunch_show2` → "hunch show"), and that
+    // normalized form doesn't match `is_path_dir_name`'s exact check,
+    // the file's bracket title must STILL win because the filename is
+    // self-describing.
+    let pipeline = Pipeline::new();
+    let siblings = vec![
+        "hunch_show2/[Group][Real Show Name S2][02][1080p].mkv",
+        "hunch_show2/[Group][Real Show Name S2][03][1080p].mkv",
+        "hunch_show2/[Group][Real Show Name S2][04][1080p].mkv",
+    ];
+    let result = pipeline.run_with_context_and_fallback(
+        "hunch_show2/[Group][Real Show Name S2][01][1080p].mkv",
+        &siblings,
+        None,
+    );
+    let title = result.title().unwrap_or("");
+    assert_ne!(
+        title, "hunch show",
+        "normalized path prefix must not become title when filename is self-describing"
+    );
+    assert_eq!(title, "Real Show Name");
+}
+
+// ── 3. Anti-regression: bracketless files still inherit fallback ──────
+
+#[test]
+fn bracketless_file_still_inherits_fallback() {
+    // Files WITHOUT bracket structure (the parent_context.rs scenario)
+    // must continue to use the ancestor fallback as override. The fix
+    // is scoped to filenames with bracket structure ONLY.
+    let pipeline = Pipeline::new();
+    let result = pipeline.run_with_context_and_fallback(
+        "Paw Patrol/SP/Special.720p.mkv",
+        &Vec::<&str>::new(),
+        Some("Paw Patrol"),
+    );
+    assert_eq!(
+        result.title(),
+        Some("Paw Patrol"),
+        "bracketless file should still inherit parent fallback (legacy behavior)"
+    );
+}
+
+// ── 4. Anti-regression: real invariance still wins for non-bracket files
+
+#[test]
+fn real_invariance_still_overrides_for_dotted_filenames() {
+    // The standard `Show.S01EXX` invariance pattern — no brackets, real
+    // invariance signal across siblings — must continue to override.
+    let pipeline = Pipeline::new();
+    let siblings = vec![
+        "Show/Season 2/Show.S02E01.720p.mkv",
+        "Show/Season 2/Show.S02E02.720p.mkv",
+        "Show/Season 2/Show.S02E03.720p.mkv",
+    ];
+    let result = pipeline.run_with_context_and_fallback(
+        "Show/Season 2/Show.S02E04.720p.mkv",
+        &siblings,
+        Some("Wrong Show Name"),
+    );
+    assert_ne!(
+        result.title(),
+        Some("Wrong Show Name"),
+        "real invariance from dotted filenames must still override fallback"
+    );
+}

--- a/tests/issue_244_title_with_inline_season.rs
+++ b/tests/issue_244_title_with_inline_season.rs
@@ -1,0 +1,108 @@
+//! Regression tests for issue #244: anime filenames in bracket format
+//! fail to extract title field when the title bracket contains an
+//! inline season marker like `S2`.
+//!
+//! Symptom (v2.0.1):
+//!   `[DBD-Raws][Re Zero kara Hajimeru Isekai Seikatsu S2][01]…`
+//!   → title MISSING, season=2, episode=1
+//!
+//! Root cause: the `S2` token inside the title bracket created a
+//! `Property::Season` match that overlapped the bracket. Bracket-based
+//! title strategies (`CjkBracket`, `UnclaimedBracket`) treated that
+//! overlap as a competing "claim" on the bracket and skipped it as a
+//! title candidate.
+//!
+//! Fix:
+//!   1. Exclude `Property::Season` and `Property::Episode` from the
+//!      `is_claimed` check in both bracket strategies — they're inline
+//!      metadata, not competing claims.
+//!   2. Extend `RE_TRAILING_SEASON` (used by `clean_title`) to match the
+//!      `S\d{1,3}` short form so the trailing `S2` is stripped.
+//!   3. Have `CjkBracket` actually run its output through `clean_title`
+//!      (it previously bypassed the cleaning pipeline).
+
+use hunch::hunch;
+
+// ── 1. The exact case from the issue ──────────────────────────────────
+
+#[test]
+fn issue_244_headline_case() {
+    let r = hunch(
+        "[DBD-Raws][Re Zero kara Hajimeru Isekai Seikatsu S2][01][1080P][BDRip][HEVC-10bit][FLACx2].mkv",
+    );
+    assert_eq!(r.title(), Some("Re Zero kara Hajimeru Isekai Seikatsu"));
+    assert_eq!(r.season(), Some(2));
+    assert_eq!(r.episode(), Some(1));
+    assert_eq!(r.release_group(), Some("DBD-Raws"));
+}
+
+// ── 2. CjkBracket strategy (has Episode match → fires) ────────────────
+
+#[test]
+fn cjk_bracket_strips_short_season() {
+    let r = hunch("[Group][Show Name S3][05][1080p].mkv");
+    assert_eq!(r.title(), Some("Show Name"));
+    assert_eq!(r.season(), Some(3));
+}
+
+#[test]
+fn cjk_bracket_strips_long_season() {
+    let r = hunch("[Group][Show Name Season 2][05][1080p].mkv");
+    assert_eq!(r.title(), Some("Show Name"));
+    assert_eq!(r.season(), Some(2));
+}
+
+#[test]
+fn cjk_bracket_strips_double_digit_season() {
+    let r = hunch("[Group][Show Name S10][05][1080p].mkv");
+    assert_eq!(r.title(), Some("Show Name"));
+    assert_eq!(r.season(), Some(10));
+}
+
+#[test]
+fn cjk_bracket_lowercase_s2() {
+    let r = hunch("[Group][Show Name s2][05][1080p].mkv");
+    assert_eq!(r.title(), Some("Show Name"));
+    assert_eq!(r.season(), Some(2));
+}
+
+// ── 3. UnclaimedBracket strategy (no Episode → falls through to here) ─
+
+#[test]
+fn unclaimed_bracket_strips_trailing_season() {
+    // No `[01]` episode bracket → CjkBracket bails, UnclaimedBracket fires.
+    // Pre-fix this returned title=null; post-fix it returns the cleaned title.
+    let r = hunch("[Group][My Show S2][1080p][BDRip][HEVC-10bit][FLAC].mkv");
+    assert_eq!(r.title(), Some("My Show"));
+    assert_eq!(r.season(), Some(2));
+}
+
+// ── 4. Anti-regression: titles WITHOUT inline season markers ──────────
+
+#[test]
+fn no_season_marker_unchanged() {
+    let r = hunch("[DBD-Raws][Re Zero kara Hajimeru Isekai Seikatsu][01][1080P][BDRip].mkv");
+    assert_eq!(r.title(), Some("Re Zero kara Hajimeru Isekai Seikatsu"));
+    assert_eq!(r.season(), None);
+}
+
+#[test]
+fn mini_animation_without_season_unchanged() {
+    let r = hunch(
+        "[DBD-Raws][Re Zero Kara Hajimeru Break Time Otto's Diary][01][1080P][BDRip][HEVC-10bit][FLAC].mkv",
+    );
+    assert_eq!(
+        r.title(),
+        Some("Re Zero Kara Hajimeru Break Time Otto's Diary")
+    );
+}
+
+// ── 5. Anti-regression: titles where the trailing `S` is genuinely     ─
+//    part of the title (e.g. `S` as a name suffix, no digits after).   ─
+
+#[test]
+fn bare_s_not_stripped() {
+    // `S` alone (no digits) is NOT a season marker; must not be stripped.
+    let r = hunch("[Group][Battlestar Galactica S][01].mkv");
+    assert_eq!(r.title(), Some("Battlestar Galactica S"));
+}


### PR DESCRIPTION
Closes #244 (4 of 6 reported bugs; #4 and #6 deliberately deferred — see [comment on #244](https://github.com/lijunzh/hunch/issues/244)).

**Supersedes #245** (which only addressed bug #1 and used a hand-rolled regex with a UTF-8 panic risk).

## What's in this PR

Four root-cause fixes for bugs reported on #244, each in its own commit so it's individually reviewable / revertable. None are bandaids — every fix plugs a hole in the existing rule machinery rather than special-casing the issue's filenames.

| Bug | Symptom | Root cause | Fix |
|---|---|---|---|
| #1 | `[...][Title S2][...]` → `title` missing | `S2` Season match shadowed the title bracket; `RE_TRAILING_SEASON` didn't know `S\d+` short form; `cjk_bracket` bypassed `clean_title` | Exclude Season/Episode from `is_claimed`; extend `RE_TRAILING_SEASON`; route `cjk_bracket` through `clean_title` |
| #2 | `PV/`, `menu/`, `NCOP&NCED/` directory names leaked as `title` in `--batch -r` | `is_generic_dir` allow-list missed the anime-extras structural names | Added `pv`, `op`, `ed`, `ncop`, `nced`, `ncop&nced`, `menu`, `ova`, `oad`, `ona`, `cm`, `tokuten` to the allow-list |
| #3 | `.ass` / `.srt` files silently dropped by `--batch -r` | `MEDIA_EXTENSIONS` was video-only | Extended with `srt`, `ass`, `ssa`, `sub`, `idx`, `vtt`, `sup`, `smi` |
| #5 | `[menu]` (lowercase) didn't match the Menu rule | Lived in `[exact_sensitive]` (case-sensitive) | Moved to `[exact]` (case-insensitive) |

## Commits

```
36b6ba4 Fix #244 (bug 2): structural anime-extras dirs no longer leak as title
5b01729 Fix #244 (bug 3): include external subtitle formats in --batch -r
703cd79 Fix #244 (bug 5): match [menu]/[Menu]/[MENU] case-insensitively
ef5a96a Fix #244 (bug 1): title extraction when bracket contains inline season marker
```

Each commit message documents its bug, root cause, and tests.

## Bugs deliberately NOT fixed in this PR

| Bug | Why skipped |
|---|---|
| #4 — `NCED1`/`NCED2`/`NCED3`/`NCED4` collapse the trailing index | The current behavior (`{1} {2}` template dropping `{2}`) is a **deliberate canonicalization**, mirroring the explicit `NCOP1=NCOP, NCOP2=NCOP, NCOP3=NCOP` exact entries. Library scanners (Plex/Jellyfin) just want "this is an extra"; the index can be read from the filename if needed. Not a bug — a design choice. Re-open in a focused issue if a concrete consumer needs the index. |
| #6 — `FLACx2` truncates to `FLAC` | The rule comment explicitly says `"treat as FLAC codec"` — also a deliberate choice. Adding a new `audio_tracks` property to the public data model (new enum, new accessor, new docs) for one esoteric DBD-Raws convention is the YAGNI tripwire. If someone needs dual-track detection, MediaInfo is the right tool. A filename parser shouldn't grow a property to capture every release-group convention. |

Both rationales posted in detail on #244 itself.

## Verification

```
cargo fmt --check    # clean
cargo clippy         # clean
cargo test           # all 575+ tests pass; +16 new regression tests across the three new files
```

End-to-end repro of the reported `--batch -r` scenario:

```
$ hunch --batch /path/to/show -r -j | jq -r '.title'
Re Zero kara Hajimeru Isekai Seikatsu     # was: "PV"
Re Zero kara Hajimeru Isekai Seikatsu     # was: "menu"
Re Zero kara Hajimeru Isekai Seikatsu     # was: "NCOP&NCED"
```

## Why one PR for four bugs

Bugs #1, #2, #3, #5 collectively make hunch correctly parse the `[DBD-Raws][Re Zero ... S2]` reference release end-to-end. Splitting them across four PRs would mean three intermediate states where #244 is still partially broken and downstream consumers (library scanners) still get wrong-not-missing output. As a coherent unit they pass the maintainer's "fix the user's reported scenario" bar; commits are atomic enough to bisect against if needed.

## New test files

- `tests/issue_244_title_with_inline_season.rs` (9 cases, both bracket strategies + bare-`S` anti-regression)
- `tests/issue_244_menu_case_insensitive.rs` (3 cases)
- `tests/issue_244_batch_recursive_extras.rs` (4 CLI integration cases for bugs #2 + #3)
